### PR TITLE
backup: remove duplicate kv size summary collect

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -919,8 +919,6 @@ func CollectChecksums(backupMeta *kvproto.BackupMeta) ([]Checksum, error) {
 			totalBytes += file.TotalBytes
 		}
 
-		summary.CollectSuccessUnit(summary.TotalKV, 1, totalKvs)
-		summary.CollectSuccessUnit(summary.TotalBytes, 1, totalBytes)
 		log.Info("fast checksum calculated", zap.Stringer("db", dbInfo.Name), zap.Stringer("table", tblInfo.Name))
 		localChecksum := Checksum{
 			Crc64Xor:   checksum,


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
resolve https://github.com/pingcap/br/issues/470

### What is changed and how it works?
we calculate duplicate in backup summary log. the first time is in BackupRange, and the second time is in checksum, we should remove the second one because not every backup task starts with checksum.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
before this PR in v4.0.4:
```
[2020/08/25 10:36:22.567 +08:00] [INFO] [collector.go:60] ["Table backup Success summary: total backup ranges: 1, total success: 1, total failed: 0, total take(s): 0.13, total kv: 71996, total size(MB): 72.23, avg speed(MB/s): 547.18"] ["backup checksum"=127.091977ms] ["backup fast checksum"=217.299µs] ["backup total regions"=1] [BackupTS=418990779862614018] [Size=530514]
```

after this fix:
```
[2020/08/25 10:33:04.525 +08:00] [INFO] [collector.go:60] ["Table backup Success summary: total backup ranges: 1, total success: 1, total failed: 0, total take(s): 0.21, total kv: 35998, total size(MB): 36.12, avg speed(MB/s): 173.17"] ["backup checksum"=39.668497ms] ["backup fast checksum"=281.476µs] ["backup total regions"=1] [BackupTS=418990727944732675] [Size=530629]
```


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Fix the issue that total kv and total bytes calculate duplicate in backup summary log.

<!-- fill in the release note, or just write "No release note" -->
