### PR TITLE
cherry-pick #327 to 4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,10 @@ testcover: tools failpoint-enable
 		-debug \
 		-- -coverpkg=./... || ( make failpoint-disable && exit 1 )
 
-integration_test: build build_for_integration_test
+integration_test: bins build build_for_integration_test
+	tests/run.sh
+
+bins:
 	@which bin/tidb-server
 	@which bin/tikv-server
 	@which bin/pd-server
@@ -52,7 +55,9 @@ integration_test: build build_for_integration_test
 	@which bin/go-ycsb
 	@which bin/minio
 	@which bin/br
-	tests/run.sh
+	@which bin/tiflash
+	@which bin/libtiflash_proxy.so
+	if [ ! -d bin/flash_cluster_manager ]; then echo "flash_cluster_manager not exist"; exit 1; fi
 
 tools:
 	@echo "install tools..."

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -321,9 +321,13 @@ func (mgr *Mgr) getGrpcConnLocked(ctx context.Context, storeID uint64) (*grpc.Cl
 	keepAliveTimeout := 3
 	bfConf := backoff.DefaultConfig
 	bfConf.MaxDelay = time.Second * 3
+	addr := store.GetPeerAddress()
+	if addr == "" {
+		addr = store.GetAddress()
+	}
 	conn, err := grpc.DialContext(
 		ctx,
-		store.GetAddress(),
+		addr,
 		opt,
 		grpc.WithConnectParams(grpc.ConnectParams{Backoff: bfConf}),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -119,7 +119,11 @@ func (ic *importClient) getImportClient(
 	if ic.tlsConf != nil {
 		opt = grpc.WithTransportCredentials(credentials.NewTLS(ic.tlsConf))
 	}
-	conn, err := grpc.Dial(store.GetAddress(), opt)
+	addr := store.GetPeerAddress()
+	if addr == "" {
+		addr = store.GetAddress()
+	}
+	conn, err := grpc.Dial(addr, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -49,6 +49,7 @@ const (
 	flagRateLimitUnit    = "ratelimit-unit"
 	flagConcurrency      = "concurrency"
 	flagChecksum         = "checksum"
+	flagRemoveTiFlash    = "remove-tiflash"
 	flagCheckRequirement = "check-requirements"
 )
 
@@ -92,6 +93,7 @@ type Config struct {
 	// LogProgress is true means the progress bar is printed to the log instead of stdout.
 	LogProgress bool `json:"log-progress" toml:"log-progress"`
 
+	RemoveTiFlash     bool         `json:"remove-tiflash" toml:"remove-tiflash"`
 	CaseSensitive     bool         `json:"case-sensitive" toml:"case-sensitive"`
 	CheckRequirements bool         `json:"check-requirements" toml:"check-requirements"`
 	Filter            filter.Rules `json:"black-white-list" toml:"black-white-list"`
@@ -108,6 +110,8 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 	flags.Uint64(flagRateLimit, 0, "The rate limit of the task, MB/s per node")
 	flags.Bool(flagChecksum, true, "Run checksum at end of task")
+	flags.Bool(flagRemoveTiFlash, true,
+		"Remove TiFlash replicas before backup or restore, for unsupported versions of TiFlash")
 
 	// Default concurrency is different for backup and restore.
 	// Leave it 0 and let them adjust the value.
@@ -192,6 +196,11 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 		return errors.Trace(err)
 	}
 	cfg.RateLimit = rateLimit * rateLimitUnit
+
+	cfg.RemoveTiFlash, err = flags.GetBool(flagRemoveTiFlash)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	if dbFlag := flags.Lookup(flagDatabase); dbFlag != nil {
 		db := escapeFilterName(dbFlag.Value.String())

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -82,6 +82,10 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	cfg.RemoveTiFlash, err = flags.GetBool(flagRemoveTiFlash)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	err = cfg.Config.ParseFromFlags(flags)
 	if err != nil {
 		return errors.Trace(err)
@@ -194,20 +198,6 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		return nil
 	}
 
-	placementRules, err := client.GetPlacementRules(cfg.PD)
-	if err != nil {
-		return err
-	}
-
-	err = client.RemoveTiFlashReplica(tables, newTables, placementRules)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		_ = client.RecoverTiFlashReplica(tables)
-	}()
-
 	ranges, err := restore.ValidateFileRanges(files, rewriteRules)
 	if err != nil {
 		return err
@@ -254,19 +244,31 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	}
 
 	// Restore sst files in batch.
-	batchSize := int(cfg.Concurrency)
-	if batchSize < defaultRestoreConcurrency {
-		batchSize = defaultRestoreConcurrency
-	}
-	batchSize = utils.MinInt(batchSize, maxRestoreBatchSizeLimit)
+	batchSize := utils.ClampInt(int(cfg.Concurrency), defaultRestoreConcurrency, maxRestoreBatchSizeLimit)
 
-	tiflashStores, err := conn.GetAllTiKVStores(ctx, client.GetPDClient(), conn.TiFlashOnly)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	rejectStoreMap := make(map[uint64]bool)
-	for _, store := range tiflashStores {
-		rejectStoreMap[store.GetId()] = true
+	if cfg.RemoveTiFlash {
+		placementRules, err := client.GetPlacementRules(cfg.PD)
+		if err != nil {
+			return err
+		}
+
+		err = client.RemoveTiFlashReplica(tables, newTables, placementRules)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			_ = client.RecoverTiFlashReplica(tables)
+		}()
+
+		tiflashStores, err := conn.GetAllTiKVStores(ctx, client.GetPDClient(), conn.TiFlashOnly)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		for _, store := range tiflashStores {
+			rejectStoreMap[store.GetId()] = true
+		}
 	}
 
 	for {

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -2,11 +2,38 @@
 
 package utils
 
-// MinInt choice smaller integer from its two arguments.
-func MinInt(x, y int) int {
-	if x < y {
-		return x
+import (
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+)
+
+// MinInt choice smallest integer from its arguments.
+func MinInt(x int, xs ...int) int {
+	min := x
+	for _, n := range xs {
+		if n < min {
+			min = n
+		}
+	}
+	return min
+}
+
+// MaxInt choice biggest integer from its arguments.
+func MaxInt(x int, xs ...int) int {
+	max := x
+	for _, n := range xs {
+		if n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+// ClampInt restrict a value to a certain interval.
+func ClampInt(n, min, max int) int {
+	if min > max {
+		log.Error("clamping integer with min > max", zap.Int("min", min), zap.Int("max", max))
 	}
 
-	return y
+	return MinInt(max, MaxInt(min, n))
 }

--- a/pkg/utils/math_test.go
+++ b/pkg/utils/math_test.go
@@ -13,5 +13,21 @@ var _ = Suite(&testMathSuite{})
 func (*testMathSuite) TestMinInt(c *C) {
 	c.Assert(MinInt(1, 2), Equals, 1)
 	c.Assert(MinInt(2, 1), Equals, 1)
+	c.Assert(MinInt(4, 2, 1, 3), Equals, 1)
 	c.Assert(MinInt(1, 1), Equals, 1)
+}
+
+func (*testMathSuite) TestMaxInt(c *C) {
+	c.Assert(MaxInt(1, 2), Equals, 2)
+	c.Assert(MaxInt(2, 1), Equals, 2)
+	c.Assert(MaxInt(4, 2, 1, 3), Equals, 4)
+	c.Assert(MaxInt(1, 1), Equals, 1)
+}
+
+func (*testMathSuite) TestClampInt(c *C) {
+	c.Assert(ClampInt(100, 1, 3), Equals, 3)
+	c.Assert(ClampInt(2, 1, 3), Equals, 2)
+	c.Assert(ClampInt(0, 1, 3), Equals, 1)
+	c.Assert(ClampInt(0, 1, 1), Equals, 1)
+	c.Assert(ClampInt(100, 1, 1), Equals, 1)
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,15 +5,18 @@ programs.
 
 ## Preparations
 
-1. The following 6 executables must be copied or linked into these locations:
+1. The following 7 executables must be copied or linked into these locations:
     * `bin/tidb-server`
 	* `bin/tikv-server`
 	* `bin/pd-server`
     * `bin/pd-ctl`
 	* `bin/go-ycsb`
 	* `bin/minio`
+    * `bin/tiflash`
 
     The versions must be ≥2.1.0 as usual.
+
+    What's more, there must be dynamic link library for TiFlash, see make target `bin` to learn more. You can install most of dependencies by running `download_tools.sh`.
 
 2. The following programs must be installed:
 
@@ -31,7 +34,7 @@ Make sure the path is `br/`
 Run `make integration_test` to execute the integration tests. This command will
 
 1. Build `br`
-2. Check that all 6 required executables and `br` executable exist
+2. Check that all 7 required executables and `br` executable exist
 3. Execute `tests/run.sh`
 
 If the first two steps are done before, you could also run `tests/run.sh` directly.

--- a/tests/_utils/make_tiflash_config
+++ b/tests/_utils/make_tiflash_config
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+cat > tests/config/tiflash-learner.toml <<eof
+[rocksdb]
+wal-dir = ""
+
+[security]
+ca-path = ""
+cert-path = ""
+key-path = ""
+
+[server]
+addr = "0.0.0.0:20170"
+advertise-addr = "127.0.0.1:20170"
+engine-addr = "127.0.0.1:3930"
+status-addr = "$TIFLASH_STATUS"
+
+[storage]
+data-dir = "$TEST_DIR/tiflash/data"
+eof
+
+cat > tests/config/tiflash.toml <<eof
+default_profile = "default"
+display_name = "TiFlash"
+http_port = 8125
+listen_host = "0.0.0.0"
+mark_cache_size = 5368709120
+path = "$TEST_DIR/tiflash/data"
+tcp_port = 9002
+tmp_path = "/tmp/tiflash"
+
+[application]
+runAsDaemon = true
+
+[flash]
+service_addr = "127.0.0.1:3930"
+tidb_status_addr = "127.0.0.1:10080"
+
+[flash.proxy]
+config = "$PWD/tests/config/tiflash-learner.toml"
+log-file = "$TEST_DIR/tiflash-proxy.log"
+
+[flash.flash_cluster]
+cluster_manager_path = "$PWD/bin/flash_cluster_manager"
+log = "$TEST_DIR/tiflash-manager.log"
+master_ttl = 60
+refresh_interval = 20
+update_rule_interval = 5
+
+[logger]
+count = 20
+level = "trace"
+log = "$TEST_DIR/tiflash-stdout.log"
+errorlog = "$TEST_DIR/tiflash-stderr.log"
+size = "1000M"
+
+[raft]
+pd_addr = "127.0.0.1:2379"
+
+[profiles]
+[profiles.default]
+load_balancing = "random"
+max_memory_usage = 10000000000
+use_uncompressed_cache = 0
+
+[users]
+[users.default]
+password = ""
+profile = "default"
+quota = "default"
+[users.default.networks]
+ip = "::/0"
+[users.readonly]
+password = ""
+profile = "readonly"
+quota = "default"
+[users.readonly.networks]
+ip = "::/0"
+
+[quotas]
+[quotas.default]
+[quotas.default.interval]
+duration = 3600
+errors = 0
+execution_time = 0
+queries = 0
+read_rows = 0
+result_rows = 0
+eof

--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -25,28 +25,39 @@ TIDB_STATUS_ADDR="127.0.0.1:10080"
 # actaul tikv_addr are TIKV_ADDR${i}
 TIKV_ADDR="127.0.0.1:2016"
 TIKV_STATUS_ADDR="127.0.0.1:2018"
-TIKV_COUNT=4
+TIKV_COUNT=3
+TIFLASH_STATUS="127.0.0.1:17000"
 
 stop_services() {
     killall -9 tikv-server || true
     killall -9 pd-server || true
     killall -9 tidb-server || true
+    killall -9 tiflash || true
 
     find "$TEST_DIR" -maxdepth 1 -not -path "$TEST_DIR" -not -name "*.log" | xargs rm -r || true
 }
 
+
 start_services() {
     stop_services
+    source tests/_utils/make_tiflash_config
 
     TIDB_CONFIG="${1-tests}/config/tidb.toml"
     TIKV_CONFIG="${1-tests}/config/tikv.toml"
+    PD_CONFIG="${1-tests}/config/pd.toml"
+    TIFLASH_CONFIG="${1-tests}/config/tiflash.toml"
+
+    if [ ! -e $PD_CONFIG ]; then PD_CONFIG=tests/config/pd.toml; fi
+    if [ ! -e $TIFLASH_CONFIG ]; then TIFLASH_CONFIG=tests/config/tiflash.toml; fi
+
 
     echo "Starting PD..."
     mkdir -p "$TEST_DIR/pd"
     bin/pd-server \
         --client-urls "http://$PD_ADDR" \
         --log-file "$TEST_DIR/pd.log" \
-        --data-dir "$TEST_DIR/pd" &
+        --data-dir "$TEST_DIR/pd" \
+        --config $PD_CONFIG &
     # wait until PD is online...
     i=0
     while ! curl -o /dev/null -sf "http://$PD_ADDR/pd/api/v1/version"; do
@@ -100,6 +111,10 @@ start_services() {
         sleep 3
     done
 
+    if [[ ! $@ =~ "--no-tiflash" ]]; then
+        start_tiflash
+    fi
+
     i=0
     while ! curl "http://$PD_ADDR/pd/api/v1/cluster/status" -sf | grep -q "\"is_initialized\": true"; do
         i=$((i+1))
@@ -107,6 +122,23 @@ start_services() {
             echo 'Failed to bootstrap cluster'
             exit 1
         fi
+        sleep 3
+    done
+}
+
+start_tiflash() {
+    echo "Starting TiFlash..."
+    LD_LIBRARY_PATH=bin/ bin/tiflash server --config-file=$TIFLASH_CONFIG &
+    echo "TiFlash started..."
+
+    i=0
+    while ! curl -sf http://$TIFLASH_STATUS/metrics 1>/dev/null 2>&1; do
+        i=$((i+1))
+        if [ "$i" -gt 20 ]; then
+            echo "failed to start tiflash"
+            exit 1
+        fi
+        echo "TiFlash seems doesn't started, retrying..."
         sleep 3
     done
 }

--- a/tests/br_rawkv/run.sh
+++ b/tests/br_rawkv/run.sh
@@ -15,6 +15,10 @@
 
 set -eu
 
+# restart service without tiflash
+source $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../_utils/run_services
+start_services "tests" --no-tiflash
+
 BACKUP_DIR="raw_backup"
 
 checksum() {

--- a/tests/br_tiflash/run.sh
+++ b/tests/br_tiflash/run.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+# Copyright 2020 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+DB="${TEST_NAME}_DATABASE"
+RECORD_COUNT=1000
+
+
+run_sql "CREATE DATABASE $DB" 
+
+run_sql "CREATE TABLE $DB.kv(k varchar(256) primary key, v int)" 
+run_sql "ALTER TABLE $DB.kv SET TIFLASH REPLICA 1" 
+
+stmt="INSERT INTO $DB.kv(k, v) VALUES ('1-record', 1)"
+for i in $(seq 2 $RECORD_COUNT); do
+    stmt="$stmt,('$i-record', $i)"
+done
+run_sql "$stmt"
+
+i=0
+while ! [ $(run_sql "select * from information_schema.tiflash_replica" | grep "PROGRESS" | sed "s/[^0-9]//g") -eq 1 ]; do
+    i=$(( i + 1 ))
+    echo "Waiting for TiFlash synchronizing [$i]."
+    if [ $i -gt 20 ]; then
+        echo "Failed to sync data to tiflash."
+        exit 1
+    fi
+    sleep 5
+done
+
+rm -rf "/${TEST_DIR}/$DB"
+run_br backup full -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+
+run_sql "DROP DATABASE $DB"
+run_br restore full -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+
+AFTER_BR_COUNT=`run_sql "SELECT count(*) FROM $DB.kv;" | sed -n "s/[^0-9]//g;/^[0-9]*$/p" | tail -n1`
+if [ $AFTER_BR_COUNT -ne $RECORD_COUNT ]; then
+    echo "failed to restore, before: $RECORD_COUNT; after: $AFTER_BR_COUNT"
+    exit 1
+fi
+
+# backup again, but don't remove tiflash replicas.
+run_br backup full -s "local://$TEST_DIR/$DB/with-tiflash" --pd $PD_ADDR --remove-tiflash=false
+run_sql "DROP DATABASE $DB"
+run_br restore full -s "local://$TEST_DIR/$DB/with-tiflash" --pd $PD_ADDR --remove-tiflash=false
+
+AFTER_BR_COUNT=`run_sql "SELECT count(*) FROM $DB.kv;" | sed -n "s/[^0-9]//g;/^[0-9]*$/p" | tail -n1`
+if [ $AFTER_BR_COUNT -ne $RECORD_COUNT ]; then
+    echo "failed to restore, before: $RECORD_COUNT; after: $AFTER_BR_COUNT"
+    exit 1
+fi
+
+echo "TEST $TEST_NAME passed!"

--- a/tests/config/pd.toml
+++ b/tests/config/pd.toml
@@ -1,0 +1,5 @@
+lease = 360
+tso-save-interval = "360s"
+
+[replication]
+enable-placement-rules = true

--- a/tests/download_tools.sh
+++ b/tests/download_tools.sh
@@ -31,6 +31,18 @@ for COMPONENT in tidb-server pd-server tikv-server pd-ctl; do
     fi
 done
 
+if [ ! -e "$BIN/tiflash" ]; then
+    echo "Downloading nightly Tiflash..."
+    curl -L -f -o "$BIN/tiflash.tar.gz" "https://download.pingcap.org/tiflash-nightly-linux-amd64.tar.gz"
+    tar -xf "$BIN/tiflash.tar.gz" -C "$BIN/"
+    rm "$BIN/tiflash.tar.gz"
+    mkdir "$BIN"/flash_cluster_manager
+    mv "$BIN"/tiflash-nightly-linux-amd64/flash_cluster_manager/* "$BIN/flash_cluster_manager"
+    rmdir "$BIN/"tiflash-nightly-linux-amd64/flash_cluster_manager
+    mv "$BIN"/tiflash-nightly-linux-amd64/* "$BIN/"
+    rmdir "$BIN/"tiflash-nightly-linux-amd64
+fi
+
 if [ -n "$MISSING_TIDB_COMPONENTS" ]; then
     echo "Downloading latest TiDB bundle..."
     curl -L -f -o "$BIN/tidb.tar.gz" "https://download.pingcap.org/tidb-nightly-linux-amd64.tar.gz"


### PR DESCRIPTION
cherry-pick #327 to 4.0(manually)

--- 

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently, we have no test cases with TiFlash, this PR add TiFlash to test cluster.

And, at post, we should remove all TiFlash replicas so that we backup or restore successfully without failed by 'RPC unimplemented', this PR also add a flag to disable this function, for farther test usage.  

### What is changed and how it works?
I replace `store.GetAddr()` to `store.GetPeerAddr() || store.GetAddr()`, because TiFlash use a 'proxy' to act like a TiKV, its 'address' is more like a 'service' address but a 'peer' address. Hence, we should try get `PeerAddr` firstly, and normal TiKV has no `PeerAddr`, so we use `Addr` as a fallback.

And I added a one-node TiFlash to the integration test cluster.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 + Manual test (add detailed scripts or steps below)
    - Start a cluster with TiFlash(`tiup playground --tiflash 1`)
    - Run br without removing TiFlash replicas.
    - Restore success.

### Release Note

 - Fix a bug that might cause BR fail when operating with clusters with TiFlash

<!-- fill in the release note, or just write "No release note" -->
