### PR TITLE
backup: move some non-fatal error log into warn level

### DIFF
--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -96,10 +96,10 @@ func (push *pushDown) pushBackup(
 				errPb := resp.GetError()
 				switch v := errPb.Detail.(type) {
 				case *backup.Error_KvError:
-					log.Error("backup occur kv error", zap.Reflect("error", v))
+					log.Warn("backup occur kv error", zap.Reflect("error", v))
 
 				case *backup.Error_RegionError:
-					log.Error("backup occur region error",
+					log.Warn("backup occur region error",
 						zap.Reflect("error", v))
 
 				case *backup.Error_ClusterIdError:

--- a/pkg/backup/safe_point.go
+++ b/pkg/backup/safe_point.go
@@ -68,7 +68,7 @@ func StartServiceSafePointKeeper(
 	updateGapTime := time.Duration(ttl) * time.Second / preUpdateServiceSafePointFactor
 	update := func(ctx context.Context) {
 		if err := UpdateServiceSafePoint(ctx, pdClient, ttl, backupTS); err != nil {
-			log.Error("failed to update service safe point, backup may fail if gc triggered",
+			log.Warn("failed to update service safe point, backup may fail if gc triggered",
 				zap.Error(err),
 			)
 		}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #403

### What is changed and how it works?
move some non-fatal error log into warn level

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

### Release Note

 - turn down some non-fetal error logs to warn level.

<!-- fill in the release note, or just write "No release note" -->
