### PR TITLE
backup: set gcttl to 5m if gcttl not set in TiDB

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -131,6 +131,9 @@ func (bc *Client) SetLockFile(ctx context.Context) error {
 
 // SetGCTTL set gcTTL for client.
 func (bc *Client) SetGCTTL(ttl int64) {
+	if ttl <= 0 {
+		ttl = DefaultBRGCSafePointTTL
+	}
 	bc.gcTTL = ttl
 }
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If we execute Backup SQL in TiDB, it won't set gcttl to default 5m. this will cause error
`'non-positive interval for NewTicker'`

### What is changed and how it works?
Set gcttl to 5m in task `runbackup`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
use TiDB not include this commit:
```
mysql>  backup database * to 'local:///tmp/backup2';
ERROR 1105 (HY000): non-positive interval for NewTicker
```

use TiDB with this commit:
```
mysql> backup database * to 'local:///tmp/backup1';
+----------------------+------+--------------------+---------------------+---------------------+
| Destination          | Size | BackupTS           | Queue Time          | Execution Time      |
+----------------------+------+--------------------+---------------------+---------------------+
| local:///tmp/backup1 |    0 | 418251612147417090 | 2020-07-23 19:21:21 | 2020-07-23 19:21:21 |
+----------------------+------+--------------------+---------------------+---------------------+
1 row in set (0.02 sec)
```
Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
