### PR TITLE
storage: use path in WalkDir and Open

### DIFF
--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -123,8 +123,8 @@ func (s *gcsStorage) FileExists(ctx context.Context, name string) (bool, error) 
 	return true, nil
 }
 
-// Open a Reader by file name.
-func (s *gcsStorage) Open(ctx context.Context, name string) (ReadSeekCloser, error) {
+// Open a Reader by file path.
+func (s *gcsStorage) Open(ctx context.Context, path string) (ReadSeekCloser, error) {
 	// TODO, implement this if needed
 	panic("Unsupported Operation")
 }

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -57,9 +57,9 @@ func (l *LocalStorage) WalkDir(ctx context.Context, fn func(string, int64) error
 	})
 }
 
-// Open a Reader by file path. path is a relative path to base path
-func (l *LocalStorage) Open(ctx context.Context, p string) (ReadSeekCloser, error) {
-	return os.Open(filepath.Join(l.base, p))
+// Open a Reader by file path, path is a relative path to base path.
+func (l *LocalStorage) Open(ctx context.Context, path string) (ReadSeekCloser, error) {
+	return os.Open(filepath.Join(l.base, path))
 }
 
 func pathExists(_path string) (bool, error) {

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -50,17 +50,16 @@ func (l *LocalStorage) WalkDir(ctx context.Context, fn func(string, int64) error
 		if f == nil || f.IsDir() {
 			return nil
 		}
-
+		// in mac osx, the path parameter is absolute path; in linux, the path is relative path to execution base dir,
+		// so use Rel to convert to relative path to l.base
+		path, _ = filepath.Rel(l.base, path)
 		return fn(path, f.Size())
 	})
 }
 
-// Open a Reader by file path.
+// Open a Reader by file path. path is a relative path to base path
 func (l *LocalStorage) Open(ctx context.Context, p string) (ReadSeekCloser, error) {
-	if !filepath.IsAbs(p) {
-		p = filepath.Join(l.base, p)
-	}
-	return os.Open(p)
+	return os.Open(filepath.Join(l.base, p))
 }
 
 func pathExists(_path string) (bool, error) {

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -52,13 +52,16 @@ func (l *LocalStorage) WalkDir(ctx context.Context, fn func(string, int64) error
 			return nil
 		}
 
-		return fn(f.Name(), f.Size())
+		return fn(path, f.Size())
 	})
 }
 
-// Open a Reader by file name.
-func (l *LocalStorage) Open(ctx context.Context, name string) (ReadSeekCloser, error) {
-	return os.Open(path.Join(l.base, name))
+// Open a Reader by file path.
+func (l *LocalStorage) Open(ctx context.Context, p string) (ReadSeekCloser, error) {
+	if !filepath.IsAbs(p) {
+		p = path.Join(l.base, p)
+	}
+	return os.Open(p)
 }
 
 func pathExists(_path string) (bool, error) {

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/pingcap/errors"
@@ -20,19 +19,19 @@ type LocalStorage struct {
 }
 
 func (l *LocalStorage) Write(ctx context.Context, name string, data []byte) error {
-	filepath := path.Join(l.base, name)
+	filepath := filepath.Join(l.base, name)
 	return ioutil.WriteFile(filepath, data, 0644) // nolint:gosec
 	// the backupmeta file _is_ intended to be world-readable.
 }
 
 func (l *LocalStorage) Read(ctx context.Context, name string) ([]byte, error) {
-	filepath := path.Join(l.base, name)
+	filepath := filepath.Join(l.base, name)
 	return ioutil.ReadFile(filepath)
 }
 
 // FileExists implement ExternalStorage.FileExists.
 func (l *LocalStorage) FileExists(ctx context.Context, name string) (bool, error) {
-	filepath := path.Join(l.base, name)
+	filepath := filepath.Join(l.base, name)
 	return pathExists(filepath)
 }
 
@@ -59,7 +58,7 @@ func (l *LocalStorage) WalkDir(ctx context.Context, fn func(string, int64) error
 // Open a Reader by file path.
 func (l *LocalStorage) Open(ctx context.Context, p string) (ReadSeekCloser, error) {
 	if !filepath.IsAbs(p) {
-		p = path.Join(l.base, p)
+		p = filepath.Join(l.base, p)
 	}
 	return os.Open(p)
 }

--- a/pkg/storage/noop.go
+++ b/pkg/storage/noop.go
@@ -23,8 +23,8 @@ func (*noopStorage) FileExists(ctx context.Context, name string) (bool, error) {
 	return false, nil
 }
 
-// Open a Reader by file name.
-func (*noopStorage) Open(ctx context.Context, name string) (ReadSeekCloser, error) {
+// Open a Reader by file path.
+func (*noopStorage) Open(ctx context.Context, path string) (ReadSeekCloser, error) {
 	return noopReader{}, nil
 }
 

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -6,6 +6,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -13,9 +17,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/spf13/pflag"
-	"io"
-	"io/ioutil"
-	"net/url"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/backup"

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -6,11 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/url"
-	"strings"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -18,6 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/spf13/pflag"
+	"io"
+	"io/ioutil"
+	"net/url"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/backup"
@@ -351,12 +349,9 @@ func (rs *S3Storage) Open(ctx context.Context, path string) (ReadSeekCloser, err
 }
 
 func (rs *S3Storage) open(ctx context.Context, path string, startOffset int64, endOffset int64) (io.ReadCloser, error) {
-	if strings.Index(path, rs.options.Prefix) != 0 {
-		path = rs.options.Prefix + path
-	}
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(rs.options.Bucket),
-		Key:    aws.String(path),
+		Key:    aws.String(rs.options.Prefix + path),
 	}
 
 	var rangeOffset *string

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/url"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -349,10 +350,13 @@ func (rs *S3Storage) Open(ctx context.Context, name string) (ReadSeekCloser, err
 	}, nil
 }
 
-func (rs *S3Storage) open(ctx context.Context, name string, startOffset int64, endOffset int64) (io.ReadCloser, error) {
+func (rs *S3Storage) open(ctx context.Context, path string, startOffset int64, endOffset int64) (io.ReadCloser, error) {
+	if strings.Index(path, rs.options.Prefix) != 0 {
+		path = rs.options.Prefix + path
+	}
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(rs.options.Bucket),
-		Key:    aws.String(rs.options.Prefix + name),
+		Key:    aws.String(path),
 	}
 
 	var rangeOffset *string

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -337,15 +337,15 @@ func (rs *S3Storage) WalkDir(ctx context.Context, fn func(string, int64) error) 
 	return nil
 }
 
-// Open a Reader by file name.
-func (rs *S3Storage) Open(ctx context.Context, name string) (ReadSeekCloser, error) {
-	reader, err := rs.open(ctx, name, 0, 0)
+// Open a Reader by file path.
+func (rs *S3Storage) Open(ctx context.Context, path string) (ReadSeekCloser, error) {
+	reader, err := rs.open(ctx, path, 0, 0)
 	if err != nil {
 		return nil, err
 	}
 	return &s3ObjectReader{
 		storage: rs,
-		name:    name,
+		name:    path,
 		reader:  reader,
 	}, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -25,8 +25,8 @@ type ExternalStorage interface {
 	Read(ctx context.Context, name string) ([]byte, error)
 	// FileExists return true if file exists
 	FileExists(ctx context.Context, name string) (bool, error)
-	// Open a Reader by file name.
-	Open(ctx context.Context, name string) (ReadSeekCloser, error)
+	// Open a Reader by file path. path can be either an absolute path or relative path to storage base path
+	Open(ctx context.Context, path string) (ReadSeekCloser, error)
 	// WalkDir traverse all the files in a dir.
 	//
 	// fn is the function called for each regular file visited by WalkDir.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -25,7 +25,7 @@ type ExternalStorage interface {
 	Read(ctx context.Context, name string) ([]byte, error)
 	// FileExists return true if file exists
 	FileExists(ctx context.Context, name string) (bool, error)
-	// Open a Reader by file path. path can be either an absolute path or relative path to storage base path
+	// Open a Reader by file path. path is relative path to storage base path
 	Open(ctx context.Context, path string) (ReadSeekCloser, error)
 	// WalkDir traverse all the files in a dir.
 	//


### PR DESCRIPTION
Signed-off-by: glorv <glorvs@163.com>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Use file path in ExtrenalStorage method `WalkDir` and `Open`

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has interface methods change

Side effects

Related changes

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
