### PR TITLE
tests: disable TLS test

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -29,6 +29,13 @@ if [ "${1-}" = '--debug' ]; then
 fi
 
 for script in tests/${TEST_NAME-*}/run.sh; do
+    TEST_NAME="$(basename "$(dirname "$script")")"
+    if [ $TEST_NAME = "br_tls" ]; then
+        echo "FIXME enable br_tls test"
+        echo "TiKV master (ed71f20f445e10595553d2bf3d1a1eb645b9a61a) aborts when TLS is enabled"
+        continue
+    fi
+
     echo "*===== Running test $script... =====*"
     TEST_DIR="$TEST_DIR" \
     PD_ADDR="$PD_ADDR" \


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

Latest TiKV core dumps (tikv/tikv#7209) when TLS is enabled and blocks BR pull requests.

### What is changed and how it works?

To unblock BR pull requests we have to disable TLS test temporarily.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
