### PR TITLE
change auto_random columns to bigint.

### DIFF
--- a/tests/br_incompatible_tidb_config/run.sh
+++ b/tests/br_incompatible_tidb_config/run.sh
@@ -89,13 +89,13 @@ start_services "$cur"
 TABLE="t3"
 INCREMENTAL_TABLE="t3inc"
 run_sql "create schema $DB;"
-run_sql "create table $DB.$TABLE (a int(11) NOT NULL /*T!30100 AUTO_RANDOM(5) */, PRIMARY KEY (a))"
+run_sql "create table $DB.$TABLE (a bigint(11) NOT NULL /*T!30100 AUTO_RANDOM(5) */, PRIMARY KEY (a))"
 run_sql "insert into $DB.$TABLE values ('42');"
 
 # Full backup
 run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB$TABLE"
 
-run_sql "create table $DB.$INCREMENTAL_TABLE (a int(11) NOT NULL /*T!30100 AUTO_RANDOM(5) */, PRIMARY KEY (a))"
+run_sql "create table $DB.$INCREMENTAL_TABLE (a bigint(11) NOT NULL /*T!30100 AUTO_RANDOM(5) */, PRIMARY KEY (a))"
 run_sql "insert into $DB.$INCREMENTAL_TABLE values ('42');"
 
 # incremental backup test for execute DDL
@@ -114,7 +114,7 @@ run_sql "drop schema $DB;"
 # test auto random issue https://github.com/pingcap/br/issues/241
 TABLE="t4"
 run_sql "create schema $DB;"
-run_sql "create table $DB.$TABLE(a int key auto_random(5));"
+run_sql "create table $DB.$TABLE(a bigint key auto_random(5));"
 run_sql "insert into $DB.$TABLE values (),(),(),(),();"
 
 # Table backup


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Because of [tidb#17119](https://github.com/pingcap/tidb/pull/17119), current version of `br_incompatible_tidb_config` will fail: 
```
[2020-05-18T02:14:18.885Z] ERROR 8216 (HY000) at line 1: Invalid auto random: auto_random option must be defined on `bigint` column, but not on `int` column
```

Because we use a int column with auto_random...
https://github.com/pingcap/br/blob/c2f193cd09da31f811eae192bf375eda42016ecd/tests/br_incompatible_tidb_config/run.sh#L92

### What is changed and how it works?
I changed type of columns with auto_random in the test case to bigint.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - No code

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
