### PR TITLE
ignore exists table when restore tables

### DIFF
--- a/pkg/gluetikv/glue.go
+++ b/pkg/gluetikv/glue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv"
 
 	"github.com/pingcap/br/pkg/glue"
+	"github.com/pingcap/br/pkg/summary"
 	"github.com/pingcap/br/pkg/utils"
 )
 
@@ -51,7 +52,9 @@ func (Glue) StartProgress(ctx context.Context, cmdName string, total int64, redi
 }
 
 // Record implements glue.Glue.
-func (Glue) Record(string, uint64) {}
+func (Glue) Record(name string, val uint64) {
+	summary.CollectUint(name, val)
+}
 
 type progress struct {
 	ch chan<- struct{}

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -29,6 +29,11 @@ func CollectInt(name string, t int) {
 	collector.CollectInt(name, t)
 }
 
+// CollectUint collects log uint64 field.
+func CollectUint(name string, t uint64) {
+	collector.CollectUInt(name, t)
+}
+
 // SetSuccessStatus sets final success status.
 func SetSuccessStatus(success bool) {
 	collector.SetSuccessStatus(success)

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -137,10 +137,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	}
 	g.Record("BackupTS", backupTS)
 
-	isIncrementalBackup := false
-	if cfg.LastBackupTS > 0 {
-		isIncrementalBackup = true
-	}
+	isIncrementalBackup := cfg.LastBackupTS > 0
 
 	ranges, backupSchemas, err := backup.BuildBackupRangeAndSchema(
 		mgr.GetDomain(), mgr.GetTiKV(), cfg.TableFilter, backupTS)

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -137,6 +137,11 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	}
 	g.Record("BackupTS", backupTS)
 
+	isIncrementalBackup := false
+	if cfg.LastBackupTS > 0 {
+		isIncrementalBackup = true
+	}
+
 	ranges, backupSchemas, err := backup.BuildBackupRangeAndSchema(
 		mgr.GetDomain(), mgr.GetTiKV(), cfg.TableFilter, backupTS)
 	if err != nil {
@@ -148,7 +153,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	}
 
 	ddlJobs := make([]*model.Job, 0)
-	if cfg.LastBackupTS > 0 {
+	if isIncrementalBackup {
 		if backupTS <= cfg.LastBackupTS {
 			log.Error("LastBackupTS is larger or equal to current TS")
 			return errors.New("LastBackupTS is larger or equal to current TS")
@@ -197,7 +202,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	updateCh.Close()
 
 	// Checksum from server, and then fulfill the backup metadata.
-	if cfg.Checksum {
+	if cfg.Checksum && !isIncrementalBackup {
 		backupSchemasConcurrency := utils.MinInt(backup.DefaultSchemaConcurrency, backupSchemas.Len())
 		updateCh = g.StartProgress(
 			ctx, "Checksum", int64(backupSchemas.Len()), !cfg.LogProgress)
@@ -210,17 +215,26 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		// Checksum has finished
 		updateCh.Close()
 		// collect file information.
-		err = checkChecksums(client, cfg)
+		err = checkChecksums(client)
 		if err != nil {
 			return err
 		}
 	} else {
-		// When user specified not to calculate checksum, don't calculate checksum.
 		// Just... copy schemas from origin.
-		log.Info("Skip fast checksum because user requirement.")
 		client.CopyMetaFrom(backupSchemas)
 		// Anyway, let's collect file info for summary.
 		client.CollectFileInfo()
+		if isIncrementalBackup {
+			// Since we don't support checksum for incremental data, fast checksum should be skipped.
+			log.Info("Skip fast checksum in incremental backup")
+			err = client.FilterSchema()
+			if err != nil {
+				return err
+			}
+		} else {
+			// When user specified not to calculate checksum, don't calculate checksum.
+			log.Info("Skip fast checksum because user requirement.")
+		}
 	}
 
 	err = client.SaveBackupMeta(ctx, ddlJobs)
@@ -237,25 +251,20 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 
 // checkChecksums checks the checksum of the client, once failed,
 // returning a error with message: "mismatched checksum".
-func checkChecksums(client *backup.Client, cfg *BackupConfig) error {
+func checkChecksums(client *backup.Client) error {
 	checksums, err := client.CollectChecksums()
 	if err != nil {
 		return err
 	}
-	if cfg.LastBackupTS == 0 {
-		var matches bool
-		matches, err = client.ChecksumMatches(checksums)
-		if err != nil {
-			return err
-		}
-		if !matches {
-			log.Error("backup FastChecksum mismatch!")
-			return errors.New("mismatched checksum")
-		}
-		return nil
+	var matches bool
+	matches, err = client.ChecksumMatches(checksums)
+	if err != nil {
+		return err
 	}
-	// Since we don't support checksum for incremental data, fast checksum should be skipped.
-	log.Info("Skip fast checksum in incremental backup")
+	if !matches {
+		log.Error("backup FastChecksum mismatch!")
+		return errors.New("mismatched checksum")
+	}
 	return nil
 }
 

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/backup"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/domain"
 	"github.com/spf13/pflag"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -179,6 +180,9 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		return nil
 	}
 
+	dom := mgr.GetDomain()
+	dbs, tables = filterExistsSchema(dom, dbs, tables)
+
 	for _, db := range dbs {
 		err = client.CreateDatabase(db.Info)
 		if err != nil {
@@ -188,7 +192,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 
 	// We make bigger errCh so we won't block on multi-part failed.
 	errCh := make(chan error, 32)
-	tableStream := client.GoCreateTables(ctx, mgr.GetDomain(), tables, newTS, errCh)
+	tableStream := client.GoCreateTables(ctx, dom, tables, newTS, errCh)
 	if len(files) == 0 {
 		log.Info("no files, empty databases and tables are restored")
 		summary.SetSuccessStatus(true)
@@ -598,4 +602,38 @@ func restoreTableStream(
 			batcher.Add(t)
 		}
 	}
+}
+
+func filterExistsSchema(
+	dom *domain.Domain,
+	dbs []*utils.Database,
+	tables []*utils.Table) (
+	[]*utils.Database, []*utils.Table) {
+	infoSchema := dom.InfoSchema()
+
+	existsDBs := make([]string, 0, len(dbs))
+	nonExistsDBs := make([]*utils.Database, 0, len(dbs))
+	for _, db := range dbs {
+		if ok := infoSchema.SchemaExists(db.Info.Name); !ok {
+			nonExistsDBs = append(nonExistsDBs, db)
+		} else {
+			existsDBs = append(existsDBs, db.Info.Name.String())
+		}
+	}
+
+	existsTables := make([]string, 0, len(dbs))
+	nonExistsTables := make([]*utils.Table, 0, len(tables))
+	for _, table := range tables {
+		if ok := infoSchema.TableExists(table.Db.Name, table.Info.Name); !ok {
+			nonExistsTables = append(nonExistsTables, table)
+		} else {
+			existsTables = append(existsTables, table.Info.Name.String())
+		}
+	}
+	log.Info("detective exists schemas to skip",
+		zap.Strings("db", existsDBs),
+		zap.Strings("table", existsTables),
+	)
+
+	return nonExistsDBs, nonExistsTables
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. Resolve #365 

### What is changed and how it works?
1. use `dom.InfoSchema()` to check whether db and tables already exists in target cluster. to skip execute unnecessary DDL.
2. record `backupts` in summary log to enhance usability.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

From below log, we can tell the increment restore will skip 
1. exists databases and tables created by full restore.
2. record DDL job during increment backup.
```
[client.go:538] ["execute ddl query"] [db=test] [query="create table t2(id int)"] [historySchemaVersion=102]
[restore.go:633] ["detective exists schemas to skip"] [db="[test]"] [table="[t,t2,warehouse,district,new_order,item,history,orders,customer,stock,order_line]"]
```

Code changes

 - Has interface methods change


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Speed up schema prepare during incremental restore.

<!-- fill in the release note, or just write "No release note" -->
