### PR TITLE
restore: don't restore auto id if the table doesn't has it.

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -268,8 +268,8 @@ func BuildBackupRangeAndSchema(
 			switch {
 			case tableInfo.IsSequence():
 				globalAutoID, err = seqAlloc.NextGlobalAutoID(tableInfo.ID)
-			case tableInfo.IsView():
-				// no auto ID for views.
+			case tableInfo.IsView() || !utils.NeedAutoID(tableInfo):
+				// no auto ID for views or table without either rowID nor auto_increment ID.
 			default:
 				globalAutoID, err = idAlloc.NextGlobalAutoID(tableInfo.ID)
 			}

--- a/pkg/restore/db.go
+++ b/pkg/restore/db.go
@@ -158,11 +158,13 @@ func (db *DB) CreateTable(ctx context.Context, table *utils.Table) error {
 		default:
 			alterAutoIncIDFormat = "alter table %s.%s auto_increment = %d;"
 		}
-		restoreMetaSQL = fmt.Sprintf(
-			alterAutoIncIDFormat,
-			utils.EncloseName(table.Db.Name.O),
-			utils.EncloseName(table.Info.Name.O),
-			table.Info.AutoIncID)
+		if table.NeedRebaseAutoID() {
+			restoreMetaSQL = fmt.Sprintf(
+				alterAutoIncIDFormat,
+				utils.EncloseName(table.Db.Name.O),
+				utils.EncloseName(table.Info.Name.O),
+				table.Info.AutoIncID)
+		}
 	}
 
 	err = db.se.Execute(ctx, restoreMetaSQL)

--- a/pkg/restore/db.go
+++ b/pkg/restore/db.go
@@ -164,7 +164,7 @@ func (db *DB) CreateTable(ctx context.Context, table *utils.Table) error {
 			utils.EncloseName(table.Db.Name.O),
 			utils.EncloseName(table.Info.Name.O),
 			table.Info.AutoIncID)
-		if table.NeedRebaseAutoID() {
+		if utils.NeedAutoID(table.Info) {
 			err = db.se.Execute(ctx, restoreMetaSQL)
 		}
 	}

--- a/pkg/utils/schema.go
+++ b/pkg/utils/schema.go
@@ -40,6 +40,13 @@ func (tbl *Table) NoChecksum() bool {
 	return tbl.Crc64Xor == 0 && tbl.TotalKvs == 0 && tbl.TotalBytes == 0
 }
 
+func (tbl *Table) NeedRebaseAutoID() bool {
+	tblInfo := tbl.Info
+	hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle
+	hasAutoIncID := tblInfo.GetAutoIncrementColInfo() != nil
+	return hasRowID || hasAutoIncID
+}
+
 // Database wraps the schema and tables of a database.
 type Database struct {
 	Info   *model.DBInfo

--- a/pkg/utils/schema.go
+++ b/pkg/utils/schema.go
@@ -40,12 +40,16 @@ func (tbl *Table) NoChecksum() bool {
 	return tbl.Crc64Xor == 0 && tbl.TotalKvs == 0 && tbl.TotalBytes == 0
 }
 
-// NeedRebaseAutoID checks whether the table need to rebase its autoid.
-func (tbl *Table) NeedRebaseAutoID() bool {
-	tblInfo := tbl.Info
+// NeedAutoID checks whether the table needs backing up with an autoid.
+func NeedAutoID(tblInfo *model.TableInfo) bool {
 	hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle
 	hasAutoIncID := tblInfo.GetAutoIncrementColInfo() != nil
 	return hasRowID || hasAutoIncID
+}
+
+// NeedRebaseAutoID checks whether the table need to rebase its autoid.
+func (tbl *Table) NeedRebaseAutoID() bool {
+	return NeedAutoID(tbl.Info)
 }
 
 // Database wraps the schema and tables of a database.

--- a/pkg/utils/schema.go
+++ b/pkg/utils/schema.go
@@ -47,11 +47,6 @@ func NeedAutoID(tblInfo *model.TableInfo) bool {
 	return hasRowID || hasAutoIncID
 }
 
-// NeedRebaseAutoID checks whether the table need to rebase its autoid.
-func (tbl *Table) NeedRebaseAutoID() bool {
-	return NeedAutoID(tbl.Info)
-}
-
 // Database wraps the schema and tables of a database.
 type Database struct {
 	Info   *model.DBInfo

--- a/pkg/utils/schema.go
+++ b/pkg/utils/schema.go
@@ -40,6 +40,7 @@ func (tbl *Table) NoChecksum() bool {
 	return tbl.Crc64Xor == 0 && tbl.TotalKvs == 0 && tbl.TotalBytes == 0
 }
 
+// NeedRebaseAutoID checks whether the table need to rebase its autoid.
 func (tbl *Table) NeedRebaseAutoID() bool {
 	tblInfo := tbl.Info
 	hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix CI failure after [tidb#18326](https://github.com/pingcap/tidb/pull/18326)

### What is changed and how it works?
We don't try to restore auto ID for tables that don't need it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release Note

 - fix a bug that causes, we will restore auto id even the table doesn't has it.

<!-- fill in the release note, or just write "No release note" -->
