### PR TITLE
Set safe point at background

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@
 
 ## Documentation
 
-[Chinese Document](https://pingcap.com/docs-cn/dev/how-to/maintain/backup-and-restore/br/)
+[Chinese Document](https://docs.pingcap.com/zh/tidb/v4.0/backup-and-restore-tool)
 
-[English Document](https://pingcap.com/docs/dev/how-to/maintain/backup-and-restore/br/)
+[English Document](https://docs.pingcap.com/tidb/v4.0/backup-and-restore-tool)
+
+[Backup SQL Statement](https://docs.pingcap.com/tidb/v4.0/sql-statement-backup)
+
+[Restore SQL Statement](https://docs.pingcap.com/tidb/v4.0/sql-statement-restore)
 
 ## Building
 

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -416,23 +416,11 @@ func (bc *Client) BackupRanges(
 	log.Info("current backup safePoint job",
 		zap.Uint64("backupTS", backupTS))
 
-	finished := false
 	for {
-		err := CheckGCSafePoint(ctx, bc.mgr.GetPDClient(), backupTS)
-		if err != nil {
-			log.Error("check GC safePoint failed", zap.Error(err))
-			return err
-		}
-		if finished {
-			// Return error (if there is any) before finishing backup.
-			return err
-		}
 		select {
 		case err, ok := <-errCh:
 			if !ok {
-				// Before finish backup, we have to make sure
-				// the backup ts does not fall behind with GC safepoint.
-				finished = true
+				return nil
 			}
 			if err != nil {
 				return err

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -439,15 +439,6 @@ func (bc *Client) BackupRanges(
 	t := time.NewTicker(time.Second * 5)
 	defer t.Stop()
 
-	backupTS := req.EndVersion
-	// use lastBackupTS as safePoint if exists
-	if req.StartVersion > 0 {
-		backupTS = req.StartVersion
-	}
-
-	log.Info("current backup safePoint job",
-		zap.Uint64("backupTS", backupTS))
-
 	for err := range errCh {
 		if err != nil {
 			return nil, err

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -447,8 +447,14 @@ func (bc *Client) BackupRanges(
 		}
 	}
 
-	<-allFilesCollected
-	return allFiles, nil
+	select {
+	case <-allFilesCollected:
+		return allFiles, nil
+	case <-ctx.Done():
+		return nil, errors.Trace(ctx.Err())
+	case err := <-errCh:
+		return nil, errors.Trace(err)
+	}
 }
 
 // BackupRange make a backup of the given key range.

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -418,12 +418,7 @@ func (bc *Client) BackupRanges(
 
 	finished := false
 	for {
-		err := UpdateServiceSafePoint(ctx, bc.mgr.GetPDClient(), bc.GetGCTTL(), backupTS)
-		if err != nil {
-			log.Error("update GC safePoint with TTL failed", zap.Error(err))
-			return err
-		}
-		err = CheckGCSafePoint(ctx, bc.mgr.GetPDClient(), backupTS)
+		err := CheckGCSafePoint(ctx, bc.mgr.GetPDClient(), backupTS)
 		if err != nil {
 			log.Error("check GC safePoint failed", zap.Error(err))
 			return err

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -448,18 +448,13 @@ func (bc *Client) BackupRanges(
 	log.Info("current backup safePoint job",
 		zap.Uint64("backupTS", backupTS))
 
-	for {
-		select {
-		case err, ok := <-errCh:
-			if !ok {
-				return nil
-			}
-			if err != nil {
-				return nil, err
-			}
-		case <-t.C:
+	for err := range errCh {
+		if err != nil {
+			return nil, err
 		}
 	}
+
+	return allFiles, nil
 }
 
 // BackupRange make a backup of the given key range.

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -452,8 +452,6 @@ func (bc *Client) BackupRanges(
 		return allFiles, nil
 	case <-ctx.Done():
 		return nil, errors.Trace(ctx.Err())
-	case err := <-errCh:
-		return nil, errors.Trace(err)
 	}
 }
 

--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -85,6 +85,7 @@ func StartServiceSafePointKeeper(
 	checkTick := time.NewTicker(checkGCSafePointGapTime)
 	go func() {
 		defer updateTick.Stop()
+		defer checkTick.Stop()
 		for {
 			select {
 			case <-ctx.Done():

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -136,7 +136,15 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		return err
 	}
 	g.Record("BackupTS", backupTS)
-	backup.StartServiceSafePointKeeper(ctx, client.GetGCTTL(), mgr.GetPDClient(), backupTS)
+	safePoint := backupTS
+	// use lastBackupTS as safePoint if exists
+	if cfg.LastBackupTS > 0 {
+		safePoint = cfg.LastBackupTS
+	}
+
+	log.Info("current backup safePoint job",
+		zap.Uint64("safepoint", safePoint))
+	backup.StartServiceSafePointKeeper(ctx, client.GetGCTTL(), mgr.GetPDClient(), safePoint)
 
 	isIncrementalBackup := cfg.LastBackupTS > 0
 

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -136,6 +136,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		return err
 	}
 	g.Record("BackupTS", backupTS)
+	backup.StartServiceSafePointKeeper(ctx, client.GetGCTTL(), mgr.GetPDClient(), backupTS)
 
 	isIncrementalBackup := cfg.LastBackupTS > 0
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently, we just set the service GC safe point when writing SST files, but not when checksumming.

If checksum time expires 5min (the service safe point lifetime) plus the TiDB GC lifetime, we might meet "GC life time is shorter than transaction duration" error.

### What is changed and how it works?
I moved the logic of setting GC safe point into another goroutine, which will set the service safe point every (1/5 service safe point lifetime).

This goroutine will be canceled by context.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    Though this test can be automatized by fail points, if we did so, our ingratiation test time will grow to 15 mins+, which is hard to accept. 
    Firstly, we insert fail point at here:    
![image](https://user-images.githubusercontent.com/36239017/86563124-693fa600-bf96-11ea-9a63-110d693285f3.png)
    Then, we run current master branch with fail point:
![image](https://user-images.githubusercontent.com/36239017/86563181-82e0ed80-bf96-11ea-828d-08ba18bb67f0.png)
    After fixed, we can finish the backup:
![image](https://user-images.githubusercontent.com/36239017/86563244-9db36200-bf96-11ea-9135-a3b7f8b84809.png)

### Release Note

 - Fix a bug that may cause failed to backup when dataset is too large and GC lifetime is too brief.

<!-- fill in the release note, or just write "No release note" -->
