### PR TITLE
backup: set zero start version to be compatible with latest tikv

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -374,7 +374,7 @@ func (bc *Client) backupRange(
 		ClusterId:      bc.clusterID,
 		StartKey:       startKey,
 		EndKey:         endKey,
-		StartVersion:   backupTS,
+		StartVersion:   0, // Zero start version means full backup.
 		EndVersion:     backupTS,
 		StorageBackend: bc.backend,
 		RateLimit:      rateLimit,
@@ -623,7 +623,7 @@ func (bc *Client) handleFineGrained(
 		ClusterId:      bc.clusterID,
 		StartKey:       rg.StartKey, // TODO: the range may cross region.
 		EndKey:         rg.EndKey,
-		StartVersion:   backupTS,
+		StartVersion:   0, // Zero start version means full backup.
 		EndVersion:     backupTS,
 		StorageBackend: bc.backend,
 		RateLimit:      rateLimit,


### PR DESCRIPTION
TiKV master uses a new backup scanner, full backup requires zero start version.