### PR TITLE
common: adjust config in task RunBackup/RunRestore

### DIFF
--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -76,8 +76,23 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 	return nil
 }
 
+// adjustRestoreConfig is use for BR(binary) and BR in TiDB.
+// When new config was add and not included in parser.
+// we should set proper value in this function.
+// so that both binary and TiDB will use same default value.
+func (cfg *RestoreConfig) adjustRestoreConfig() {
+	if cfg.Config.Concurrency == 0 {
+		cfg.Config.Concurrency = defaultRestoreConcurrency
+	}
+	if cfg.Config.SwitchModeInterval == 0 {
+		cfg.Config.SwitchModeInterval = defaultSwitchInterval
+	}
+}
+
 // RunRestore starts a restore task inside the current goroutine.
 func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConfig) error {
+	cfg.adjustRestoreConfig()
+
 	defer summary.Summary(cmdName)
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The only common entrance of BR binary and BR in TiDB is task.RunXXX.
and we should adjust related config in this function for both binary and TiDB 

### What is changed and how it works?
Add `adjustBackupConfig` for task.RunBackup
Add `adjustRestoreConfig` for task.RunRestore


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
