### PR TITLE
restore: insert `IF NOT EXISTS` to create table SQL

### DIFF
--- a/pkg/restore/db_test.go
+++ b/pkg/restore/db_test.go
@@ -34,7 +34,7 @@ func (s *testRestoreSchemaSuite) TearDownSuite(c *C) {
 	testleak.AfterTest(c)()
 }
 
-func (s *testRestoreSchemaSuite) TestRestoreAutoIncID(c *C) {
+func (s *testRestoreSchemaSuite) TestRestoreTableSchema(c *C) {
 	c.Assert(s.mock.Start(), IsNil)
 	defer s.mock.Stop()
 
@@ -86,6 +86,8 @@ func (s *testRestoreSchemaSuite) TestRestoreAutoIncID(c *C) {
 	c.Assert(err, IsNil, Commentf("Error create empty charset db: %s %s", err, s.mock.DSN))
 	err = db.CreateTable(context.Background(), &table)
 	c.Assert(err, IsNil, Commentf("Error create table: %s %s", err, s.mock.DSN))
+	err = db.CreateTable(context.Background(), &table)
+	c.Assert(err, IsNil, Commentf("Error create existed table: %s %s", err, s.mock.DSN))
 	tk.MustExec("use test")
 	// Check if AutoIncID is altered successfully
 	autoIncID, err = strconv.ParseUint(tk.MustQuery("admin show t next_row_id").Rows()[0][3].(string), 10, 64)


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

When we cannot rebuild the CREATE TABLE SQL correctly, users should be able to create the table manually.
This PR inserts `IF NOT EXISTS` to skip creating the existed table.

Maybe a better way is to check if the table existed before creating it, but that will introduce extra cost.