### PR TITLE
Fix row data lost

### DIFF
--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -250,6 +250,12 @@ func (importer *FileImporter) Import(
 					switch e {
 					case ErrRewriteRuleNotFound, ErrRangeIsEmpty:
 						// Skip this region
+						log.Error("download file skipped",
+							zap.Stringer("file", file),
+							zap.Stringer("region", info.Region),
+							zap.Binary("startKey", startKey),
+							zap.Binary("endKey", endKey),
+							zap.Error(e))
 						continue regionLoop
 					}
 				}
@@ -368,6 +374,7 @@ func (importer *FileImporter) downloadSST(
 	}
 	log.Debug("download SST",
 		zap.Stringer("sstMeta", &sstMeta),
+		zap.Stringer("file", file),
 		zap.Stringer("region", regionInfo.Region),
 	)
 	var resp *import_sstpb.DownloadResponse

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -190,8 +190,10 @@ func (importer *FileImporter) Import(
 		endKey = file.EndKey
 	} else {
 		startKey, endKey, err = rewriteFileKeys(file, rewriteRules)
-		startKey = truncateRowKey(startKey)
-		endKey = truncateRowKey(endKey)
+		// if not truncateRowKey here, if will scan one more region
+		// TODO need more test to check here
+		// startKey = truncateRowKey(startKey)
+		// endKey = truncateRowKey(endKey)
 	}
 	if err != nil {
 		return err

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -190,6 +190,8 @@ func (importer *FileImporter) Import(
 		endKey = file.EndKey
 	} else {
 		startKey, endKey, err = rewriteFileKeys(file, rewriteRules)
+		startKey = truncateRowKey(startKey)
+		endKey = truncateRowKey(endKey)
 	}
 	if err != nil {
 		return err

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -103,8 +103,13 @@ func GetSSTMetaFromFile(
 	if bytes.Compare(rangeStart, region.GetStartKey()) < 0 {
 		rangeStart = region.GetStartKey()
 	}
-	suffix := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
-	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), suffix...)
+	rangeEnd := append([]byte{}, regionRule.GetNewKeyPrefix()...)
+	for i := len(rangeEnd)-1; i >= 0; i -- {
+		if rangeEnd[i] != 0xff {
+			rangeEnd[i] += 1
+			break
+		}
+	}
 	// rangeEnd = min(rangeEnd, region.EndKey)
 	if len(region.GetEndKey()) > 0 && bytes.Compare(rangeEnd, region.GetEndKey()) > 0 {
 		rangeEnd = region.GetEndKey()

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -106,7 +106,8 @@ func GetSSTMetaFromFile(
 
 	// Append 10 * 0xff to make sure rangeEnd cover all file key
 	// If choose to regionRule.NewKeyPrefix + 1, it may cause WrongPrefix here
-	// https://github.com/tikv/tikv/blob/970a9bf2a9ea782a455ae579ad237aaf6cb1daec/components/sst_importer/src/sst_importer.rs#L221
+	// https://github.com/tikv/tikv/blob/970a9bf2a9ea782a455ae579ad237aaf6cb1daec/
+	// components/sst_importer/src/sst_importer.rs#L221
 	suffix := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), suffix...)
 	// rangeEnd = min(rangeEnd, region.EndKey)
@@ -114,10 +115,17 @@ func GetSSTMetaFromFile(
 		rangeEnd = region.GetEndKey()
 	}
 
+	if bytes.Compare(rangeStart, rangeEnd) > 0 {
+		log.Fatal("range start exceed range end",
+			zap.Binary("start", rangeStart),
+			zap.Binary("end", rangeEnd))
+	}
+
 	log.Debug("get sstMeta",
 		zap.Stringer("file", file),
 		zap.Binary("rangeStart", rangeStart),
 		zap.Binary("rangeEnd", rangeEnd))
+
 	return import_sstpb.SSTMeta{
 		Uuid:   id,
 		CfName: cfName,

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -103,7 +103,8 @@ func GetSSTMetaFromFile(
 	if bytes.Compare(rangeStart, region.GetStartKey()) < 0 {
 		rangeStart = region.GetStartKey()
 	}
-	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), 0xff)
+	suffix := []byte{0xff, 0xff}
+	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), suffix...)
 	// rangeEnd = min(rangeEnd, region.EndKey)
 	if len(region.GetEndKey()) > 0 && bytes.Compare(rangeEnd, region.GetEndKey()) > 0 {
 		rangeEnd = region.GetEndKey()

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -104,9 +104,9 @@ func GetSSTMetaFromFile(
 		rangeStart = region.GetStartKey()
 	}
 	rangeEnd := append([]byte{}, regionRule.GetNewKeyPrefix()...)
-	for i := len(rangeEnd)-1; i >= 0; i -- {
+	for i := len(rangeEnd) - 1; i >= 0; i-- {
 		if rangeEnd[i] != 0xff {
-			rangeEnd[i] += 1
+			rangeEnd[i] ++
 			break
 		}
 	}

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -103,6 +103,10 @@ func GetSSTMetaFromFile(
 	if bytes.Compare(rangeStart, region.GetStartKey()) < 0 {
 		rangeStart = region.GetStartKey()
 	}
+
+	// Append 10 * 0xff to make sure rangeEnd cover all file key
+	// If choose to regionRule.NewKeyPrefix + 1, it may cause WrongPrefix here
+	// https://github.com/tikv/tikv/blob/master/components/sst_importer/src/sst_importer.rs#L221
 	suffix := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), suffix...)
 	// rangeEnd = min(rangeEnd, region.EndKey)

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -106,7 +106,7 @@ func GetSSTMetaFromFile(
 
 	// Append 10 * 0xff to make sure rangeEnd cover all file key
 	// If choose to regionRule.NewKeyPrefix + 1, it may cause WrongPrefix here
-	// https://github.com/tikv/tikv/blob/master/components/sst_importer/src/sst_importer.rs#L221
+	// https://github.com/tikv/tikv/blob/970a9bf2a9ea782a455ae579ad237aaf6cb1daec/components/sst_importer/src/sst_importer.rs#L221
 	suffix := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), suffix...)
 	// rangeEnd = min(rangeEnd, region.EndKey)
@@ -114,7 +114,7 @@ func GetSSTMetaFromFile(
 		rangeEnd = region.GetEndKey()
 	}
 
-	log.Debug("Get sstMeta",
+	log.Debug("get sstMeta",
 		zap.Stringer("file", file),
 		zap.Binary("rangeStart", rangeStart),
 		zap.Binary("rangeEnd", rangeEnd))

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -103,7 +103,7 @@ func GetSSTMetaFromFile(
 	if bytes.Compare(rangeStart, region.GetStartKey()) < 0 {
 		rangeStart = region.GetStartKey()
 	}
-	suffix := []byte{0xff, 0xff}
+	suffix := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), suffix...)
 	// rangeEnd = min(rangeEnd, region.EndKey)
 	if len(region.GetEndKey()) > 0 && bytes.Compare(rangeEnd, region.GetEndKey()) > 0 {

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -103,13 +103,8 @@ func GetSSTMetaFromFile(
 	if bytes.Compare(rangeStart, region.GetStartKey()) < 0 {
 		rangeStart = region.GetStartKey()
 	}
-	rangeEnd := append([]byte{}, regionRule.GetNewKeyPrefix()...)
-	for i := len(rangeEnd) - 1; i >= 0; i-- {
-		if rangeEnd[i] != 0xff {
-			rangeEnd[i] ++
-			break
-		}
-	}
+	suffix := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), suffix...)
 	// rangeEnd = min(rangeEnd, region.EndKey)
 	if len(region.GetEndKey()) > 0 && bytes.Compare(rangeEnd, region.GetEndKey()) > 0 {
 		rangeEnd = region.GetEndKey()

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -108,6 +108,11 @@ func GetSSTMetaFromFile(
 	if len(region.GetEndKey()) > 0 && bytes.Compare(rangeEnd, region.GetEndKey()) > 0 {
 		rangeEnd = region.GetEndKey()
 	}
+
+	log.Debug("Get sstMeta",
+		zap.Stringer("file", file),
+		zap.Binary("rangeStart", rangeStart),
+		zap.Binary("rangeEnd", rangeEnd))
 	return import_sstpb.SSTMeta{
 		Uuid:   id,
 		CfName: cfName,

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -103,7 +103,7 @@ func GetSSTMetaFromFile(
 	if bytes.Compare(rangeStart, region.GetStartKey()) < 0 {
 		rangeStart = region.GetStartKey()
 	}
-	suffix := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	suffix := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	rangeEnd := append(append([]byte{}, regionRule.GetNewKeyPrefix()...), suffix...)
 	// rangeEnd = min(rangeEnd, region.EndKey)
 	if len(region.GetEndKey()) > 0 && bytes.Compare(rangeEnd, region.GetEndKey()) > 0 {

--- a/pkg/restore/util_test.go
+++ b/pkg/restore/util_test.go
@@ -37,7 +37,7 @@ func (s *testRestoreUtilSuite) TestGetSSTMetaFromFile(c *C) {
 	}
 	sstMeta := restore.GetSSTMetaFromFile([]byte{}, file, region, rule)
 	c.Assert(string(sstMeta.GetRange().GetStart()), Equals, "t2abc")
-	c.Assert(string(sstMeta.GetRange().GetEnd()), Equals, "t2\xff")
+	c.Assert(string(sstMeta.GetRange().GetEnd()), Equals, "t2\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
 }
 
 func (s *testRestoreUtilSuite) TestValidateFileRanges(c *C) {

--- a/pkg/restore/util_test.go
+++ b/pkg/restore/util_test.go
@@ -37,19 +37,7 @@ func (s *testRestoreUtilSuite) TestGetSSTMetaFromFile(c *C) {
 	}
 	sstMeta := restore.GetSSTMetaFromFile([]byte{}, file, region, rule)
 	c.Assert(string(sstMeta.GetRange().GetStart()), Equals, "t2abc")
-	c.Assert(string(sstMeta.GetRange().GetEnd()), Equals, "t3")
-
-	rule = &import_sstpb.RewriteRule{
-		OldKeyPrefix: []byte("t1"),
-		NewKeyPrefix: []byte("t2\xff"),
-	}
-	region = &metapb.Region{
-		StartKey: []byte("t2abc"),
-		EndKey:   []byte("t3a"),
-	}
-	sstMeta = restore.GetSSTMetaFromFile([]byte{}, file, region, rule)
-	c.Assert(string(sstMeta.GetRange().GetStart()), Equals, "t2\xff")
-	c.Assert(string(sstMeta.GetRange().GetEnd()), Equals, "t3a")
+	c.Assert(string(sstMeta.GetRange().GetEnd()), Equals, "t2\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
 }
 
 func (s *testRestoreUtilSuite) TestValidateFileRanges(c *C) {

--- a/pkg/restore/util_test.go
+++ b/pkg/restore/util_test.go
@@ -37,7 +37,19 @@ func (s *testRestoreUtilSuite) TestGetSSTMetaFromFile(c *C) {
 	}
 	sstMeta := restore.GetSSTMetaFromFile([]byte{}, file, region, rule)
 	c.Assert(string(sstMeta.GetRange().GetStart()), Equals, "t2abc")
-	c.Assert(string(sstMeta.GetRange().GetEnd()), Equals, "t2\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
+	c.Assert(string(sstMeta.GetRange().GetEnd()), Equals, "t3")
+
+	rule = &import_sstpb.RewriteRule{
+		OldKeyPrefix: []byte("t1"),
+		NewKeyPrefix: []byte("t2\xff"),
+	}
+	region = &metapb.Region{
+		StartKey: []byte("t2abc"),
+		EndKey:   []byte("t3a"),
+	}
+	sstMeta = restore.GetSSTMetaFromFile([]byte{}, file, region, rule)
+	c.Assert(string(sstMeta.GetRange().GetStart()), Equals, "t2\xff")
+	c.Assert(string(sstMeta.GetRange().GetEnd()), Equals, "t3a")
 }
 
 func (s *testRestoreUtilSuite) TestValidateFileRanges(c *C) {

--- a/tests/br_range/run.sh
+++ b/tests/br_range/run.sh
@@ -22,6 +22,10 @@ run_sql "create table $DB.sbtest(id bigint primary key, c char(120) not null);"
 run_sql "insert into $DB.sbtest values (9223372036854775807, 'test');"
 run_sql "insert into $DB.sbtest values (9187343239835811840, 'test');"
 
+run_sql "create table $DB.sbtest2(id bigint unsigned primary key, c char(120) not null);"
+run_sql "insert into $DB.sbtest2 values (18446744073709551615, 'test');"
+run_sql "insert into $DB.sbtest2 values (9223372036854775808, 'test');"
+
 # backup db
 echo "backup start..."
 run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR

--- a/tests/br_range/run.sh
+++ b/tests/br_range/run.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Copyright 2020 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+DB="$TEST_NAME"
+
+run_sql "create schema $DB;"
+
+run_sql "create table $DB.sbtest(id bigint primary key, c char(120) not null);"
+run_sql "insert into $DB.sbtest values (9223372036854775807, 'test');"
+run_sql "insert into $DB.sbtest values (9187343239835811840, 'test');"
+
+# backup db
+echo "backup start..."
+run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+
+run_sql "drop schema $DB;"
+
+# restore db
+echo "restore start..."
+run_br restore db --db $DB -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+
+run_sql "drop schema $DB;"


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Try fix row data lost.

### What is changed and how it works?
row id bigger than 9151314442816847872 after encoded may exceed than default max range end [`0xff`]( https://github.com/pingcap/br/blob/943e502cc14da6bff81d15b78d2468500526a44b/pkg/restore/util.go#L106), change it `10*[0xff]`
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - manual test


### Release Note

 - Fix the row data lost when row_id bigger than 9151314442816847872


<!-- fill in the release note, or just write "No release note" -->
