### PR TITLE
restore: switch mode automatically 5 minutes

### DIFF
--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -337,9 +337,7 @@ func restorePreWork(ctx context.Context, client *restore.Client, mgr *conn.Mgr) 
 	}
 
 	// Switch TiKV cluster to import mode (adjust rocksdb configuration).
-	if err := client.SwitchToImportMode(ctx); err != nil {
-		return clusterConfig{}, nil
-	}
+	client.SwitchToImportMode(ctx)
 
 	// Remove default PD scheduler that may affect restore process.
 	existSchedulers, err := mgr.ListSchedulers(ctx)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
after https://github.com/tikv/tikv/pull/7959 merged, tikv will automatically switch to normal mode in 10 minutes.

### What is changed and how it works?
switch to import mode every 5 minutes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
