### PR TITLE
Add a hint when running on incompatible cluster

### DIFF
--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -200,7 +200,10 @@ func NewMgr(
 	if checkRequirements {
 		err = utils.CheckClusterVersion(ctx, pdClient)
 		if err != nil {
-			return nil, err
+			errMsg := "running BR in incompatible version of cluster, " +
+				"error: (%s). " +
+				"if you believe it's OK, use --check-requirements=false to skip."
+			return nil, errors.Errorf(fmt.Sprintf(errMsg, err.Error()))
 		}
 	}
 	log.Info("new mgr", zap.String("pdAddrs", pdAddrs))

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -201,9 +201,8 @@ func NewMgr(
 		err = utils.CheckClusterVersion(ctx, pdClient)
 		if err != nil {
 			errMsg := "running BR in incompatible version of cluster, " +
-				"error: (%s). " +
 				"if you believe it's OK, use --check-requirements=false to skip."
-			return nil, errors.Errorf(errMsg, err.Error())
+			return nil, errors.Annotate(err, errMsg)
 		}
 	}
 	log.Info("new mgr", zap.String("pdAddrs", pdAddrs))

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -203,7 +203,7 @@ func NewMgr(
 			errMsg := "running BR in incompatible version of cluster, " +
 				"error: (%s). " +
 				"if you believe it's OK, use --check-requirements=false to skip."
-			return nil, errors.Errorf(fmt.Sprintf(errMsg, err.Error()))
+			return nil, errors.Errorf(errMsg, err.Error())
 		}
 	}
 	log.Info("new mgr", zap.String("pdAddrs", pdAddrs))


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some times the version info can be lost (e.g. when build br with `go build` directly, instead of `make build`), at that time, the error message is confusing: 

```
None is not in dotted-tri format.
```

### What is changed and how it works?
In all conditions when we failed to run checksum, we add a hint that "we can use `--check-requirements=false` to skip the version checker."

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
  1. run `go build -o bin/br` directly.
  2. execute `br`.
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/36239017/86457739-b7fefd00-bd56-11ea-9a9e-e287e31f1f74.png">

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
