### PR TITLE
Fixed handling for a dbName that do not exist in the backup being restored

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
@@ -112,13 +110,11 @@ func runRestore(flagSet *flag.FlagSet, cmdName, dbName, tableName string) error 
 		}
 	case len(dbName) != 0 && len(tableName) == 0:
 		// database restore
-		fmt.Fprintf(os.Stderr, "dbName: %s\n", dbName)
 		db := client.GetDatabase(dbName)
 		if db == nil {
-			err = errors.Errorf("database %s not found in backup", dbName)
-		} else {
-			err = client.CreateDatabase(db.Schema)
+			return errors.Errorf("database %s not found in backup", dbName)
 		}
+		err = client.CreateDatabase(db.Schema)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -130,10 +126,9 @@ func runRestore(flagSet *flag.FlagSet, cmdName, dbName, tableName string) error 
 		// table restore
 		db := client.GetDatabase(dbName)
 		if db == nil {
-			err = errors.Errorf("database %s not found in backup", dbName)
-		} else {
-			err = client.CreateDatabase(db.Schema)
+			return errors.Errorf("database %s not found in backup", dbName)
 		}
+		err = client.CreateDatabase(db.Schema)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
@@ -110,8 +112,13 @@ func runRestore(flagSet *flag.FlagSet, cmdName, dbName, tableName string) error 
 		}
 	case len(dbName) != 0 && len(tableName) == 0:
 		// database restore
+		fmt.Fprintf(os.Stderr, "dbName: %s\n", dbName)
 		db := client.GetDatabase(dbName)
-		err = client.CreateDatabase(db.Schema)
+		if db == nil {
+			err = errors.Errorf("database %s not found in backup", dbName)
+		} else {
+			err = client.CreateDatabase(db.Schema)
+		}
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -122,7 +129,11 @@ func runRestore(flagSet *flag.FlagSet, cmdName, dbName, tableName string) error 
 	case len(dbName) != 0 && len(tableName) != 0:
 		// table restore
 		db := client.GetDatabase(dbName)
-		err = client.CreateDatabase(db.Schema)
+		if db == nil {
+			err = errors.Errorf("database %s not found in backup", dbName)
+		} else {
+			err = client.CreateDatabase(db.Schema)
+		}
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Restoring a database or table giving a table name that does not exist in the given backup causes SIGSEGV:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x56192dd]

goroutine 1 [running]:
github.com/pingcap/br/cmd.runRestore(0xc000328c00, 0x5b77dc9, 0x10, 0x7ffeefbff98d, 0x3, 0x0, 0x0, 0x0, 0x0)
        /Users/kolbe/Devel/git/pingcap/br/cmd/restore.go:114 +0x122d
github.com/pingcap/br/cmd.newDbRestoreCommand.func1(0xc00037b180, 0xc000626240, 0x0, 0x4, 0x0, 0x0)
        /Users/kolbe/Devel/git/pingcap/br/cmd/restore.go:234 +0x169
github.com/spf13/cobra.(*Command).execute(0xc00037b180, 0xc00004e0a0, 0x4, 0x4, 0xc00037b180, 0xc00004e0a0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc000050c80, 0xc000607ef8, 0x3, 0x3)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
        /Users/kolbe/Devel/git/pingcap/br/main.go:55 +0x333
```

### What is changed and how it works?

If the database does not exist in the backup, an error is returned and execution is stopped.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

A manual test using a database name that used to cause SIGSEGV no longer does.

A unit test *should be added* for both `br restore db` and `br restore table` to make sure a non-existent dbName does not cause br to crash.