### PR TITLE
move waiting reject stores in import file

### DIFF
--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -347,7 +347,8 @@ func (rc *Client) CreateTables(
 
 // RemoveTiFlashReplica removes all the tiflash replicas of a table
 // TODO: remove this after tiflash supports restore
-func (rc *Client) RemoveTiFlashReplica(tables []*utils.Table, newTables []*model.TableInfo, placementRules []placement.Rule) error {
+func (rc *Client) RemoveTiFlashReplica(
+	tables []*utils.Table, newTables []*model.TableInfo, placementRules []placement.Rule) error {
 	schemas := make([]*backup.Schema, 0, len(tables))
 	var updateReplica bool
 	// must use new table id to search placement rules

--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -454,6 +454,7 @@ func (rc *Client) setSpeedLimit() error {
 func (rc *Client) RestoreFiles(
 	files []*backup.File,
 	rewriteRules *RewriteRules,
+	rejectStoreMap map[uint64]bool,
 	updateCh glue.Progress,
 ) (err error) {
 	start := time.Now()
@@ -486,7 +487,7 @@ func (rc *Client) RestoreFiles(
 				select {
 				case <-rc.ctx.Done():
 					errCh <- rc.ctx.Err()
-				case errCh <- rc.fileImporter.Import(fileReplica, rewriteRules):
+				case errCh <- rc.fileImporter.Import(fileReplica, rejectStoreMap, rewriteRules):
 					updateCh.Inc()
 				}
 			})
@@ -537,7 +538,7 @@ func (rc *Client) RestoreRaw(startKey []byte, endKey []byte, files []*backup.Fil
 				select {
 				case <-rc.ctx.Done():
 					errCh <- rc.ctx.Err()
-				case errCh <- rc.fileImporter.Import(fileReplica, emptyRules):
+				case errCh <- rc.fileImporter.Import(fileReplica, nil, emptyRules):
 					updateCh.Inc()
 				}
 			})

--- a/pkg/restore/client_test.go
+++ b/pkg/restore/client_test.go
@@ -72,6 +72,10 @@ func (s *testRestoreClientSuite) TestCreateTables(c *C) {
 	}
 	rules, newTables, err := client.CreateTables(s.mock.Domain, tables, 0)
 	c.Assert(err, IsNil)
+	// make sure tables and newTables have same order
+	for i, t := range tables {
+		c.Assert(newTables[i].Name, Equals, t.Info.Name)
+	}
 	for _, nt := range newTables {
 		c.Assert(nt.Name.String(), Matches, "test[0-3]")
 	}

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -175,7 +175,8 @@ func (importer *FileImporter) SetRawRange(startKey, endKey []byte) error {
 
 // Import tries to import a file.
 // All rules must contain encoded keys.
-func (importer *FileImporter) Import(file *backup.File,
+func (importer *FileImporter) Import(
+	file *backup.File,
 	rejectStoreMap map[uint64]bool,
 	rewriteRules *RewriteRules,
 ) error {

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -198,10 +198,7 @@ func (importer *FileImporter) Import(
 		zap.Binary("startKey", startKey),
 		zap.Binary("endKey", endKey))
 
-	needReject := false
-	if len(rejectStoreMap) > 0 {
-		needReject = true
-	}
+	needReject := len(rejectStoreMap) > 0
 
 	err = utils.WithRetry(importer.ctx, func() error {
 		ctx, cancel := context.WithTimeout(importer.ctx, importScanRegionTime)

--- a/pkg/restore/split_test.go
+++ b/pkg/restore/split_test.go
@@ -193,7 +193,7 @@ func (s *testRestoreUtilSuite) TestSplit(c *C) {
 	regionSplitter := NewRegionSplitter(client)
 
 	ctx := context.Background()
-	err := regionSplitter.Split(ctx, ranges, rewriteRules, map[uint64]bool{}, func(key [][]byte) {})
+	err := regionSplitter.Split(ctx, ranges, rewriteRules, func(key [][]byte) {})
 	if err != nil {
 		c.Assert(err, IsNil, Commentf("split regions failed: %v", err))
 	}

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"go.uber.org/zap"
 
-	"github.com/pingcap/br/pkg/conn"
 	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/rtree"
 	"github.com/pingcap/br/pkg/summary"
@@ -332,16 +331,8 @@ func SplitRanges(
 		summary.CollectDuration("split region", elapsed)
 	}()
 	splitter := NewRegionSplitter(NewSplitClient(client.GetPDClient(), client.GetTLSConfig()))
-	tiflashStores, err := conn.GetAllTiKVStores(ctx, client.GetPDClient(), conn.TiFlashOnly)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	storeMap := make(map[uint64]bool)
-	for _, store := range tiflashStores {
-		storeMap[store.GetId()] = true
-	}
 
-	return splitter.Split(ctx, ranges, rewriteRules, storeMap, func(keys [][]byte) {
+	return splitter.Split(ctx, ranges, rewriteRules, func(keys [][]byte) {
 		for range keys {
 			updateCh.Inc()
 		}
@@ -415,4 +406,60 @@ func paginateScanRegion(
 		}
 	}
 	return regions, nil
+}
+
+func hasRejectStorePeer(
+	ctx context.Context,
+	client SplitClient,
+	regionID uint64,
+	rejectStores map[uint64]bool,
+) (bool, error) {
+	regionInfo, err := client.GetRegionByID(ctx, regionID)
+	if err != nil {
+		return false, err
+	}
+	if regionInfo == nil {
+		return false, nil
+	}
+	for _, peer := range regionInfo.Region.GetPeers() {
+		if rejectStores[peer.GetStoreId()] {
+			return true, nil
+		}
+	}
+	retryTimes := ctx.Value(retryTimes).(int)
+	if retryTimes > 10 {
+		log.Warn("get region info", zap.Stringer("region", regionInfo.Region))
+	}
+	return false, nil
+}
+
+func waitForRemoveRejectStores(
+	ctx context.Context,
+	client SplitClient,
+	regionInfo *RegionInfo,
+	rejectStores map[uint64]bool,
+) bool {
+	interval := RejectStoreCheckInterval
+	regionID := regionInfo.Region.GetId()
+	for i := 0; i < RejectStoreCheckRetryTimes; i++ {
+		ctx1 := context.WithValue(ctx, retryTimes, i)
+		ok, err := hasRejectStorePeer(ctx1, client, regionID, rejectStores)
+		if err != nil {
+			log.Warn("wait for rejecting store failed",
+				zap.Stringer("region", regionInfo.Region),
+				zap.Error(err))
+			return false
+		}
+		// Do not have any peer in the rejected store, return true
+		if !ok {
+			return true
+		}
+		interval = 2 * interval
+		if interval > RejectStoreMaxCheckInterval {
+			interval = RejectStoreMaxCheckInterval
+		}
+		time.Sleep(interval)
+	}
+
+	return false
 }

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -174,7 +174,8 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	if err != nil {
 		return err
 	}
-	err = client.RemoveTiFlashReplica(tables, placementRules)
+
+	err = client.RemoveTiFlashReplica(tables, newTables, placementRules)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
currently we have issue when deal with tiflash stores:
to reproduce it, we can assume
  1. we have two tables, t1 and t2
        * t1 has 100000 record
        * t2 has 10 record
2. alter table `t1` set tiflash replica 1;
3. br backup table --db xxx --table `t2` -s ... --pd ...
4. br restore table --db xxx --table `t2` -s ... --pd ...

then we may get this log until waiting out of time
```
[2020/03/31 17:57:12.714 +08:00] [INFO] [split.go:150] ["start to wait for removing rejected stores"] [rejectStores="{\"92\":true}"]
```

this because `t2` and `t1` may be in the same region. and the condition of waiting rejected store is whether [region has tiflash store peers](https://github.com/pingcap/br/blob/6268cde45e6a05b5e46d1208b31ea18a1770b8ba/pkg/restore/split.go#L292)


### What is changed and how it works?
move `wait reject store` logic after import file region scan, when we finish split & scatter, the new scan regions will only belong to one table.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test



Related changes

 - Need to cherry-pick to the release branch

