### PR TITLE
tests: wait tikv 100 seconds to init

### DIFF
--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -77,7 +77,7 @@ start_services() {
           echo 'Failed to initialize TiKV cluster'
           exit 1
        fi
-       sleep 3
+       sleep 5
     done
 
     echo "Starting TiDB..."


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
try to fix integration_test failed with `Failed to initialize TiKV cluster`

### What is changed and how it works?
wait tikv 100 seconds to start

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

Related changes

 - Need to cherry-pick to the release branch


### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
