### PR TITLE
cherry-pick to release 4.0

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -68,6 +68,8 @@ type Client struct {
 	backupMeta kvproto.BackupMeta
 	storage    storage.ExternalStorage
 	backend    *kvproto.StorageBackend
+
+	gcTTL int64
 }
 
 // NewBackupClient returns a new backup client
@@ -112,12 +114,22 @@ func (bc *Client) GetTS(ctx context.Context, duration time.Duration, ts uint64) 
 	}
 
 	// check backup time do not exceed GCSafePoint
-	err = CheckGCSafepoint(ctx, bc.mgr.GetPDClient(), backupTS)
+	err = CheckGCSafePoint(ctx, bc.mgr.GetPDClient(), backupTS)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
 	log.Info("backup encode timestamp", zap.Uint64("BackupTS", backupTS))
 	return backupTS, nil
+}
+
+// SetGCTTL set gcTTL for client
+func (bc *Client) SetGCTTL(ttl int64) {
+	bc.gcTTL = ttl
+}
+
+// GetGCTTL get gcTTL for this backup.
+func (bc *Client) GetGCTTL() int64 {
+	return bc.gcTTL
 }
 
 // SetStorage set ExternalStorage for client
@@ -355,19 +367,26 @@ func (bc *Client) BackupRanges(
 	t := time.NewTicker(time.Second * 5)
 	defer t.Stop()
 
+	backupTS := req.EndVersion
+	// use lastBackupTS as safePoint if exists
+	if req.StartVersion > 0 {
+		backupTS = req.StartVersion
+	}
+
+	log.Info("current backup safePoint job",
+		zap.Uint64("backupTS", backupTS))
+
 	finished := false
 	for {
-		err := CheckGCSafepoint(ctx, bc.mgr.GetPDClient(), req.EndVersion)
+		err := UpdateServiceSafePoint(ctx, bc.mgr.GetPDClient(), bc.GetGCTTL(), backupTS)
 		if err != nil {
-			log.Error("check GC safepoint failed", zap.Error(err))
+			log.Error("update GC safePoint with TTL failed", zap.Error(err))
 			return err
 		}
-		if req.StartVersion > 0 {
-			err = CheckGCSafepoint(ctx, bc.mgr.GetPDClient(), req.StartVersion)
-			if err != nil {
-				log.Error("Check gc safepoint for last backup ts failed", zap.Error(err))
-				return err
-			}
+		err = CheckGCSafePoint(ctx, bc.mgr.GetPDClient(), backupTS)
+		if err != nil {
+			log.Error("check GC safePoint failed", zap.Error(err))
+			return err
 		}
 		if finished {
 			// Return error (if there is any) before finishing backup.

--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -11,6 +11,12 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	brServiceSafePointID = "br"
+	// DefaultBRGCSafePointTTL means PD keep safePoint limit at least 5min
+	DefaultBRGCSafePointTTL = 5 * 60
+)
+
 // getGCSafePoint returns the current gc safe point.
 // TODO: Some cluster may not enable distributed GC.
 func getGCSafePoint(ctx context.Context, pdClient pd.Client) (uint64, error) {
@@ -21,9 +27,9 @@ func getGCSafePoint(ctx context.Context, pdClient pd.Client) (uint64, error) {
 	return safePoint, nil
 }
 
-// CheckGCSafepoint checks whether the ts is older than GC safepoint.
+// CheckGCSafePoint checks whether the ts is older than GC safepoint.
 // Note: It ignores errors other than exceed GC safepoint.
-func CheckGCSafepoint(ctx context.Context, pdClient pd.Client, ts uint64) error {
+func CheckGCSafePoint(ctx context.Context, pdClient pd.Client, ts uint64) error {
 	// TODO: use PDClient.GetGCSafePoint instead once PD client exports it.
 	safePoint, err := getGCSafePoint(ctx, pdClient)
 	if err != nil {
@@ -34,4 +40,15 @@ func CheckGCSafepoint(ctx context.Context, pdClient pd.Client, ts uint64) error 
 		return errors.Errorf("GC safepoint %d exceed TS %d", safePoint, ts)
 	}
 	return nil
+}
+
+// UpdateServiceSafePoint register backupTS to PD, to lock down backupTS as safePoint with ttl seconds
+func UpdateServiceSafePoint(ctx context.Context, pdClient pd.Client, ttl int64, backupTS uint64) error {
+	log.Debug("update PD safePoint limit with ttl",
+		zap.Uint64("safePoint", backupTS),
+		zap.Int64("ttl", ttl))
+
+	_, err := pdClient.UpdateServiceGCSafePoint(ctx,
+		brServiceSafePointID, ttl, backupTS-1)
+	return err
 }

--- a/pkg/backup/safe_point_test.go
+++ b/pkg/backup/safe_point_test.go
@@ -13,53 +13,53 @@ import (
 	"github.com/pingcap/br/pkg/mock"
 )
 
-var _ = Suite(&testSaftPointSuite{})
+var _ = Suite(&testSafePointSuite{})
 
-type testSaftPointSuite struct {
+type testSafePointSuite struct {
 	mock *mock.Cluster
 }
 
-func (s *testSaftPointSuite) SetUpSuite(c *C) {
+func (s *testSafePointSuite) SetUpSuite(c *C) {
 	var err error
 	s.mock, err = mock.NewCluster()
 	c.Assert(err, IsNil)
 }
 
-func (s *testSaftPointSuite) TearDownSuite(c *C) {
+func (s *testSafePointSuite) TearDownSuite(c *C) {
 	testleak.AfterTest(c)()
 }
 
-func (s *testSaftPointSuite) TestCheckGCSafepoint(c *C) {
+func (s *testSafePointSuite) TestCheckGCSafepoint(c *C) {
 	c.Assert(s.mock.Start(), IsNil)
 	defer s.mock.Stop()
 
 	ctx := context.Background()
-	pdClient := &mockSafepoint{Client: s.mock.PDClient, safepoint: 2333}
+	pdClient := &mockSafePoint{Client: s.mock.PDClient, safepoint: 2333}
 	{
-		err := CheckGCSafepoint(ctx, pdClient, 2333+1)
+		err := CheckGCSafePoint(ctx, pdClient, 2333+1)
 		c.Assert(err, IsNil)
 	}
 	{
-		err := CheckGCSafepoint(ctx, pdClient, 2333)
+		err := CheckGCSafePoint(ctx, pdClient, 2333)
 		c.Assert(err, NotNil)
 	}
 	{
-		err := CheckGCSafepoint(ctx, pdClient, 2333-1)
+		err := CheckGCSafePoint(ctx, pdClient, 2333-1)
 		c.Assert(err, NotNil)
 	}
 	{
-		err := CheckGCSafepoint(ctx, pdClient, 0)
+		err := CheckGCSafePoint(ctx, pdClient, 0)
 		c.Assert(err, ErrorMatches, "GC safepoint 2333 exceed TS 0")
 	}
 }
 
-type mockSafepoint struct {
+type mockSafePoint struct {
 	sync.Mutex
 	pd.Client
 	safepoint uint64
 }
 
-func (m *mockSafepoint) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint64, error) {
+func (m *mockSafePoint) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint64, error) {
 	m.Lock()
 	defer m.Unlock()
 


### PR DESCRIPTION
cherry-pick #257 to release-4.0
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR can register backupTS as safePoint to PD, so the SafePoint won't move forward during backup. Avoid manually set GC safePoint.

### What is changed and how it works?
Use `pdClient.UpdateServiceSafePoint` interface to lock down safePoint with TTL(60 secs)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
             need cherry-pick to release-4.0
 - Need to update the documentation
 - Need to be included in the release note
