### PR TITLE
cherry-pick (#377) to release-4.0

### DIFF
--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -141,6 +141,19 @@ func GetSSTMetaFromFile(
 	}
 }
 
+// MakeDBPool makes a session pool with specficated size by sessionFactory.
+func MakeDBPool(size uint, dbFactory func() (*DB, error)) ([]*DB, error) {
+	dbPool := make([]*DB, 0, size)
+	for i := uint(0); i < size; i++ {
+		db, e := dbFactory()
+		if e != nil {
+			return dbPool, e
+		}
+		dbPool = append(dbPool, db)
+	}
+	return dbPool, nil
+}
+
 // EstimateRangeSize estimates the total range count by file.
 func EstimateRangeSize(files []*backup.File) int {
 	result := 0

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -31,6 +31,7 @@ const (
 
 	defaultRestoreConcurrency = 128
 	maxRestoreBatchSizeLimit  = 256
+	defaultDDLConcurrency     = 16
 )
 
 var (
@@ -192,7 +193,21 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 
 	// We make bigger errCh so we won't block on multi-part failed.
 	errCh := make(chan error, 32)
-	tableStream := client.GoCreateTables(ctx, mgr.GetDomain(), tables, newTS, errCh)
+	// Maybe allow user modify the DDL concurrency isn't necessary,
+	// because executing DDL is really I/O bound (or, algorithm bound?),
+	// and we cost most of time at waiting DDL jobs be enqueued.
+	// So these jobs won't be faster or slower when machine become faster or slower,
+	// hence make it a fixed value would be fine.
+	dbPool, err := restore.MakeDBPool(defaultDDLConcurrency, func() (*restore.DB, error) {
+		return restore.NewDB(g, mgr.GetTiKV())
+	})
+	if err != nil {
+		log.Warn("create session pool failed, we will send DDLs only by created sessions",
+			zap.Error(err),
+			zap.Int("sessionCount", len(dbPool)),
+		)
+	}
+	tableStream := client.GoCreateTables(ctx, mgr.GetDomain(), tables, newTS, dbPool, errCh)
 	if len(files) == 0 {
 		log.Info("no files, empty databases and tables are restored")
 		summary.SetSuccessStatus(true)

--- a/pkg/utils/worker.go
+++ b/pkg/utils/worker.go
@@ -21,7 +21,7 @@ type Worker struct {
 }
 
 type taskFunc func()
-type identifiedTaskFunc func(id uint64)
+type identifiedTaskFunc func(uint64)
 
 // NewWorkerPool returns a WorkPool.
 func NewWorkerPool(limit uint, name string) *WorkerPool {


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently, DDLs are send to TiDB cluster sequently, if we were the DDL owner, that is fine: we can execute this DDL immediately, and return very fast.

But we are not, and probably cannot. Then things getting bad, we **must** block and waiting our DDL job pushed to the queue, and executed by owner, then we can send next DDL. Even during waiting time, we can push more DDLs into the DDL job queue.

This PR make `GoCreateTabels` send create table jobs into DDL queue concurrently.

### What is changed and how it works?

we change `GoCreateTables` and make it use below strategy to create tables:
1. if provided a `dbPool`, use this DB pool to execute DDLs concurrently.
2. if not, roll back to old version: send DDL sequentially.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test (`br_300_small_tables`)
 - Manual test
    We test it locally, by a 300 table, per table 100 records workload:
```bash
for i in $(seq 0 $1); do
    (echo "CREATE TABLE FOO.sbtest$i(k int primary key, v varchar (255), trailling varchar(1024))" | mysql -P $MYSQL_PORT -h $MYSQL_SERVER -u root &&
        echo "INSERT INTO FOO.sbtest$i(k, v, trailling) VALUES `make_values 100`" | mysql -P $MYSQL_PORT -h $MYSQL_SERVER -u root) 
done
```

With different concurrency, the result at my computer is:

```
test-result/1_concurrency
621.19 real        11.08 user         9.64 sys

test-result/4_concurrency
153.06 real         7.50 user         5.97 sys

test-result/8_concurrency
89.42 real         6.48 user         4.97 sys

test-result/16_concurrency
62.90 real         6.47 user         4.82 sys

test-result/baseline (master branch)
605.30 real        11.13 user         9.59 sys
```

### Release Note

 - Speed up restore.

### More Things

- Currently, we make the concurrency of sending DDL the same as `cfg.concurrency`, which sometimes may be too big and will make many transaction conflicts. Since the execution time of a DDL has no much relative to environment, maybe a fixed value(like 16 or 32) would be good?

<!-- fill in the release note, or just write "No release note" -->
