### PR TITLE
fix restore auto increment ID overflow

### DIFF
--- a/pkg/restore/db.go
+++ b/pkg/restore/db.go
@@ -5,6 +5,7 @@ package restore
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/pingcap/errors"
@@ -159,11 +160,17 @@ func (db *DB) CreateTable(ctx context.Context, table *utils.Table) error {
 		default:
 			alterAutoIncIDFormat = "alter table %s.%s auto_increment = %d;"
 		}
+
+		// auto inc id overflow
+		autoIncID := table.Info.AutoIncID
+		if table.Info.AutoIncID < 0 {
+			autoIncID = math.MaxInt64
+		}
 		restoreMetaSQL = fmt.Sprintf(
 			alterAutoIncIDFormat,
 			utils.EncloseName(table.Db.Name.O),
 			utils.EncloseName(table.Info.Name.O),
-			table.Info.AutoIncID)
+			autoIncID)
 		if utils.NeedAutoID(table.Info) {
 			err = db.se.Execute(ctx, restoreMetaSQL)
 		}

--- a/tests/br_other/run.sh
+++ b/tests/br_other/run.sh
@@ -103,3 +103,20 @@ run_sql "DROP DATABASE $DB;"
 # Test version
 run_br --version
 run_br -V
+
+
+# generate table with auto_inc_id
+run_sql "create table $DB.autoid(`auto_inc_id` bigint(20) NOT NULL AUTO_INCREMENT,UNIQUE KEY `auto_inc_id` (`auto_inc_id`))"
+run_sql "insert into $DB.autoid values(9223372036854775805)"
+
+# backup db
+echo "backup start overflow test..."
+run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+
+run_sql "DROP DATABASE $DB;"
+
+# restore db
+echo "restore start..."
+run_br restore db --db $DB -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+
+run_sql "DROP DATABASE $DB;"


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when auto_increment id reached max.Int64, it can backs up success. but failed when restore. we should handle this situation.

### What is changed and how it works?
if autoIncID overflowed. change is to max.Int64, to keep consistency with backup cluster.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
