### PR TITLE
br: add lock file

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -122,6 +122,11 @@ func (bc *Client) GetTS(ctx context.Context, duration time.Duration, ts uint64) 
 	return backupTS, nil
 }
 
+// SetLockFile set write lock file.
+func (bc *Client) SetLockFile(ctx context.Context) error {
+	return bc.storage.Write(ctx, utils.LockFile, []byte{})
+}
+
 // SetGCTTL set gcTTL for client.
 func (bc *Client) SetGCTTL(ttl int64) {
 	bc.gcTTL = ttl
@@ -146,6 +151,13 @@ func (bc *Client) SetStorage(ctx context.Context, backend *kvproto.StorageBacken
 	}
 	if exist {
 		return errors.New("backup meta exists, may be some backup files in the path already")
+	}
+	exist, err = bc.storage.FileExists(ctx, utils.LockFile)
+	if err != nil {
+		return errors.Annotatef(err, "error occurred when checking %s file", utils.LockFile)
+	}
+	if exist {
+		return errors.New("backup lock exists, may be some backup files in the path already")
 	}
 	bc.backend = backend
 	return nil

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -124,7 +124,9 @@ func (bc *Client) GetTS(ctx context.Context, duration time.Duration, ts uint64) 
 
 // SetLockFile set write lock file.
 func (bc *Client) SetLockFile(ctx context.Context) error {
-	return bc.storage.Write(ctx, utils.LockFile, []byte{})
+	return bc.storage.Write(ctx, utils.LockFile,
+		[]byte("DO NOT DELETE\n"+
+			"This file exists to remind other backup jobs won't use this path"))
 }
 
 // SetGCTTL set gcTTL for client.

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -121,6 +121,10 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err = client.SetStorage(ctx, u, cfg.SendCreds); err != nil {
 		return err
 	}
+	err = client.SetLockFile(ctx)
+	if err != nil {
+		return err
+	}
 	client.SetGCTTL(cfg.GCTTL)
 
 	backupTS, err := client.GetTS(ctx, cfg.TimeAgo, cfg.BackupTS)

--- a/pkg/utils/schema.go
+++ b/pkg/utils/schema.go
@@ -14,6 +14,8 @@ import (
 )
 
 const (
+	// LockFile represents file name,
+	LockFile = "backup.lock"
 	// MetaFile represents file name
 	MetaFile = "backupmeta"
 	// MetaJSONFile represents backup meta json file name

--- a/tests/br_other/run.sh
+++ b/tests/br_other/run.sh
@@ -20,13 +20,13 @@ run_sql "CREATE DATABASE $DB;"
 
 run_sql "CREATE TABLE $DB.usertable1 ( \
   YCSB_KEY varchar(64) NOT NULL, \
-  FIELD0 varchar(1) DEFAULT NULL, \
+  FIELD0 varchar(10) DEFAULT NULL, \
   PRIMARY KEY (YCSB_KEY) \
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;"
 
 for i in `seq 1 100`
 do
-run_sql "INSERT INTO $DB.usertable1 VALUES (\"a$i\", \"b\");"
+run_sql "INSERT INTO $DB.usertable1 VALUES (\"a$i\", \"bbbbbbbbbb\");"
 done
 
 # backup full


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/br/issues/328
Add a lock file at beginning, to make sure other backup task won't be able to start backup.

### What is changed and how it works?
Add a lock file when storage created.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release Note

 - Fix the issue that fast fail when multiple backup task start backup on same path.

<!-- fill in the release note, or just write "No release note" -->
