### PR TITLE
summary: add real time cost to log collector

### DIFF
--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -814,7 +814,7 @@ func (rc *Client) GoValidateChecksum(
 			}
 			elapsed := time.Since(start)
 			summary.CollectDuration("restore checksum", elapsed)
-			summary.CollectSuccessUnit("table checksumed", 1, elapsed)
+			summary.CollectSuccessUnit("table checksum", 1, elapsed)
 			outCh <- struct{}{}
 			close(outCh)
 		}()

--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -814,6 +814,7 @@ func (rc *Client) GoValidateChecksum(
 			}
 			elapsed := time.Since(start)
 			summary.CollectDuration("restore checksum", elapsed)
+			summary.CollectSuccessUnit("table checksumed", 1, elapsed)
 			outCh <- struct{}{}
 			close(outCh)
 		}()

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -326,9 +326,9 @@ func (importer *FileImporter) Import(
 					zap.Error(errIngest))
 				return errIngest
 			}
-			summary.CollectSuccessUnit(summary.TotalKV, 1, file.TotalKvs)
-			summary.CollectSuccessUnit(summary.TotalBytes, 1, file.TotalBytes)
 		}
+		summary.CollectSuccessUnit(summary.TotalKV, 1, file.TotalKvs)
+		summary.CollectSuccessUnit(summary.TotalBytes, 1, file.TotalBytes)
 		return nil
 	}, newImportSSTBackoffer())
 	return err

--- a/pkg/summary/collector.go
+++ b/pkg/summary/collector.go
@@ -77,6 +77,7 @@ type logCollector struct {
 	ints             map[string]int
 	uints            map[string]uint64
 	successStatus    bool
+	startTime        time.Time
 
 	log logFunc
 }
@@ -92,6 +93,7 @@ func newLogCollector(log logFunc) LogCollector {
 		ints:             make(map[string]int),
 		uints:            make(map[string]uint64),
 		log:              log,
+		startTime:        time.Now(),
 	}
 }
 
@@ -189,7 +191,8 @@ func (tc *logCollector) Summary(name string) {
 	for _, cost := range tc.successCosts {
 		totalCost += cost
 	}
-	msg += fmt.Sprintf(", total take(s): %.2f", totalCost.Seconds())
+	msg += fmt.Sprintf(", total take(TiKV service time): %s", totalCost)
+	msg += fmt.Sprintf(", total take(real time): %s", time.Since(tc.startTime))
 	for name, data := range tc.successData {
 		if name == TotalBytes {
 			fData := float64(data) / 1024 / 1024

--- a/pkg/summary/collector.go
+++ b/pkg/summary/collector.go
@@ -191,7 +191,7 @@ func (tc *logCollector) Summary(name string) {
 	for _, cost := range tc.successCosts {
 		totalCost += cost
 	}
-	msg += fmt.Sprintf(", total take(TiKV service time): %s", totalCost)
+	msg += fmt.Sprintf(", total take(%s time): %s", name, totalCost)
 	msg += fmt.Sprintf(", total take(real time): %s", time.Since(tc.startTime))
 	for name, data := range tc.successData {
 		if name == TotalBytes {


### PR DESCRIPTION
Signed-off-by: Hillium <maruruku@stu.csust.edu.cn>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement #478 

### What is changed and how it works?
We make serval changes to make the log of time cost correct:
1. collect kv and size each time of importing.
https://github.com/pingcap/br/blob/d9d6207c0aa7bad470093683427338053435e1ba/pkg/restore/import.go#L328-L331
2. a log of real time cost is added to the summary.
3. collect the success unit when checksumming, so the total cost field would be (the time of restoring + the time of checksumming) instead of just the time of restoring.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/36239017/91679842-f7da3900-eb7b-11ea-987d-e6e4c066a616.png">

 - Manual test (add detailed scripts or steps below)

### Release Note

 - Add real time cost to log.

<!-- fill in the release note, or just write "No release note" -->
