### PR TITLE
glue,task: let the tasks inform the glue about the BackupTS and Size.…

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -859,6 +859,11 @@ func (bc *Client) ChecksumMatches(local []Checksum) (bool, error) {
 	return true, nil
 }
 
+// ArchiveSize returns the total size of the archive (before encryption).
+func (bc *Client) ArchiveSize() uint64 {
+	return utils.ArchiveSize(&bc.backupMeta)
+}
+
 // CollectFileInfo collects ungrouped file summary information, like kv count and size.
 func (bc *Client) CollectFileInfo() {
 	for _, file := range bc.backupMeta.Files {

--- a/pkg/glue/glue.go
+++ b/pkg/glue/glue.go
@@ -22,6 +22,9 @@ type Glue interface {
 	OwnsStorage() bool
 
 	StartProgress(ctx context.Context, cmdName string, total int64, redirectLog bool) Progress
+
+	// Record records some information useful for log-less summary.
+	Record(name string, value uint64)
 }
 
 // Session is an abstraction of the session.Session interface.

--- a/pkg/gluetidb/glue.go
+++ b/pkg/gluetidb/glue.go
@@ -55,7 +55,11 @@ func (g Glue) StartProgress(ctx context.Context, cmdName string, total int64, re
 	return g.tikvGlue.StartProgress(ctx, cmdName, total, redirectLog)
 }
 
-// Execute implements glue.Session.
+// Record implements glue.Glue.
+func (g Glue) Record(name string, value uint64) {
+	g.tikvGlue.Record(name, value)
+}
+
 func (gs *tidbSession) Execute(ctx context.Context, sql string) error {
 	_, err := gs.se.Execute(ctx, sql)
 	return err

--- a/pkg/gluetikv/glue.go
+++ b/pkg/gluetikv/glue.go
@@ -50,6 +50,9 @@ func (Glue) StartProgress(ctx context.Context, cmdName string, total int64, redi
 	return progress{ch: utils.StartProgress(ctx, cmdName, total, redirectLog)}
 }
 
+// Record implements glue.Glue.
+func (Glue) Record(string, uint64) {}
+
 type progress struct {
 	ch chan<- struct{}
 }

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -140,6 +140,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err != nil {
 		return err
 	}
+	g.Record("BackupTS", backupTS)
 
 	ranges, backupSchemas, err := backup.BuildBackupRangeAndSchema(
 		mgr.GetDomain(), mgr.GetTiKV(), tableFilter, backupTS)
@@ -231,6 +232,8 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err != nil {
 		return err
 	}
+
+	g.Record("Size", client.ArchiveSize())
 
 	// Set task summary to success status.
 	summary.SetSuccessStatus(true)

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -142,6 +142,8 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 		return err
 	}
 
+	g.Record("Size", client.ArchiveSize())
+
 	// Set task summary to success status.
 	summary.SetSuccessStatus(true)
 	return nil

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -140,6 +140,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	if err != nil {
 		return err
 	}
+	g.Record("Size", utils.ArchiveSize(backupMeta))
 	if err = client.InitBackupMeta(backupMeta, u); err != nil {
 		return err
 	}

--- a/pkg/task/restore_raw.go
+++ b/pkg/task/restore_raw.go
@@ -72,6 +72,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	if err != nil {
 		return err
 	}
+	g.Record("Size", utils.ArchiveSize(backupMeta))
 	if err = client.InitBackupMeta(backupMeta, u); err != nil {
 		return err
 	}

--- a/pkg/utils/schema.go
+++ b/pkg/utils/schema.go
@@ -116,6 +116,15 @@ func LoadBackupTables(meta *backup.BackupMeta) (map[string]*Database, error) {
 	return databases, nil
 }
 
+// ArchiveSize returns the total size of the backup archive.
+func ArchiveSize(meta *backup.BackupMeta) uint64 {
+	total := uint64(meta.Size())
+	for _, file := range meta.Files {
+		total += file.Size_
+	}
+	return total
+}
+
 // EncloseName formats name in sql.
 func EncloseName(name string) string {
 	return "`" + strings.ReplaceAll(name, "`", "``") + "`"


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Added some methods to the glue for recording the total backup size and BackupTS for the summary in TiDB.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * Verified with computation result from TiDB.

Code changes

 - Has interface methods change
    * New method in Glue.


### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->