### PR TITLE
[cherry-pick] remove scheduler(#426)

### DIFF
--- a/pkg/conn/scheduler_utils.go
+++ b/pkg/conn/scheduler_utils.go
@@ -1,0 +1,168 @@
+// Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
+
+package conn
+
+import (
+	"context"
+	"math"
+
+	"github.com/pingcap/errors"
+
+	"github.com/pingcap/br/pkg/utils"
+)
+
+// clusterConfig represents a set of scheduler whose config have been modified
+// along with their original config.
+type clusterConfig struct {
+	// Enable PD schedulers before restore
+	scheduler []string
+	// Original scheudle configuration
+	scheduleCfg map[string]interface{}
+}
+
+var (
+	schedulers = map[string]struct{}{
+		"balance-leader-scheduler":     {},
+		"balance-hot-region-scheduler": {},
+		"balance-region-scheduler":     {},
+
+		"shuffle-leader-scheduler":     {},
+		"shuffle-region-scheduler":     {},
+		"shuffle-hot-region-scheduler": {},
+	}
+	pdRegionMergeCfg = []string{
+		"max-merge-region-keys",
+		"max-merge-region-size",
+	}
+	pdScheduleLimitCfg = []string{
+		"leader-schedule-limit",
+		"region-schedule-limit",
+		"max-snapshot-count",
+	}
+)
+
+func addPDLeaderScheduler(ctx context.Context, mgr *Mgr, removedSchedulers []string) error {
+	for _, scheduler := range removedSchedulers {
+		err := mgr.AddScheduler(ctx, scheduler)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func restoreSchedulers(ctx context.Context, mgr *Mgr, clusterCfg clusterConfig) error {
+	if err := addPDLeaderScheduler(ctx, mgr, clusterCfg.scheduler); err != nil {
+		return errors.Annotate(err, "fail to add PD schedulers")
+	}
+	mergeCfg := make(map[string]interface{})
+	for _, cfgKey := range pdRegionMergeCfg {
+		value := clusterCfg.scheduleCfg[cfgKey]
+		if value == nil {
+			// Ignore non-exist config.
+			continue
+		}
+		mergeCfg[cfgKey] = value
+	}
+	if err := mgr.UpdatePDScheduleConfig(ctx, mergeCfg); err != nil {
+		return errors.Annotate(err, "fail to update PD merge config")
+	}
+
+	scheduleLimitCfg := make(map[string]interface{})
+	for _, cfgKey := range pdScheduleLimitCfg {
+		value := clusterCfg.scheduleCfg[cfgKey]
+		if value == nil {
+			// Ignore non-exist config.
+			continue
+		}
+		scheduleLimitCfg[cfgKey] = value
+	}
+	if err := mgr.UpdatePDScheduleConfig(ctx, scheduleLimitCfg); err != nil {
+		return errors.Annotate(err, "fail to update PD schedule config")
+	}
+	return nil
+}
+
+func (mgr *Mgr) makeUndoFunctionByConfig(config clusterConfig) utils.UndoFunc {
+	restore := func(ctx context.Context) error {
+		return restoreSchedulers(ctx, mgr, config)
+	}
+	return restore
+}
+
+// RemoveSchedulers removes the schedulers that may slow down BR speed.
+func (mgr *Mgr) RemoveSchedulers(ctx context.Context) (undo utils.UndoFunc, err error) {
+	undo = utils.Nop
+
+	// Remove default PD scheduler that may affect restore process.
+	existSchedulers, err := mgr.ListSchedulers(ctx)
+	if err != nil {
+		return
+	}
+	needRemoveSchedulers := make([]string, 0, len(existSchedulers))
+	for _, s := range existSchedulers {
+		if _, ok := schedulers[s]; ok {
+			needRemoveSchedulers = append(needRemoveSchedulers, s)
+		}
+	}
+	scheduler, err := removePDLeaderScheduler(ctx, mgr, needRemoveSchedulers)
+	if err != nil {
+		return
+	}
+
+	undo = mgr.makeUndoFunctionByConfig(clusterConfig{scheduler: scheduler})
+
+	stores, err := mgr.GetPDClient().GetAllStores(ctx)
+	if err != nil {
+		return
+	}
+	scheduleCfg, err := mgr.GetPDScheduleConfig(ctx)
+	if err != nil {
+		return
+	}
+
+	undo = mgr.makeUndoFunctionByConfig(clusterConfig{scheduler: scheduler, scheduleCfg: scheduleCfg})
+
+	disableMergeCfg := make(map[string]interface{})
+	for _, cfgKey := range pdRegionMergeCfg {
+		value := scheduleCfg[cfgKey]
+		if value == nil {
+			// Ignore non-exist config.
+			continue
+		}
+		// Disable region merge by setting config to 0.
+		disableMergeCfg[cfgKey] = 0
+	}
+	err = mgr.UpdatePDScheduleConfig(ctx, disableMergeCfg)
+	if err != nil {
+		return
+	}
+
+	scheduleLimitCfg := make(map[string]interface{})
+	for _, cfgKey := range pdScheduleLimitCfg {
+		value := scheduleCfg[cfgKey]
+		if value == nil {
+			// Ignore non-exist config.
+			continue
+		}
+
+		// Speed update PD scheduler by enlarging scheduling limits.
+		// Multiply limits by store count but no more than 40.
+		// Larger limit may make cluster unstable.
+		limit := int(value.(float64))
+		scheduleLimitCfg[cfgKey] = math.Min(40, float64(limit*len(stores)))
+	}
+	return undo, mgr.UpdatePDScheduleConfig(ctx, scheduleLimitCfg)
+}
+
+func removePDLeaderScheduler(ctx context.Context, mgr *Mgr, existSchedulers []string) ([]string, error) {
+	removedSchedulers := make([]string, 0, len(existSchedulers))
+	for _, scheduler := range existSchedulers {
+		err := mgr.RemoveScheduler(ctx, scheduler)
+		if err != nil {
+			return nil, err
+		}
+		removedSchedulers = append(removedSchedulers, scheduler)
+	}
+	return removedSchedulers, nil
+}

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -28,10 +28,11 @@ import (
 )
 
 const (
-	flagBackupTimeago   = "timeago"
-	flagBackupTS        = "backupts"
-	flagLastBackupTS    = "lastbackupts"
-	flagCompressionType = "compression"
+	flagBackupTimeago    = "timeago"
+	flagBackupTS         = "backupts"
+	flagLastBackupTS     = "lastbackupts"
+	flagCompressionType  = "compression"
+	flagRemoveSchedulers = "remove-schedulers"
 
 	flagGCTTL = "gcttl"
 
@@ -43,11 +44,12 @@ const (
 type BackupConfig struct {
 	Config
 
-	TimeAgo         time.Duration           `json:"time-ago" toml:"time-ago"`
-	BackupTS        uint64                  `json:"backup-ts" toml:"backup-ts"`
-	LastBackupTS    uint64                  `json:"last-backup-ts" toml:"last-backup-ts"`
-	GCTTL           int64                   `json:"gc-ttl" toml:"gc-ttl"`
-	CompressionType kvproto.CompressionType `json:"compression-type" toml:"compression-type"`
+	TimeAgo          time.Duration           `json:"time-ago" toml:"time-ago"`
+	BackupTS         uint64                  `json:"backup-ts" toml:"backup-ts"`
+	LastBackupTS     uint64                  `json:"last-backup-ts" toml:"last-backup-ts"`
+	GCTTL            int64                   `json:"gc-ttl" toml:"gc-ttl"`
+	CompressionType  kvproto.CompressionType `json:"compression-type" toml:"compression-type"`
+	RemoveSchedulers bool                    `json:"remove-schedulers" toml:"remove-schedulers"`
 }
 
 // DefineBackupFlags defines common flags for the backup command.
@@ -64,6 +66,11 @@ func DefineBackupFlags(flags *pflag.FlagSet) {
 	flags.Int64(flagGCTTL, backup.DefaultBRGCSafePointTTL, "the TTL (in seconds) that PD holds for BR's GC safepoint")
 	flags.String(flagCompressionType, "zstd",
 		"backup sst file compression algorithm, value can be one of 'lz4|zstd|snappy'")
+
+	flags.Bool(flagRemoveSchedulers, false,
+		"disable the balance, shuffle and region-merge schedulers in PD to speed up backup")
+	// This flag can impact the online cluster, so hide it in case of abuse.
+	_ = flags.MarkHidden(flagRemoveSchedulers)
 }
 
 // ParseFromFlags parses the backup-related flags from the flag set.
@@ -113,7 +120,8 @@ func (cfg *BackupConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 	if cfg.Config.Concurrency > maxBackupConcurrency {
 		cfg.Config.Concurrency = maxBackupConcurrency
 	}
-	return nil
+	cfg.RemoveSchedulers, err = flags.GetBool(flagRemoveSchedulers)
+	return err
 }
 
 // RunBackup starts a backup task inside the current goroutine.
@@ -161,6 +169,19 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	backup.StartServiceSafePointKeeper(ctx, client.GetGCTTL(), mgr.GetPDClient(), safePoint)
 
 	isIncrementalBackup := cfg.LastBackupTS > 0
+
+	if cfg.RemoveSchedulers {
+		log.Debug("removing some PD schedulers")
+		restore, e := mgr.RemoveSchedulers(ctx)
+		defer func() {
+			if restoreE := restore(ctx); restoreE != nil {
+				log.Warn("failed to restore removed schedulers, you may need to restore them manually", zap.Error(restoreE))
+			}
+		}()
+		if e != nil {
+			return err
+		}
+	}
 
 	req := kvproto.BackupRequest{
 		StartVersion:    cfg.LastBackupTS,

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -4,7 +4,6 @@ package task
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -31,27 +30,6 @@ const (
 	defaultRestoreConcurrency = 128
 	maxRestoreBatchSizeLimit  = 256
 	defaultDDLConcurrency     = 16
-)
-
-var (
-	schedulers = map[string]struct{}{
-		"balance-leader-scheduler":     {},
-		"balance-hot-region-scheduler": {},
-		"balance-region-scheduler":     {},
-
-		"shuffle-leader-scheduler":     {},
-		"shuffle-region-scheduler":     {},
-		"shuffle-hot-region-scheduler": {},
-	}
-	pdRegionMergeCfg = []string{
-		"max-merge-region-keys",
-		"max-merge-region-size",
-	}
-	pdScheduleLimitCfg = []string{
-		"leader-schedule-limit",
-		"region-schedule-limit",
-		"max-snapshot-count",
-	}
 )
 
 // RestoreConfig is the configuration specific for restore tasks.
@@ -220,13 +198,13 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	summary.CollectInt("restore ranges", rangeSize)
 	log.Info("range and file prepared", zap.Int("file count", len(files)), zap.Int("range count", rangeSize))
 
-	clusterCfg, err := restorePreWork(ctx, client, mgr)
+	restoreSchedulers, err := restorePreWork(ctx, client, mgr)
 	if err != nil {
 		return err
 	}
 	// Always run the post-work even on error, so we don't stuck in the import
 	// mode or emptied schedulers
-	defer restorePostWork(ctx, client, mgr, clusterCfg)
+	defer restorePostWork(ctx, client, restoreSchedulers)
 
 	// Do not reset timestamp if we are doing incremental restore, because
 	// we are not allowed to decrease timestamp.
@@ -339,153 +317,33 @@ func filterRestoreFiles(
 	return
 }
 
-type clusterConfig struct {
-	// Enable PD schedulers before restore
-	scheduler []string
-	// Original scheudle configuration
-	scheduleCfg map[string]interface{}
-}
-
 // restorePreWork executes some prepare work before restore.
-func restorePreWork(ctx context.Context, client *restore.Client, mgr *conn.Mgr) (clusterConfig, error) {
+// TODO make this function returns a restore post work.
+func restorePreWork(ctx context.Context, client *restore.Client, mgr *conn.Mgr) (utils.UndoFunc, error) {
 	if client.IsOnline() {
-		return clusterConfig{}, nil
+		return utils.Nop, nil
 	}
 
 	// Switch TiKV cluster to import mode (adjust rocksdb configuration).
 	client.SwitchToImportMode(ctx)
 
-	// Remove default PD scheduler that may affect restore process.
-	existSchedulers, err := mgr.ListSchedulers(ctx)
-	if err != nil {
-		return clusterConfig{}, nil
-	}
-	needRemoveSchedulers := make([]string, 0, len(existSchedulers))
-	for _, s := range existSchedulers {
-		if _, ok := schedulers[s]; ok {
-			needRemoveSchedulers = append(needRemoveSchedulers, s)
-		}
-	}
-	scheduler, err := removePDLeaderScheduler(ctx, mgr, needRemoveSchedulers)
-	if err != nil {
-		return clusterConfig{}, nil
-	}
-
-	stores, err := mgr.GetPDClient().GetAllStores(ctx)
-	if err != nil {
-		return clusterConfig{}, err
-	}
-
-	scheduleCfg, err := mgr.GetPDScheduleConfig(ctx)
-	if err != nil {
-		return clusterConfig{}, err
-	}
-
-	disableMergeCfg := make(map[string]interface{})
-	for _, cfgKey := range pdRegionMergeCfg {
-		value := scheduleCfg[cfgKey]
-		if value == nil {
-			// Ignore non-exist config.
-			continue
-		}
-		// Disable region merge by setting config to 0.
-		disableMergeCfg[cfgKey] = 0
-	}
-	err = mgr.UpdatePDScheduleConfig(ctx, disableMergeCfg)
-	if err != nil {
-		return clusterConfig{}, err
-	}
-
-	scheduleLimitCfg := make(map[string]interface{})
-	for _, cfgKey := range pdScheduleLimitCfg {
-		value := scheduleCfg[cfgKey]
-		if value == nil {
-			// Ignore non-exist config.
-			continue
-		}
-
-		// Speed update PD scheduler by enlarging scheduling limits.
-		// Multiply limits by store count but no more than 40.
-		// Larger limit may make cluster unstable.
-		limit := int(value.(float64))
-		scheduleLimitCfg[cfgKey] = math.Min(40, float64(limit*len(stores)))
-	}
-	err = mgr.UpdatePDScheduleConfig(ctx, scheduleLimitCfg)
-	if err != nil {
-		return clusterConfig{}, err
-	}
-
-	cluster := clusterConfig{
-		scheduler:   scheduler,
-		scheduleCfg: scheduleCfg,
-	}
-	return cluster, nil
-}
-
-func removePDLeaderScheduler(ctx context.Context, mgr *conn.Mgr, existSchedulers []string) ([]string, error) {
-	removedSchedulers := make([]string, 0, len(existSchedulers))
-	for _, scheduler := range existSchedulers {
-		err := mgr.RemoveScheduler(ctx, scheduler)
-		if err != nil {
-			return nil, err
-		}
-		removedSchedulers = append(removedSchedulers, scheduler)
-	}
-	return removedSchedulers, nil
+	return mgr.RemoveSchedulers(ctx)
 }
 
 // restorePostWork executes some post work after restore.
 // TODO: aggregate all lifetime manage methods into batcher's context manager field.
 func restorePostWork(
-	ctx context.Context, client *restore.Client, mgr *conn.Mgr, clusterCfg clusterConfig,
+	ctx context.Context, client *restore.Client, restoreSchedulers utils.UndoFunc,
 ) {
 	if client.IsOnline() {
 		return
 	}
 	if err := client.SwitchToNormalMode(ctx); err != nil {
-		log.Warn("fail to switch to normal mode")
+		log.Warn("fail to switch to normal mode", zap.Error(err))
 	}
-	if err := addPDLeaderScheduler(ctx, mgr, clusterCfg.scheduler); err != nil {
-		log.Warn("fail to add PD schedulers")
+	if err := restoreSchedulers(ctx); err != nil {
+		log.Warn("failed to restore PD schedulers", zap.Error(err))
 	}
-	mergeCfg := make(map[string]interface{})
-	for _, cfgKey := range pdRegionMergeCfg {
-		value := clusterCfg.scheduleCfg[cfgKey]
-		if value == nil {
-			// Ignore non-exist config.
-			continue
-		}
-		mergeCfg[cfgKey] = value
-	}
-	if err := mgr.UpdatePDScheduleConfig(ctx, mergeCfg); err != nil {
-		log.Warn("fail to update PD region merge config")
-	}
-
-	scheduleLimitCfg := make(map[string]interface{})
-	for _, cfgKey := range pdScheduleLimitCfg {
-		value := clusterCfg.scheduleCfg[cfgKey]
-		if value == nil {
-			// Ignore non-exist config.
-			continue
-		}
-		scheduleLimitCfg[cfgKey] = value
-	}
-	if err := mgr.UpdatePDScheduleConfig(ctx, scheduleLimitCfg); err != nil {
-		log.Warn("fail to update PD schedule config")
-	}
-	if err := client.ResetRestoreLabels(ctx); err != nil {
-		log.Warn("reset store labels failed", zap.Error(err))
-	}
-}
-
-func addPDLeaderScheduler(ctx context.Context, mgr *conn.Mgr, removedSchedulers []string) error {
-	for _, scheduler := range removedSchedulers {
-		err := mgr.AddScheduler(ctx, scheduler)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // RunRestoreTiflashReplica restores the replica of tiflash saved in the last restore.

--- a/pkg/task/restore_raw.go
+++ b/pkg/task/restore_raw.go
@@ -111,11 +111,11 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 		return errors.Trace(err)
 	}
 
-	removedSchedulers, err := restorePreWork(ctx, client, mgr)
+	restoreSchedulers, err := restorePreWork(ctx, client, mgr)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer restorePostWork(ctx, client, mgr, removedSchedulers)
+	defer restorePostWork(ctx, client, restoreSchedulers)
 
 	err = client.RestoreRaw(cfg.StartKey, cfg.EndKey, files, updateCh)
 	if err != nil {

--- a/pkg/utils/pd.go
+++ b/pkg/utils/pd.go
@@ -4,6 +4,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
@@ -17,6 +18,13 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/placement"
 	"github.com/pingcap/tidb/tablecodec"
 )
+
+// UndoFunc is a 'undo' operation of some undoable command.
+// (e.g. RemoveSchedulers).
+type UndoFunc func(context.Context) error
+
+// Nop is the 'zero value' of undo func.
+var Nop UndoFunc = func(context.Context) error { return nil }
 
 const (
 	resetTSURL       = "/pd/api/v1/admin/reset-ts"


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fixed #412.

### What is changed and how it works?
Firstly, we extract the logic of removing schedulers to `conn` package, as a method of `conn.Manager`.
Then, we add a flag that controls whether to remove scheduler when backing up.
Finally, we call the extracted method on backup if the flag is set. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release Note

 - Add an option that can be used to speed up backing up by changing some cluster config.

<!-- fill in the release note, or just write "No release note" -->

