### PR TITLE
restore: replace ErrGRPC by recognizing raw gRPC errors

### DIFF
--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -387,7 +387,7 @@ func (importer *FileImporter) downloadSST(
 	for _, peer := range regionInfo.Region.GetPeers() {
 		resp, err = importer.importClient.DownloadSST(importer.ctx, peer.GetStoreId(), req)
 		if err != nil {
-			return nil, errors.Annotatef(ErrGRPC, "%s", err)
+			return nil, errors.Trace(err)
 		}
 		if resp.GetError() != nil {
 			return nil, errors.Annotate(ErrDownloadFailed, resp.GetError().GetMessage())
@@ -439,7 +439,7 @@ func (importer *FileImporter) downloadRawKVSST(
 	for _, peer := range regionInfo.Region.GetPeers() {
 		resp, err = importer.importClient.DownloadSST(importer.ctx, peer.GetStoreId(), req)
 		if err != nil {
-			return nil, errors.Annotatef(ErrGRPC, "%s", err)
+			return nil, errors.Trace(err)
 		}
 		if resp.GetError() != nil {
 			return nil, errors.Annotate(ErrDownloadFailed, resp.GetError().GetMessage())


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #333.

### What is changed and how it works?

The gRPC error from `Ingest` is returned raw. The raw gRPC error is not recognized by `utils.WithRetry`, so any gRPC error from ingest will fail immediately.

This PR:

1. Gets rid of the `ErrGRPC` error, and instead just use `status.Codes` to check if the error is really a gRPC error. Thus gRPC errors from IngestSST would also be covered.
2. Restricts the retryable gRPC errors to only "Aborted" and "Unavailable", as described in https://pkg.go.dev/google.golang.org/grpc/codes?tab=doc#Code. Thus legit "Unknown" error wouldn't be retried.

(Potential problem: currently the entire import process would restart from scratch, rather than just the IngestSST RPC.)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
    * (DBaaS is going to re-test using this PR)

Code changes

Side effects

Related changes

### Release Note

 - Improved robustness: spurious network failure during ingestion would now be retried.

<!-- fill in the release note, or just write "No release note" -->
