### PR TITLE
tasks: print error to log after fail.

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -3,9 +3,11 @@
 package cmd
 
 import (
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/session"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/br/pkg/gluetikv"
 	"github.com/pingcap/br/pkg/summary"
@@ -19,7 +21,11 @@ func runBackupCommand(command *cobra.Command, cmdName string) error {
 		command.SilenceUsage = false
 		return err
 	}
-	return task.RunBackup(GetDefaultContext(), tidbGlue, cmdName, &cfg)
+	if err := task.RunBackup(GetDefaultContext(), tidbGlue, cmdName, &cfg); err != nil {
+		log.Error("failed to backup", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 func runBackupRawCommand(command *cobra.Command, cmdName string) error {
@@ -28,7 +34,11 @@ func runBackupRawCommand(command *cobra.Command, cmdName string) error {
 		command.SilenceUsage = false
 		return err
 	}
-	return task.RunBackupRaw(GetDefaultContext(), gluetikv.Glue{}, cmdName, &cfg)
+	if err := task.RunBackupRaw(GetDefaultContext(), gluetikv.Glue{}, cmdName, &cfg); err != nil {
+		log.Error("failed to backup raw kv", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 // NewBackupCommand return a full backup subcommand.

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -21,7 +21,7 @@ func runRestoreCommand(command *cobra.Command, cmdName string) error {
 		return err
 	}
 	if err := task.RunRestore(GetDefaultContext(), tidbGlue, cmdName, &cfg); err != nil {
-		log.Error("restore failed", zap.Error(err))
+		log.Error("failed to restore", zap.Error(err))
 		return err
 	}
 	return nil
@@ -36,7 +36,7 @@ func runRestoreRawCommand(command *cobra.Command, cmdName string) error {
 		return err
 	}
 	if err := task.RunRestoreRaw(GetDefaultContext(), gluetikv.Glue{}, cmdName, &cfg); err != nil {
-		log.Error("restore failed", zap.Error(err))
+		log.Error("failed to restore raw kv", zap.Error(err))
 		return err
 	}
 	return nil
@@ -50,7 +50,7 @@ func runRestoreTiflashReplicaCommand(command *cobra.Command, cmdName string) err
 	}
 
 	if err := task.RunRestoreTiflashReplica(GetDefaultContext(), tidbGlue, cmdName, &cfg); err != nil {
-		log.Error("restore failed", zap.Error(err))
+		log.Error("failed to restore tiflash replica", zap.Error(err))
 		return err
 	}
 	return nil

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -3,8 +3,10 @@
 package cmd
 
 import (
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/session"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/br/pkg/gluetikv"
 	"github.com/pingcap/br/pkg/summary"
@@ -18,7 +20,11 @@ func runRestoreCommand(command *cobra.Command, cmdName string) error {
 		command.SilenceUsage = false
 		return err
 	}
-	return task.RunRestore(GetDefaultContext(), tidbGlue, cmdName, &cfg)
+	if err := task.RunRestore(GetDefaultContext(), tidbGlue, cmdName, &cfg); err != nil {
+		log.Error("restore failed", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 func runRestoreRawCommand(command *cobra.Command, cmdName string) error {
@@ -29,7 +35,11 @@ func runRestoreRawCommand(command *cobra.Command, cmdName string) error {
 		command.SilenceUsage = false
 		return err
 	}
-	return task.RunRestoreRaw(GetDefaultContext(), gluetikv.Glue{}, cmdName, &cfg)
+	if err := task.RunRestoreRaw(GetDefaultContext(), gluetikv.Glue{}, cmdName, &cfg); err != nil {
+		log.Error("restore failed", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 func runRestoreTiflashReplicaCommand(command *cobra.Command, cmdName string) error {
@@ -39,7 +49,11 @@ func runRestoreTiflashReplicaCommand(command *cobra.Command, cmdName string) err
 		return err
 	}
 
-	return task.RunRestoreTiflashReplica(GetDefaultContext(), tidbGlue, cmdName, &cfg)
+	if err := task.RunRestoreTiflashReplica(GetDefaultContext(), tidbGlue, cmdName, &cfg); err != nil {
+		log.Error("restore failed", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 // NewRestoreCommand returns a restore subcommand.


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #309 

### What is changed and how it works?

I add log at `runXxxxCommand` if receive an error from `RunXxxx`. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Old version, run BR with empty storage, no error message log to log file: 
![2020-05-26 16-15-11 的屏幕截图](https://user-images.githubusercontent.com/36239017/82879895-30acb580-9f70-11ea-919d-a07babb08b98.png)

New version, an error record presents in the log file:
![2020-05-26 16-24-29 的屏幕截图](https://user-images.githubusercontent.com/36239017/82879958-4c17c080-9f70-11ea-97b5-a3afc60f3728.png)


### Release Note

 - Add log on failure.

<!-- fill in the release note, or just write "No release note" -->
