### PR TITLE
Fix the problem that backup time may be negative

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -409,7 +409,7 @@ func (bc *Client) BackupRanges(
 		for files := range filesCh {
 			cur, start = start, time.Now()
 			allFiles = append(allFiles, files...)
-			summary.CollectSuccessUnit("backup ranges", 1, cur.Sub(start))
+			summary.CollectSuccessUnit("backup ranges", 1, start.Sub(cur))
 		}
 		log.Info("Backup Ranges", zap.Duration("take", cur.Sub(init)))
 	}()

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -405,13 +405,13 @@ func (bc *Client) BackupRanges(
 	allFiles := make([]*kvproto.File, 0, len(ranges))
 	go func() {
 		init := time.Now()
-		start, cur := init, init
+		currentBackupStart, lastBackupStart := init, init
 		for files := range filesCh {
-			cur, start = start, time.Now()
+			lastBackupStart, currentBackupStart = currentBackupStart, time.Now()
 			allFiles = append(allFiles, files...)
-			summary.CollectSuccessUnit("backup ranges", 1, start.Sub(cur))
+			summary.CollectSuccessUnit("backup ranges", 1, currentBackupStart.Sub(lastBackupStart))
 		}
-		log.Info("Backup Ranges", zap.Duration("take", cur.Sub(init)))
+		log.Info("Backup Ranges", zap.Duration("take", currentBackupStart.Sub(init)))
 	}()
 
 	go func() {

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -405,12 +405,13 @@ func (bc *Client) BackupRanges(
 	allFiles := make([]*kvproto.File, 0, len(ranges))
 	go func() {
 		init := time.Now()
-		currentBackupStart, lastBackupStart := init, init
+		lastBackupStart, currentBackupStart := init, init
 		for files := range filesCh {
 			lastBackupStart, currentBackupStart = currentBackupStart, time.Now()
 			allFiles = append(allFiles, files...)
 			summary.CollectSuccessUnit("backup ranges", 1, currentBackupStart.Sub(lastBackupStart))
 		}
+		_ = lastBackupStart
 		log.Info("Backup Ranges", zap.Duration("take", currentBackupStart.Sub(init)))
 	}()
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#396 made a little mistake, which make `last backup finish time - now` become backup time spent, and will lead to backup time become negative.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/36239017/86880025-a9ca2b80-c11e-11ea-8595-2698cb139866.png">

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
