### PR TITLE
Use table info

### DIFF
--- a/pkg/restore/db.go
+++ b/pkg/restore/db.go
@@ -57,7 +57,10 @@ func (db *DB) ExecDDL(ctx context.Context, ddlJob *model.Job) error {
 	case model.ActionCreateTable:
 		err = db.se.CreateTable(ctx, model.NewCIStr(ddlJob.SchemaName), tableInfo)
 		if err != nil {
-			log.Error("create database failed", zap.Stringer("db", dbInfo.Name), zap.Error(err))
+			log.Error("create table failed",
+				zap.Stringer("db", dbInfo.Name),
+				zap.Stringer("table", tableInfo.Name),
+				zap.Error(err))
 		}
 		return errors.Trace(err)
 	}

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -471,6 +471,10 @@ func enableTiDBConfig() {
 	conf.MaxIndexLength = config.DefMaxOfMaxIndexLength
 	log.Warn("set max-index-length to max(3072*4) to skip check index length in DDL")
 
+	// we need set this to true, since all create table DDLs will create with tableInfo
+	// and we can handle alter drop pk/add pk DDLs with no impact
+	conf.AlterPrimaryKey = true
+
 	// set this to true for some auto random DDL execute normally during incremental restore
 	conf.Experimental.AllowAutoRandom = true
 	conf.Experimental.AllowsExpressionIndex = true

--- a/tests/br_incompatible_tidb_config/run.sh
+++ b/tests/br_incompatible_tidb_config/run.sh
@@ -42,6 +42,9 @@ run_sql "insert into $DB.$INCREMENTAL_TABLE values (42, 42);"
 
 # drop pk
 run_sql "alter table $DB.$INCREMENTAL_TABLE drop primary key"
+run_sql "drop table $DB.$INCREMENTAL_TABLE"
+run_sql "create table $DB.$INCREMENTAL_TABLE like $DB.$TABLE"
+run_sql "insert into $DB.$INCREMENTAL_TABLEvalues (42, 42);"
 
 # incremental backup
 run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB$INCREMENTAL_TABLE"

--- a/tests/br_incompatible_tidb_config/run.sh
+++ b/tests/br_incompatible_tidb_config/run.sh
@@ -29,6 +29,7 @@ run_sql "create schema $DB;"
 
 # test alter pk issue https://github.com/pingcap/br/issues/215
 TABLE="t1"
+INCREMENTAL_TABLE="t1inc"
 
 run_sql "create table $DB.$TABLE (a int primary key, b int unique);"
 run_sql "insert into $DB.$TABLE values (42, 42);"
@@ -36,9 +37,21 @@ run_sql "insert into $DB.$TABLE values (42, 42);"
 # backup
 run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB$TABLE"
 
+run_sql "create table $DB.$INCREMENTAL_TABLE (a int primary key, b int unique);"
+run_sql "insert into $DB.$INCREMENTAL_TABLE values (42, 42);"
+
+# drop pk
+run_sql "alter table $DB.$INCREMENTAL_TABLE drop primary key"
+
+# incremental backup
+run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB$INCREMENTAL_TABLE"
+
 # restore
 run_sql "drop schema $DB;"
+
 run_br --pd $PD_ADDR restore db --db "$DB" -s "local://$TEST_DIR/$DB$TABLE"
+
+run_br --pd $PD_ADDR restore db --db "$DB" -s "local://$TEST_DIR/$DB$INCREMENTAL_TABLE"
 
 run_sql "drop schema $DB;"
 run_sql "create schema $DB;"

--- a/tests/br_incompatible_tidb_config/run.sh
+++ b/tests/br_incompatible_tidb_config/run.sh
@@ -99,7 +99,8 @@ run_sql "create table $DB.$INCREMENTAL_TABLE (a int(11) NOT NULL /*T!30100 AUTO_
 run_sql "insert into $DB.$INCREMENTAL_TABLE values ('42');"
 
 # incremental backup test for execute DDL
-run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB$INCREMENTAL_TABLE"
+last_backup_ts=$(br validate decode --field="end-version" -s "local://$TEST_DIR/$DB$TABLE" | tail -n1)
+run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB$INCREMENTAL_TABLE" --lastbackupts $last_backup_ts
 
 run_sql "drop schema $DB;"
 

--- a/tests/br_incompatible_tidb_config/run.sh
+++ b/tests/br_incompatible_tidb_config/run.sh
@@ -44,7 +44,7 @@ run_sql "insert into $DB.$INCREMENTAL_TABLE values (42, 42);"
 run_sql "alter table $DB.$INCREMENTAL_TABLE drop primary key"
 run_sql "drop table $DB.$INCREMENTAL_TABLE"
 run_sql "create table $DB.$INCREMENTAL_TABLE like $DB.$TABLE"
-run_sql "insert into $DB.$INCREMENTAL_TABLEvalues (42, 42);"
+run_sql "insert into $DB.$INCREMENTAL_TABLE values (42, 42);"
 
 # incremental backup
 run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB$INCREMENTAL_TABLE"


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/br/pull/230#issuecomment-610798266

### What is changed and how it works?
1. use `ddljob.TableInfo` and `ddljob.DBInfo` to create tables and schema in incremental restore.
2. set `config.AlterPrimaryKey` to true so we can execute drop/add pk DDL in incremental restore.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)


Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

