### PR TITLE
Backup: register backupTS as safepoint to PD 

### DIFF
--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -11,6 +11,12 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	brServiceSafePointID = "br"
+	// DefaultBRGCSafePointTTL means PD keep safePoint limit at least 5min
+	DefaultBRGCSafePointTTL = 5 * 60
+)
+
 // getGCSafePoint returns the current gc safe point.
 // TODO: Some cluster may not enable distributed GC.
 func getGCSafePoint(ctx context.Context, pdClient pd.Client) (uint64, error) {
@@ -21,9 +27,9 @@ func getGCSafePoint(ctx context.Context, pdClient pd.Client) (uint64, error) {
 	return safePoint, nil
 }
 
-// CheckGCSafepoint checks whether the ts is older than GC safepoint.
+// CheckGCSafePoint checks whether the ts is older than GC safepoint.
 // Note: It ignores errors other than exceed GC safepoint.
-func CheckGCSafepoint(ctx context.Context, pdClient pd.Client, ts uint64) error {
+func CheckGCSafePoint(ctx context.Context, pdClient pd.Client, ts uint64) error {
 	// TODO: use PDClient.GetGCSafePoint instead once PD client exports it.
 	safePoint, err := getGCSafePoint(ctx, pdClient)
 	if err != nil {
@@ -34,4 +40,15 @@ func CheckGCSafepoint(ctx context.Context, pdClient pd.Client, ts uint64) error 
 		return errors.Errorf("GC safepoint %d exceed TS %d", safePoint, ts)
 	}
 	return nil
+}
+
+// UpdateServiceSafePoint register backupTS to PD, to lock down backupTS as safePoint with ttl seconds
+func UpdateServiceSafePoint(ctx context.Context, pdClient pd.Client, ttl int64, backupTS uint64) error {
+	log.Debug("update PD safePoint limit with ttl",
+		zap.Uint64("safePoint", backupTS),
+		zap.Int64("ttl", ttl))
+
+	_, err := pdClient.UpdateServiceGCSafePoint(ctx,
+		brServiceSafePointID, ttl, backupTS-1)
+	return err
 }

--- a/pkg/backup/safe_point_test.go
+++ b/pkg/backup/safe_point_test.go
@@ -13,53 +13,53 @@ import (
 	"github.com/pingcap/br/pkg/mock"
 )
 
-var _ = Suite(&testSaftPointSuite{})
+var _ = Suite(&testSafePointSuite{})
 
-type testSaftPointSuite struct {
+type testSafePointSuite struct {
 	mock *mock.Cluster
 }
 
-func (s *testSaftPointSuite) SetUpSuite(c *C) {
+func (s *testSafePointSuite) SetUpSuite(c *C) {
 	var err error
 	s.mock, err = mock.NewCluster()
 	c.Assert(err, IsNil)
 }
 
-func (s *testSaftPointSuite) TearDownSuite(c *C) {
+func (s *testSafePointSuite) TearDownSuite(c *C) {
 	testleak.AfterTest(c)()
 }
 
-func (s *testSaftPointSuite) TestCheckGCSafepoint(c *C) {
+func (s *testSafePointSuite) TestCheckGCSafepoint(c *C) {
 	c.Assert(s.mock.Start(), IsNil)
 	defer s.mock.Stop()
 
 	ctx := context.Background()
-	pdClient := &mockSafepoint{Client: s.mock.PDClient, safepoint: 2333}
+	pdClient := &mockSafePoint{Client: s.mock.PDClient, safepoint: 2333}
 	{
-		err := CheckGCSafepoint(ctx, pdClient, 2333+1)
+		err := CheckGCSafePoint(ctx, pdClient, 2333+1)
 		c.Assert(err, IsNil)
 	}
 	{
-		err := CheckGCSafepoint(ctx, pdClient, 2333)
+		err := CheckGCSafePoint(ctx, pdClient, 2333)
 		c.Assert(err, NotNil)
 	}
 	{
-		err := CheckGCSafepoint(ctx, pdClient, 2333-1)
+		err := CheckGCSafePoint(ctx, pdClient, 2333-1)
 		c.Assert(err, NotNil)
 	}
 	{
-		err := CheckGCSafepoint(ctx, pdClient, 0)
+		err := CheckGCSafePoint(ctx, pdClient, 0)
 		c.Assert(err, ErrorMatches, "GC safepoint 2333 exceed TS 0")
 	}
 }
 
-type mockSafepoint struct {
+type mockSafePoint struct {
 	sync.Mutex
 	pd.Client
 	safepoint uint64
 }
 
-func (m *mockSafepoint) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint64, error) {
+func (m *mockSafePoint) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint64, error) {
 	m.Lock()
 	defer m.Unlock()
 

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -33,6 +33,8 @@ const (
 	flagBackupTS      = "backupts"
 	flagLastBackupTS  = "lastbackupts"
 
+	flagGCTTL = "gcttl"
+
 	defaultBackupConcurrency = 4
 )
 
@@ -43,6 +45,7 @@ type BackupConfig struct {
 	TimeAgo      time.Duration `json:"time-ago" toml:"time-ago"`
 	BackupTS     uint64        `json:"backup-ts" toml:"backup-ts"`
 	LastBackupTS uint64        `json:"last-backup-ts" toml:"last-backup-ts"`
+	GCTTL        int64         `json:"gc-ttl" toml:"gc-ttl"`
 }
 
 // DefineBackupFlags defines common flags for the backup command.
@@ -56,6 +59,7 @@ func DefineBackupFlags(flags *pflag.FlagSet) {
 		" use for incremental backup, support TSO only")
 	flags.String(flagBackupTS, "", "the backup ts support TSO or datetime,"+
 		" e.g. '400036290571534337', '2018-05-11 01:42:23'")
+	flags.Int64(flagGCTTL, backup.DefaultBRGCSafePointTTL, "the TTL (in seconds) that PD holds for BR's GC safepoint")
 }
 
 // ParseFromFlags parses the backup-related flags from the flag set.
@@ -80,6 +84,11 @@ func (cfg *BackupConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	gcTTL, err := flags.GetInt64(flagGCTTL)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cfg.GCTTL = gcTTL
 
 	if err = cfg.Config.ParseFromFlags(flags); err != nil {
 		return errors.Trace(err)
@@ -117,6 +126,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err = client.SetStorage(ctx, u, cfg.SendCreds); err != nil {
 		return err
 	}
+	client.SetGCTTL(cfg.GCTTL)
 
 	backupTS, err := client.GetTS(ctx, cfg.TimeAgo, cfg.BackupTS)
 	if err != nil {
@@ -140,7 +150,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 			log.Error("LastBackupTS is larger than current TS")
 			return errors.New("LastBackupTS is larger than current TS")
 		}
-		err = backup.CheckGCSafepoint(ctx, mgr.GetPDClient(), cfg.LastBackupTS)
+		err = backup.CheckGCSafePoint(ctx, mgr.GetPDClient(), cfg.LastBackupTS)
 		if err != nil {
 			log.Error("Check gc safepoint for last backup ts failed", zap.Error(err))
 			return err


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR can register backupTS as safePoint to PD, so the SafePoint won't move forward during backup. Avoid manually set GC safePoint.

### What is changed and how it works?
Use `pdClient.UpdateServiceSafePoint` interface to lock down safePoint with TTL(60 secs)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
             need cherry-pick to release-4.0
 - Need to update the documentation
 - Need to be included in the release note
