### PR TITLE
restore: remove auto_random option

### DIFF
--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -593,8 +593,6 @@ func enableTiDBConfig() {
 	// and we can handle alter drop pk/add pk DDLs with no impact
 	conf.AlterPrimaryKey = true
 
-	// set this to true for some auto random DDL execute normally during incremental restore
-	conf.Experimental.AllowAutoRandom = true
 	conf.Experimental.AllowsExpressionIndex = true
 
 	config.StoreGlobalConfig(conf)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
See pingcap/tidb#17882.
Related TiDB PR: pingcap/tidb#16596.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - The column attribute `auto_random` gets stable and it can be used without the config option `allow-auto-random`.

<!-- fill in the release note, or just write "No release note" -->
