### PR TITLE
utils: fix excessive refresh frequency when BR_LOG_TO_TERM=1

### DIFF
--- a/pkg/utils/progress_test.go
+++ b/pkg/utils/progress_test.go
@@ -33,13 +33,13 @@ func (r *testProgressSuite) TestProgress(c *C) {
 	updateCh2 := progress2.UpdateCh()
 	updateCh2 <- struct{}{}
 	p = <-pCh2
-	c.Assert(p, Matches, ".*50.*")
+	c.Assert(p, Matches, `.*"P":"50\.00%".*`)
 	updateCh2 <- struct{}{}
 	p = <-pCh2
-	c.Assert(p, Matches, ".*100.*")
+	c.Assert(p, Matches, `.*"P":"100\.00%".*`)
 	updateCh2 <- struct{}{}
 	p = <-pCh2
-	c.Assert(p, Matches, ".*100.*")
+	c.Assert(p, Matches, `.*"P":"100\.00%".*`)
 
 	pCh4 := make(chan string, 4)
 	progress4 := NewProgressPrinter("test", 4, false)
@@ -49,11 +49,11 @@ func (r *testProgressSuite) TestProgress(c *C) {
 	updateCh4 := progress4.UpdateCh()
 	updateCh4 <- struct{}{}
 	p = <-pCh4
-	c.Assert(p, Matches, ".*25.*")
+	c.Assert(p, Matches, `.*"P":"25\.00%".*`)
 	updateCh4 <- struct{}{}
 	close(updateCh4)
 	p = <-pCh4
-	c.Assert(p, Matches, ".*100.*")
+	c.Assert(p, Matches, `.*"P":"100\.00%".*`)
 
 	pCh8 := make(chan string, 8)
 	progress8 := NewProgressPrinter("test", 8, false)
@@ -65,10 +65,10 @@ func (r *testProgressSuite) TestProgress(c *C) {
 	updateCh8 <- struct{}{}
 	<-pCh8
 	p = <-pCh8
-	c.Assert(p, Matches, ".*25.*")
+	c.Assert(p, Matches, `.*"P":"25\.00%".*`)
 
 	// Cancel should stop progress at the current position.
 	cancel()
 	p = <-pCh8
-	c.Assert(p, Matches, ".*25.*")
+	c.Assert(p, Matches, `.*"P":"25\.00%".*`)
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix item 5 of #259.

### What is changed and how it works?

1. Do not start the progress bar before it was fully configured (so that the refresh rate can really be respected).
2. Further increased the refresh rate when BR_LOG_TO_TERM=1 from 10s to 2m.
3. Included more progress information into the log when BR_LOG_TO_TERM=1:

```
[2020/06/04 20:01:14.965 +00:00] [INFO] [progress.go:113] [progress] [step="Full restore"] [progress=29.18%] [count="700 / 2399"] [speed="11 p/s"] [elapsed=48s] [remaining=2m34s]
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
    * Execute BR manually with BR_LOG_TO_TERM=1 and inspect the output.

Code changes

Side effects

Related changes

### Release Note

 - Reduced the excessive refresh rate of progress logs when logging to terminal (e.g. when using K8s).

<!-- fill in the release note, or just write "No release note" -->
