### PR TITLE
restore: switch mode immediately when restore start.

### DIFF
--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -714,6 +714,14 @@ func (rc *Client) SwitchToImportMode(ctx context.Context) {
 	// so we need ping tikv in less than 10 minute
 	go func() {
 		tick := time.NewTicker(rc.switchModeInterval)
+		defer tick.Stop()
+
+		// [important!] switch tikv mode into import at the beginning
+		log.Info("switch to import mode at beginning")
+		err := rc.switchTiKVMode(ctx, import_sstpb.SwitchMode_Import)
+		if err != nil {
+			log.Warn("switch to import mode failed", zap.Error(err))
+		}
 
 		for {
 			select {


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the issue that switch to import mode not work at first 5 minutes.

### What is changed and how it works?
do switchToImportMode at first.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
There is no "switch to import mode" log if we finish restore in 5 minutes.


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Fix the issue that switch to import mode not work at first 5 minutes.


<!-- fill in the release note, or just write "No release note" -->
