### PR TITLE
summary: put summary log at last

### DIFF
--- a/pkg/restore/db.go
+++ b/pkg/restore/db.go
@@ -47,7 +47,7 @@ func NewDB(g glue.Glue, store kv.Storage) (*DB, error) {
 func (db *DB) ExecDDL(ctx context.Context, ddlJob *model.Job) error {
 	var err error
 	if ddlJob.BinlogInfo.TableInfo != nil {
-		switchDbSQL := fmt.Sprintf("use %s;", ddlJob.SchemaName)
+		switchDbSQL := fmt.Sprintf("use %s;", utils.EncloseName(ddlJob.SchemaName))
 		err = db.se.Execute(ctx, switchDbSQL)
 		if err != nil {
 			log.Error("switch db failed",

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -91,6 +91,7 @@ func (cfg *BackupConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 
 // RunBackup starts a backup task inside the current goroutine.
 func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig) error {
+	defer summary.Summary(cmdName)
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
@@ -120,8 +121,6 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err != nil {
 		return err
 	}
-
-	defer summary.Summary(cmdName)
 
 	ranges, backupSchemas, err := backup.BuildBackupRangeAndSchema(
 		mgr.GetDomain(), mgr.GetTiKV(), tableFilter, backupTS)

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -83,6 +83,7 @@ func (cfg *RawKvConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 
 // RunBackupRaw starts a backup task inside the current goroutine.
 func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConfig) error {
+	defer summary.Summary(cmdName)
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
@@ -103,8 +104,6 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	if err = client.SetStorage(ctx, u, cfg.SendCreds); err != nil {
 		return err
 	}
-
-	defer summary.Summary(cmdName)
 
 	backupRange := rtree.Range{StartKey: cfg.StartKey, EndKey: cfg.EndKey}
 

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -73,6 +73,7 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 
 // RunRestore starts a restore task inside the current goroutine.
 func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConfig) error {
+	defer summary.Summary(cmdName)
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
@@ -104,8 +105,6 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	if err != nil {
 		return err
 	}
-
-	defer summary.Summary(cmdName)
 
 	u, _, backupMeta, err := ReadBackupMeta(ctx, utils.MetaFile, &cfg.Config)
 	if err != nil {

--- a/pkg/task/restore_raw.go
+++ b/pkg/task/restore_raw.go
@@ -47,6 +47,7 @@ func (cfg *RestoreRawConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 
 // RunRestoreRaw starts a raw kv restore task inside the current goroutine.
 func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreRawConfig) error {
+	defer summary.Summary(cmdName)
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
@@ -66,8 +67,6 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	if cfg.Online {
 		client.EnableOnline()
 	}
-
-	defer summary.Summary(cmdName)
 
 	u, _, backupMeta, err := ReadBackupMeta(ctx, utils.MetaFile, &cfg.Config)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
always put summary output at last 

### What is changed and how it works?
move defer summary in the front of `runBackup`/`runRestore`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test 

