### PR TITLE
conn: fix inaccurate region count

### DIFF
--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/util/codec"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -182,7 +183,9 @@ func (mgr *Mgr) getRegionCountWith(
 		query := fmt.Sprintf(
 			"%s?start_key=%s&end_key=%s",
 			regionCountPrefix,
-			url.QueryEscape(string(startKey)), url.QueryEscape(string(endKey)))
+			// TiKV reports region start/end keys to PD in memcomparable-format.
+			url.QueryEscape(string(codec.EncodeBytes(nil, startKey))),
+			url.QueryEscape(string(codec.EncodeBytes(nil, endKey))))
 		v, e := get(ctx, addr, query, mgr.pdHTTP.cli)
 		if e != nil {
 			err = e

--- a/pkg/conn/conn_test.go
+++ b/pkg/conn/conn_test.go
@@ -2,12 +2,19 @@ package conn
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/statistics"
+	"github.com/pingcap/tidb/util/codec"
 )
 
 func TestT(t *testing.T) {
@@ -20,35 +27,89 @@ type testClientSuite struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	mgr *Mgr
+	mgr     *Mgr
+	regions *core.RegionsInfo
 }
 
 func (s *testClientSuite) SetUpSuite(c *C) {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.mgr = &Mgr{}
+	s.regions = core.NewRegionsInfo()
 }
 
 func (s *testClientSuite) TearDownSuite(c *C) {
 	s.cancel()
 }
 
-func (s *testClientSuite) TestPDHTTP(c *C) {
+func (s *testClientSuite) TestGetClusterVersion(c *C) {
 	ctx := context.Background()
-	mock := func(context.Context, string, string, *http.Client) ([]byte, error) {
-		stats := statistics.RegionStats{Count: 6}
-		ret, err := json.Marshal(stats)
-		c.Assert(err, IsNil)
-		return ret, nil
-	}
-	s.mgr.pdHTTP.addrs = []string{""}
-	resp, err := s.mgr.getRegionCountWith(ctx, mock, []byte{}, []byte{})
-	c.Assert(err, IsNil)
-	c.Assert(resp, Equals, 6)
 
-	mock = func(context.Context, string, string, *http.Client) ([]byte, error) {
+	s.mgr.pdHTTP.addrs = []string{"", ""} // two endpoints
+	counter := 0
+	mock := func(context.Context, string, string, *http.Client) ([]byte, error) {
+		counter++
+		if counter <= 1 {
+			return nil, errors.New("mock error")
+		}
 		return []byte(`test`), nil
 	}
 	respString, err := s.mgr.getClusterVersionWith(ctx, mock)
 	c.Assert(err, IsNil)
 	c.Assert(respString, Equals, "test")
+
+	mock = func(context.Context, string, string, *http.Client) ([]byte, error) {
+		return nil, errors.New("mock error")
+	}
+	_, err = s.mgr.getClusterVersionWith(ctx, mock)
+	c.Assert(err, NotNil)
+}
+
+func (s *testClientSuite) TestRegionCount(c *C) {
+	s.regions.SetRegion(core.NewRegionInfo(&metapb.Region{
+		Id:          1,
+		StartKey:    codec.EncodeBytes(nil, []byte{1, 1}),
+		EndKey:      codec.EncodeBytes(nil, []byte{1, 3}),
+		RegionEpoch: &metapb.RegionEpoch{},
+	}, nil))
+	s.regions.SetRegion(core.NewRegionInfo(&metapb.Region{
+		Id:          2,
+		StartKey:    codec.EncodeBytes(nil, []byte{1, 3}),
+		EndKey:      codec.EncodeBytes(nil, []byte{1, 5}),
+		RegionEpoch: &metapb.RegionEpoch{},
+	}, nil))
+	s.regions.SetRegion(core.NewRegionInfo(&metapb.Region{
+		Id:          3,
+		StartKey:    codec.EncodeBytes(nil, []byte{2, 3}),
+		EndKey:      codec.EncodeBytes(nil, []byte{3, 4}),
+		RegionEpoch: &metapb.RegionEpoch{},
+	}, nil))
+	c.Assert(s.regions.Length(), Equals, 3)
+
+	ctx := context.Background()
+	mock := func(_ context.Context, addr string, prefix string, _ *http.Client) ([]byte, error) {
+		query := fmt.Sprintf("%s/%s", addr, prefix)
+		u, e := url.Parse(query)
+		c.Assert(e, IsNil, Commentf("%s", query))
+		start := u.Query().Get("start_key")
+		end := u.Query().Get("end_key")
+		c.Log(hex.EncodeToString([]byte(start)))
+		c.Log(hex.EncodeToString([]byte(end)))
+		regions := s.regions.ScanRange([]byte(start), []byte(end), 0)
+		stats := statistics.RegionStats{Count: len(regions)}
+		ret, err := json.Marshal(stats)
+		c.Assert(err, IsNil)
+		return ret, nil
+	}
+	s.mgr.pdHTTP.addrs = []string{"http://mock"}
+	resp, err := s.mgr.getRegionCountWith(ctx, mock, []byte{}, []byte{})
+	c.Assert(err, IsNil)
+	c.Assert(resp, Equals, 3)
+
+	resp, err = s.mgr.getRegionCountWith(ctx, mock, []byte{0}, []byte{0xff})
+	c.Assert(err, IsNil)
+	c.Assert(resp, Equals, 3)
+
+	resp, err = s.mgr.getRegionCountWith(ctx, mock, []byte{1, 2}, []byte{1, 4})
+	c.Assert(err, IsNil)
+	c.Assert(resp, Equals, 2)
 }


### PR DESCRIPTION
Encode keys into memcomparable-format before calling `stats/region`.

Fix #125 