### PR TITLE
fix some design of safe point keeper

### DIFF
--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -99,6 +99,8 @@ func StartServiceSafePointKeeper(
 		defer checkTick.Stop()
 		for {
 			select {
+			case <-ctx.Done():
+				log.Info("service safe point keeper exited")
 			case <-updateTick.C:
 				update(ctx)
 			case <-checkTick.C:

--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -5,9 +5,10 @@ package backup
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/pingcap/pd/v4/pkg/tsoutil"
 	"go.uber.org/zap/zapcore"
-	"time"
 
 	"github.com/google/uuid"
 

--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -7,15 +7,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pingcap/pd/v4/pkg/tsoutil"
-	"go.uber.org/zap/zapcore"
-
 	"github.com/google/uuid"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	pd "github.com/pingcap/pd/v4/client"
+	"github.com/pingcap/pd/v4/pkg/tsoutil"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const (

--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -32,6 +32,7 @@ type BRServiceSafePoint struct {
 	BackupTS uint64
 }
 
+// MarshalLogObject implements zapcore.ObjectMarshaler.
 func (sp BRServiceSafePoint) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddString("ID", sp.ID)
 	ttlDuration := time.Duration(sp.TTL) * time.Second

--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -101,6 +101,7 @@ func StartServiceSafePointKeeper(
 			select {
 			case <-ctx.Done():
 				log.Info("service safe point keeper exited")
+				return
 			case <-updateTick.C:
 				update(ctx)
 			case <-checkTick.C:

--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -100,7 +100,7 @@ func StartServiceSafePointKeeper(
 	// It would be OK since TTL won't be zero, so gapTime should > `0.
 	updateGapTime := time.Duration(sp.TTL) * time.Second / preUpdateServiceSafePointFactor
 	update := func(ctx context.Context) {
-		if err := UpdateServiceSafePoint(ctx, pdClient, ttl, backupTS); err != nil {
+		if err := UpdateServiceSafePoint(ctx, pdClient, sp); err != nil {
 			log.Warn("failed to update service safe point, backup may fail if gc triggered",
 				zap.Error(err),
 			)

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -161,7 +161,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	}
 
 	log.Info("current backup safePoint job",
-		zap.Uint64("safepoint", sp.BackupTS))
+		zap.Object("safePoint", sp))
 	backup.StartServiceSafePointKeeper(ctx, mgr.GetPDClient(), sp)
 
 	isIncrementalBackup := cfg.LastBackupTS > 0

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -150,15 +150,19 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		return err
 	}
 	g.Record("BackupTS", backupTS)
-	safePoint := backupTS
+	sp := backup.BRServiceSafePoint{
+		BackupTS: backupTS,
+		TTL:      client.GetGCTTL(),
+		ID:       backup.MakeSafePointID(),
+	}
 	// use lastBackupTS as safePoint if exists
 	if cfg.LastBackupTS > 0 {
-		safePoint = cfg.LastBackupTS
+		sp.BackupTS = cfg.LastBackupTS
 	}
 
 	log.Info("current backup safePoint job",
-		zap.Uint64("safepoint", safePoint))
-	backup.StartServiceSafePointKeeper(ctx, client.GetGCTTL(), mgr.GetPDClient(), safePoint)
+		zap.Uint64("safepoint", sp.BackupTS))
+	backup.StartServiceSafePointKeeper(ctx, mgr.GetPDClient(), sp)
 
 	isIncrementalBackup := cfg.LastBackupTS > 0
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Safe point keeper now will enable safe point at begin.
- Safe point keeper will show warning if safe point exceeds last backup TS.
- Use a random service safe point suffix so concurrently run BR won't conflict (even few people wants do such... , a little... insane thing).

### What is changed and how it works?

See above.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
  See #402, this PR is just some enhance.

### Release Note

 - no release note

<!-- fill in the release note, or just write "No release note" -->
