### PR TITLE
conn: use GetDomain to avoid some TiDB breaking changes

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -30,7 +30,7 @@ func runBackupRawCommand(command *cobra.Command, cmdName string) error {
 func NewBackupCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:          "backup",
-		Short:        "backup a TiDB cluster",
+		Short:        "backup a TiDB/TiKV cluster",
 		SilenceUsage: false,
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
 			if err := Init(c); err != nil {

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -21,7 +21,7 @@ func runRestoreCommand(command *cobra.Command, cmdName string) error {
 func NewRestoreCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:          "restore",
-		Short:        "restore a TiKV cluster from a backup",
+		Short:        "restore a TiDB/TiKV cluster",
 		SilenceUsage: false,
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
 			if err := Init(c); err != nil {

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -159,7 +159,7 @@ func NewMgr(
 		return nil, errors.Errorf("tikv cluster not health %+v", stores)
 	}
 
-	dom, err := g.BootstrapSession(storage)
+	dom, err := g.GetDomain(storage)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/glue/glue.go
+++ b/pkg/glue/glue.go
@@ -12,7 +12,7 @@ import (
 
 // Glue is an abstraction of TiDB function calls used in BR.
 type Glue interface {
-	BootstrapSession(store kv.Storage) (*domain.Domain, error)
+	GetDomain(store kv.Storage) (*domain.Domain, error)
 	CreateSession(store kv.Storage) (Session, error)
 	Open(path string, option pd.SecurityOption) (kv.Storage, error)
 }

--- a/pkg/gluetidb/glue.go
+++ b/pkg/gluetidb/glue.go
@@ -24,9 +24,9 @@ type tidbSession struct {
 	se session.Session
 }
 
-// BootstrapSession implements glue.Glue
-func (Glue) BootstrapSession(store kv.Storage) (*domain.Domain, error) {
-	return session.BootstrapSession(store)
+// GetDomain implements glue.Glue
+func (Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
+	return session.GetDomain(store)
 }
 
 // CreateSession implements glue.Glue

--- a/pkg/utils/progress.go
+++ b/pkg/utils/progress.go
@@ -55,7 +55,7 @@ func (pp *ProgressPrinter) goPrintProgress(
 		bar.Set(pb.Color, true)
 		bar.SetWriter(&wrappedWriter{name: pp.name})
 	} else {
-		tmpl := `{{string . "barName" | red}} {{ bar . "<" "-" (cycle . "-" "\\" "|" "/" ) "." ">"}} {{percent .}}`
+		tmpl := `{{string . "barName" | green}} {{ bar . "<" "-" (cycle . "-" "\\" "|" "/" ) "." ">"}} {{percent .}}`
 		bar = pb.ProgressBarTemplate(tmpl).Start64(pp.total)
 		bar.Set("barName", pp.name)
 	}


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

TiDB Bootstrap API may include some breaking changes that breaks BR too. 

### What is changed and how it works?

Use GetDomain to avoid some TiDB breaking changes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch
