### PR TITLE
cmd: don't use ':' in the default log file name

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -47,7 +47,7 @@ const (
 )
 
 func timestampLogFileName() string {
-	return filepath.Join(os.TempDir(), "br.log."+time.Now().Format(time.RFC3339))
+	return filepath.Join(os.TempDir(), time.Now().Format("br.log.2006-01-02T15.04.05Z0700"))
 }
 
 // AddFlags adds flags to the given cmd.


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`:` is not a valid filename character for NTFS. The default log file path contains a `:` and thus invalid.

### What is changed and how it works?

Replace the `:` in the filename by `.`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * run `bin/br --help` and check the output.

Code changes

Side effects

Related changes
