### PR TITLE
main: log the received OS signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/br/cmd"
 )
@@ -27,6 +29,7 @@ func main() {
 	go func() {
 		sig := <-sc
 		fmt.Printf("\nGot signal [%v] to exit.\n", sig)
+		log.Warn("received signal to exit", zap.Stringer("signal", sig))
 		switch sig {
 		case syscall.SIGTERM:
 			cancel()


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently when we received an OS signal (e.g. SIGHUP), it is only printed to stdout, which is usually not saved.

### What is changed and how it works?

Write the message to log in additional to stdout.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * run BR and press Ctrl+C, check that a warning is present in the log.

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
