### PR TITLE
cmd: make the log file and pprof address configurable

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
 	"github.com/pingcap/br/pkg/meta"
 	"github.com/pingcap/br/pkg/raw"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 var (
@@ -26,18 +29,30 @@ const (
 	FlagCert = "cert"
 	// FlagKey is the name of key flag.
 	FlagKey = "key"
-	// FlagStorage is the name of key flag.
+	// FlagStorage is the name of storage flag.
 	FlagStorage = "storage"
+	// FlagLogLevel is the name of log-level flag.
+	FlagLogLevel = "log-level"
+	// FlagLogFile is the name of log-file flag.
+	FlagLogFile = "log-file"
+	// FlagStatusAddr is the name of status-addr flag.
+	FlagStatusAddr = "status-addr"
 )
 
 // AddFlags adds flags to the given cmd.
 func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP(FlagPD, "u", "127.0.0.1:2379", "PD address")
-	cmd.PersistentFlags().String(FlagCA, "", "CA path")
-	cmd.PersistentFlags().String(FlagCert, "", "Cert path")
-	cmd.PersistentFlags().String(FlagKey, "", "Key path")
+	cmd.PersistentFlags().String(FlagCA, "", "CA certificate path for TLS connection")
+	cmd.PersistentFlags().String(FlagCert, "", "Certificate path for TLS connection")
+	cmd.PersistentFlags().String(FlagKey, "", "Private key path for TLS connection")
 	cmd.PersistentFlags().StringP(FlagStorage, "s", "",
 		`specify the url where backup storage, eg, "local:///path/to/save"`)
+	cmd.PersistentFlags().StringP(FlagLogLevel, "L", "info",
+		"Set the log level")
+	cmd.PersistentFlags().String(FlagLogFile, "",
+		"Set the log file path. If not set, logs will output to stdout")
+	cmd.PersistentFlags().String(FlagStatusAddr, "localhost:6060",
+		"Set the HTTP listening address for the status report service. Set to empty string to disable")
 	cmd.MarkFlagRequired(FlagPD)
 	cmd.MarkFlagRequired(FlagStorage)
 }
@@ -46,16 +61,54 @@ func AddFlags(cmd *cobra.Command) {
 func Init(ctx context.Context, cmd *cobra.Command) (err error) {
 	initOnce.Do(func() {
 		defaultContext = ctx
+
+		// Initialize the logger.
+		conf := new(log.Config)
+		conf.Level, err = cmd.Flags().GetString(FlagLogLevel)
+		if err != nil {
+			return
+		}
+		conf.File.Filename, err = cmd.Flags().GetString(FlagLogFile)
+		if err != nil {
+			return
+		}
+		lg, p, e := log.InitLogger(conf)
+		if e != nil {
+			err = e
+			return
+		}
+		log.ReplaceGlobals(lg, p)
+
+		// Initialize the pprof server.
+		statusAddr, e := cmd.Flags().GetString(FlagStatusAddr)
+		if e != nil {
+			err = e
+			return
+		}
+		if len(statusAddr) != 0 {
+			go func() {
+				if e := http.ListenAndServe(statusAddr, nil); e != nil {
+					log.Warn("fail to start pprof", zap.String("addr", statusAddr), zap.Error(e))
+				} else {
+					log.Info("start pprof", zap.String("addr", statusAddr))
+				}
+			}()
+		}
+
+		// Initialize the main program.
 		var addr string
 		addr, err = cmd.Flags().GetString(FlagPD)
 		if err != nil {
 			return
 		}
 		if addr == "" {
-			err = errors.Errorf("pd address can not be empty")
+			err = errors.New("pd address can not be empty")
 			return
 		}
 		defaultBacker, err = meta.NewBacker(defaultContext, addr)
+		if err != nil {
+			return
+		}
 		defaultRawClient, err = raw.NewBackupClient(defaultBacker)
 	})
 	return

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
@@ -11,26 +10,12 @@ import (
 
 	"github.com/pingcap/br/cmd"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 func main() {
-	conf := &log.Config{Level: "info", File: log.FileLogConfig{Filename: "br.log"}}
-	lg, p, _ := log.InitLogger(conf)
-	log.ReplaceGlobals(lg, p)
-
 	gCtx := context.Background()
 	ctx, cancel := context.WithCancel(gCtx)
-
-	go func() {
-		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
-			log.Warn("fail to start pprof", zap.Error(err))
-		} else {
-			log.Info("start pprof at localhost:6060")
-		}
-	}()
 
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc,


### PR DESCRIPTION
Added the command line flags `--log-level` (`-L`), `--log-file` and `--status-addr`. Since these values can now be configured, the initialization of the logger and pprof server are moved into `cmd.Init()`.

Also clarified the meaning of the `--key` flag (the meaning of "key path" is ambiguous since we're dealing with a key-value database after all).