### PR TITLE
pass sse_kms_key_id to S3 (#243)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ backupmeta
 coverage.txt
 docker/data/
 docker/logs/
+*.swp

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/montanaflynn/stats v0.5.0 // indirect
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011
-	github.com/pingcap/kvproto v0.0.0-20200331072206-c211b473fe43
+	github.com/pingcap/kvproto v0.0.0-20200506072111-3a6b8b9cb29e
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
 	github.com/pingcap/parser v3.1.0-beta.2.0.20200425032215-994651e9b6df+incompatible
 	github.com/pingcap/pd/v3 v3.1.1-0.20200426091027-e639f0b1e62b

--- a/go.sum
+++ b/go.sum
@@ -329,10 +329,9 @@ github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e h1:P73/4dPCL96rGrobssy1nVy2VaVpNCuLpCbr+FEaTA8=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20200213074014-83e827908584/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20200317043902-2838e21ca222 h1:y+qDC9hP5ZMQADkVtbGvZOP68NsoYFlt4I3r8QhIvVk=
 github.com/pingcap/kvproto v0.0.0-20200317043902-2838e21ca222/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20200331072206-c211b473fe43 h1:JFKYB7Y6koAVT0l/f1SDgb0DfFlRZh8ku39fF2NC9aM=
-github.com/pingcap/kvproto v0.0.0-20200331072206-c211b473fe43/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20200506072111-3a6b8b9cb29e h1:X1t/m9VcPBzx1BtSfziqILkMz5gRwBWdbgpeR129p8o=
+github.com/pingcap/kvproto v0.0.0-20200506072111-3a6b8b9cb29e/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -24,7 +24,8 @@ const (
 	s3EndpointOption     = "s3.endpoint"
 	s3RegionOption       = "s3.region"
 	s3StorageClassOption = "s3.storage-class"
-	s3SSEOption          = "s3.sse"
+	s3SseOption          = "s3.sse"
+	s3SseKmsKeyIDOption  = "s3.sse-kms-key-id"
 	s3ACLOption          = "s3.acl"
 	s3ProviderOption     = "s3.provider"
 	notFound             = "NotFound"
@@ -53,7 +54,8 @@ type S3BackendOptions struct {
 	Endpoint              string `json:"endpoint" toml:"endpoint"`
 	Region                string `json:"region" toml:"region"`
 	StorageClass          string `json:"storage-class" toml:"storage-class"`
-	SSE                   string `json:"sse" toml:"sse"`
+	Sse                   string `json:"sse" toml:"sse"`
+	SseKmsKeyID           string `json:"sse-kms-key-id" toml:"sse-kms-key-id"`
 	ACL                   string `json:"acl" toml:"acl"`
 	AccessKey             string `json:"access-key" toml:"access-key"`
 	SecretAccessKey       string `json:"secret-access-key" toml:"secret-access-key"`
@@ -95,7 +97,8 @@ func (options *S3BackendOptions) apply(s3 *backup.S3) error {
 	s3.Region = options.Region
 	// StorageClass, SSE and ACL are acceptable to be empty
 	s3.StorageClass = options.StorageClass
-	s3.Sse = options.SSE
+	s3.Sse = options.Sse
+	s3.SseKmsKeyId = options.SseKmsKeyID
 	s3.Acl = options.ACL
 	s3.AccessKey = options.AccessKey
 	s3.SecretAccessKey = options.SecretAccessKey
@@ -109,7 +112,9 @@ func defineS3Flags(flags *pflag.FlagSet) {
 		"(experimental) Set the S3 endpoint URL, please specify the http or https scheme explicitly")
 	flags.String(s3RegionOption, "", "(experimental) Set the S3 region, e.g. us-east-1")
 	flags.String(s3StorageClassOption, "", "(experimental) Set the S3 storage class, e.g. STANDARD")
-	flags.String(s3SSEOption, "", "(experimental) Set the S3 server-side encryption algorithm, e.g. AES256")
+	flags.String(s3SseOption, "", "Set S3 server-side encryption, e.g. aws:kms")
+	flags.String(s3SseKmsKeyIDOption, "", "KMS CMK key id to use with S3 server-side encryption."+
+		"Leave empty to use S3 owned key.")
 	flags.String(s3ACLOption, "", "(experimental) Set the S3 canned ACLs, e.g. authenticated-read")
 	flags.String(s3ProviderOption, "", "(experimental) Set the S3 provider, e.g. aws, alibaba, ceph")
 }
@@ -124,7 +129,11 @@ func (options *S3BackendOptions) parseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	options.SSE, err = flags.GetString(s3SSEOption)
+	options.Sse, err = flags.GetString(s3SseOption)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	options.SseKmsKeyID, err = flags.GetString(s3SseKmsKeyIDOption)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -223,6 +232,9 @@ func (rs *S3Storage) Write(ctx context.Context, file string, data []byte) error 
 	}
 	if rs.options.Sse != "" {
 		input = input.SetServerSideEncryption(rs.options.Sse)
+	}
+	if rs.options.SseKmsKeyId != "" {
+		input = input.SetSSEKMSKeyId(rs.options.SseKmsKeyId)
 	}
 	if rs.options.StorageClass != "" {
 		input = input.SetStorageClass(rs.options.StorageClass)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

Pass sse_kms_key_id when backup to S3. This is to support using user owned KMS key for server-side encryption.

Pass sse_kms_key_id when backup to S3 to both tikv and when storing backupmeta in S3.

Tests <!-- At least one of them must be included. -->
Manual test with BR. Try:
* specify kms key id on backup. restore success.
* disable the kms key and try restore again. restore failed.

Related changes

depends on kvproto change: https://github.com/pingcap/kvproto/pull/607 and tikv change: https://github.com/tikv/tikv/pull/7627

Signed-off-by: Yi Wu <yiwu@pingcap.com>

Co-authored-by: kennytm <kennytm@gmail.com>