### PR TITLE
conn: support not shutting down the storage when closing the connection

### DIFF
--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -55,6 +55,7 @@ type Mgr struct {
 		mu   sync.Mutex
 		clis map[uint64]*grpc.ClientConn
 	}
+	ownsStorage bool
 }
 
 type pdHTTPRequest func(context.Context, string, string, *http.Client, string, io.Reader) ([]byte, error)
@@ -165,10 +166,11 @@ func NewMgr(
 	}
 
 	mgr := &Mgr{
-		pdClient: pdClient,
-		storage:  storage,
-		dom:      dom,
-		tlsConf:  tlsConf,
+		pdClient:    pdClient,
+		storage:     storage,
+		dom:         dom,
+		tlsConf:     tlsConf,
+		ownsStorage: g.OwnsStorage(),
 	}
 	mgr.pdHTTP.addrs = processedAddrs
 	mgr.pdHTTP.cli = cli
@@ -386,11 +388,14 @@ func (mgr *Mgr) Close() {
 
 	// Gracefully shutdown domain so it does not affect other TiDB DDL.
 	// Must close domain before closing storage, otherwise it gets stuck forever.
-	if mgr.dom != nil {
-		mgr.dom.Close()
+	if mgr.ownsStorage {
+		if mgr.dom != nil {
+			mgr.dom.Close()
+		}
+
+		atomic.StoreUint32(&tikv.ShuttingDown, 1)
+		mgr.storage.Close()
 	}
 
-	atomic.StoreUint32(&tikv.ShuttingDown, 1)
-	mgr.storage.Close()
 	mgr.pdClient.Close()
 }

--- a/pkg/glue/glue.go
+++ b/pkg/glue/glue.go
@@ -15,6 +15,10 @@ type Glue interface {
 	BootstrapSession(store kv.Storage) (*domain.Domain, error)
 	CreateSession(store kv.Storage) (Session, error)
 	Open(path string, option pd.SecurityOption) (kv.Storage, error)
+
+	// OwnsStorage returns whether the storage returned by Open() is owned
+	// If this method returns false, the connection manager will never close the storage.
+	OwnsStorage() bool
 }
 
 // Session is an abstraction of the session.Session interface.

--- a/pkg/gluetidb/glue.go
+++ b/pkg/gluetidb/glue.go
@@ -50,6 +50,11 @@ func (Glue) Open(path string, option pd.SecurityOption) (kv.Storage, error) {
 	return tikv.Driver{}.Open(path)
 }
 
+// OwnsStorage implements glue.Glue
+func (Glue) OwnsStorage() bool {
+	return true
+}
+
 // Execute implements glue.Session
 func (gs *tidbSession) Execute(ctx context.Context, sql string) error {
 	_, err := gs.se.Execute(ctx, sql)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When integrating BR into TiDB, the BR glue will reuse the storage & domain & session from the caller.

However, currently the `conn.Mgr` unconditionally closes the storage & domain, causing double-close panic at the end of BACKUP/RESTORE.

### What is changed and how it works?

Added a method to `glue.Glue` indicating whether the storage & domain is "owned" or "borrowed". Change `(*conn.Mgr).Close()` to avoid closing the storage & domain when they are "borrowed".

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * pingcap/tidb#15274 works after including this change.

Code changes

 - Has interface methods change
    * `glue.Glue` has a new method.

Side effects

Related changes
