### PR TITLE
ignore exists table when restore tables (#384)

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -145,6 +145,7 @@ func (bc *Client) SaveBackupMeta(ctx context.Context, ddlJobs []*model.Job) erro
 	if err != nil {
 		return errors.Trace(err)
 	}
+
 	bc.backupMeta.Ddls = ddlJobsData
 	backupMetaData, err := proto.Marshal(&bc.backupMeta)
 	if err != nil {
@@ -889,4 +890,33 @@ func (bc *Client) CopyMetaFrom(backupSchemas *Schemas) {
 		schemas = append(schemas, &schema)
 	}
 	bc.backupMeta.Schemas = schemas
+}
+
+// FilterSchema filter schema that doesn't have backup files
+// this is useful during incremental backup, no files in backup means no files to restore
+// so we can skip some DDL in restore to speed up restoration.
+func (bc *Client) FilterSchema() error {
+	dbs, err := utils.LoadBackupTables(&bc.backupMeta)
+	if err != nil {
+		return err
+	}
+	schemas := make([]*kvproto.Schema, 0, len(bc.backupMeta.Schemas))
+	for _, schema := range bc.backupMeta.Schemas {
+		dbInfo := &model.DBInfo{}
+		err := json.Unmarshal(schema.Db, dbInfo)
+		if err != nil {
+			return err
+		}
+		tblInfo := &model.TableInfo{}
+		err = json.Unmarshal(schema.Table, tblInfo)
+		if err != nil {
+			return err
+		}
+		tbl := dbs[dbInfo.Name.String()].GetTable(tblInfo.Name.String())
+		if len(tbl.Files) > 0 {
+			schemas = append(schemas, schema)
+		}
+	}
+	bc.backupMeta.Schemas = schemas
+	return nil
 }

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -29,7 +29,12 @@ func CollectInt(name string, t int) {
 	collector.CollectInt(name, t)
 }
 
-// SetSuccessStatus sets final success status
+// CollectUint collects log uint64 field.
+func CollectUint(name string, t uint64) {
+	collector.CollectUInt(name, t)
+}
+
+// SetSuccessStatus sets final success status.
 func SetSuccessStatus(success bool) {
 	collector.SetSuccessStatus(success)
 }

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -126,6 +126,8 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err != nil {
 		return err
 	}
+	summary.CollectUint("backup ts", backupTS)
+	isIncrementalBackup := cfg.LastBackupTS > 0
 
 	ranges, backupSchemas, err := backup.BuildBackupRangeAndSchema(
 		mgr.GetDomain(), mgr.GetTiKV(), tableFilter, backupTS)
@@ -138,7 +140,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	}
 
 	ddlJobs := make([]*model.Job, 0)
-	if cfg.LastBackupTS > 0 {
+	if isIncrementalBackup {
 		if backupTS <= cfg.LastBackupTS {
 			log.Error("LastBackupTS is larger or equal to current TS")
 			return errors.New("LastBackupTS is larger or equal to current TS")
@@ -187,7 +189,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	updateCh.Close()
 
 	// Checksum from server, and then fulfill the backup metadata.
-	if cfg.Checksum {
+	if cfg.Checksum && !isIncrementalBackup {
 		backupSchemasConcurrency := utils.MinInt(backup.DefaultSchemaConcurrency, backupSchemas.Len())
 		updateCh = g.StartProgress(
 			ctx, "Checksum", int64(backupSchemas.Len()), !cfg.LogProgress)
@@ -200,17 +202,26 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		// Checksum has finished
 		updateCh.Close()
 		// collect file information.
-		err = checkChecksums(client, cfg)
+		err = checkChecksums(client)
 		if err != nil {
 			return err
 		}
 	} else {
-		// When user specified not to calculate checksum, don't calculate checksum.
 		// Just... copy schemas from origin.
-		log.Info("Skip fast checksum because user requirement.")
 		client.CopyMetaFrom(backupSchemas)
 		// Anyway, let's collect file info for summary.
 		client.CollectFileInfo()
+		if isIncrementalBackup {
+			// Since we don't support checksum for incremental data, fast checksum should be skipped.
+			log.Info("Skip fast checksum in incremental backup")
+			err = client.FilterSchema()
+			if err != nil {
+				return err
+			}
+		} else {
+			// When user specified not to calculate checksum, don't calculate checksum.
+			log.Info("Skip fast checksum because user requirement.")
+		}
 	}
 
 	err = client.SaveBackupMeta(ctx, ddlJobs)
@@ -225,25 +236,20 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 
 // checkChecksums checks the checksum of the client, once failed,
 // returning a error with message: "mismatched checksum".
-func checkChecksums(client *backup.Client, cfg *BackupConfig) error {
+func checkChecksums(client *backup.Client) error {
 	checksums, err := client.CollectChecksums()
 	if err != nil {
 		return err
 	}
-	if cfg.LastBackupTS == 0 {
-		var matches bool
-		matches, err = client.ChecksumMatches(checksums)
-		if err != nil {
-			return err
-		}
-		if !matches {
-			log.Error("backup FastChecksum mismatch!")
-			return errors.New("mismatched checksum")
-		}
-		return nil
+	var matches bool
+	matches, err = client.ChecksumMatches(checksums)
+	if err != nil {
+		return err
 	}
-	// Since we don't support checksum for incremental data, fast checksum should be skipped.
-	log.Info("Skip fast checksum in incremental backup")
+	if !matches {
+		log.Error("backup FastChecksum mismatch!")
+		return errors.New("mismatched checksum")
+	}
 	return nil
 }
 


### PR DESCRIPTION
cherry-pick #384 to release-3.1

---

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. Resolve #365 

### What is changed and how it works?
1. use `dom.InfoSchema()` to check whether db and tables already exists in target cluster. to skip execute unnecessary DDL.
2. record `backupts` in summary log to enhance usability.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

From below log, we can tell the increment restore will skip 
1. exists databases and tables created by full restore.
2. record DDL job during increment backup.
```
[client.go:538] ["execute ddl query"] [db=test] [query="create table t2(id int)"] [historySchemaVersion=102]
[restore.go:633] ["detective exists schemas to skip"] [db="[test]"] [table="[t,t2,warehouse,district,new_order,item,history,orders,customer,stock,order_line]"]
```

Code changes

 - Has interface methods change


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Speed up schema prepare during incremental restore.

<!-- fill in the release note, or just write "No release note" -->
