### PR TITLE
.github: change the PR template to include the "Release note" section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,4 +34,9 @@ Related changes
 
  - Need to cherry-pick to the release branch
  - Need to update the documentation
- - Need to be included in the release note
+
+### Release Note
+
+ -
+
+<!-- fill in the release note, or just write "No release note" -->


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The new "release note checker" bot demands a "Release note" section 🤖.

### What is changed and how it works?

Replaced the original "Need to be included in the release note" item by a "Release note" section.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

### Release Note

 * No release note
