### PR TITLE
*: don't remove tiflash more.

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -127,7 +127,7 @@ func newTableRestoreCommand() *cobra.Command {
 func newTiflashReplicaRestoreCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "tiflash-replica",
-		Short: "restore the tiflash replica before the last restore, it must only be used after the last restore failed",
+		Short: "restore the tiflash replica removed by a failed restore of the older version BR",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runRestoreTiflashReplicaCommand(cmd, "Restore TiFlash Replica")
 		},

--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/backup"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
@@ -27,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/server/schedule/placement"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -75,15 +73,8 @@ type Client struct {
 	isOnline        bool
 	noSchema        bool
 	hasSpeedLimited bool
-	// Those fields should be removed after we have FULLY supportted TiFlash.
-	// we place this field here to make a 'good' memory align, but mainly make golang-ci happy :)
-	tiFlashRecordUpdated bool
 
 	restoreStores []uint64
-
-	// tables that has TiFlash and those TiFlash have been removed, should be written to disk.
-	// Those fields should be removed after we have FULLY supportted TiFlash.
-	tablesRemovedTiFlash []*backup.Schema
 
 	storage            storage.ExternalStorage
 	backend            *backup.StorageBackend
@@ -480,107 +471,6 @@ func (rc *Client) createTablesWithDBPool(ctx context.Context,
 	return eg.Wait()
 }
 
-// makeTiFlashOfTableRecord make a 'record' repsenting TiFlash of a table that has been removed.
-// We doesn't record table ID here because when restore TiFlash replicas,
-// we use `ALTER TABLE db.tbl SET TIFLASH_REPLICA = xxx` DDL, instead of use some internal TiDB API.
-func makeTiFlashOfTableRecord(table *utils.Table, replica int) (*backup.Schema, error) {
-	tableData, err := json.Marshal(table.Info)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	dbData, err := json.Marshal(table.Db)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	result := &backup.Schema{
-		Db:              dbData,
-		Table:           tableData,
-		Crc64Xor:        table.Crc64Xor,
-		TotalKvs:        table.TotalKvs,
-		TotalBytes:      table.TotalBytes,
-		TiflashReplicas: uint32(replica),
-	}
-	return result, nil
-}
-
-// RemoveTiFlashOfTable removes TiFlash replica of some table,
-// returns the removed count of TiFlash nodes.
-// TODO: save the removed TiFlash information into disk.
-// TODO: remove this after tiflash supports restore.
-func (rc *Client) RemoveTiFlashOfTable(table CreatedTable, rule []placement.Rule) (int, error) {
-	if rule := utils.SearchPlacementRule(table.Table.ID, rule, placement.Learner); rule != nil {
-		if rule.Count > 0 {
-			log.Info("remove TiFlash of table", zap.Int64("table ID", table.Table.ID), zap.Int("count", rule.Count))
-			err := multierr.Combine(
-				rc.db.AlterTiflashReplica(rc.ctx, table.OldTable, 0),
-				rc.removeTiFlashOf(table.OldTable, rule.Count),
-				rc.flushTiFlashRecord(),
-			)
-			if err != nil {
-				return 0, errors.Trace(err)
-			}
-			return rule.Count, nil
-		}
-	}
-	return 0, nil
-}
-
-func (rc *Client) removeTiFlashOf(table *utils.Table, replica int) error {
-	tableRecord, err := makeTiFlashOfTableRecord(table, replica)
-	if err != nil {
-		return err
-	}
-	rc.tablesRemovedTiFlash = append(rc.tablesRemovedTiFlash, tableRecord)
-	rc.tiFlashRecordUpdated = true
-	return nil
-}
-
-func (rc *Client) flushTiFlashRecord() error {
-	// Today nothing to do :D
-	if !rc.tiFlashRecordUpdated {
-		return nil
-	}
-
-	// should we make a deep copy here?
-	// currently, write things directly to backup meta is OK since there seems nobody uses it.
-	// But would it be better if we don't do it?
-	rc.backupMeta.Schemas = rc.tablesRemovedTiFlash
-	backupMetaData, err := proto.Marshal(rc.backupMeta)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	backendURL := storage.FormatBackendURL(rc.backend)
-	log.Info("update backup meta", zap.Stringer("path", &backendURL))
-	err = rc.storage.Write(rc.ctx, utils.SavedMetaFile, backupMetaData)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
-// RecoverTiFlashOfTable recovers TiFlash replica of some table.
-// TODO: remove this after tiflash supports restore.
-func (rc *Client) RecoverTiFlashOfTable(table *utils.Table) error {
-	if table.TiFlashReplicas > 0 {
-		err := rc.db.AlterTiflashReplica(rc.ctx, table, table.TiFlashReplicas)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
-// RecoverTiFlashReplica recovers all the tiflash replicas of a table
-// TODO: remove this after tiflash supports restore.
-func (rc *Client) RecoverTiFlashReplica(tables []*utils.Table) error {
-	for _, table := range tables {
-		if err := rc.RecoverTiFlashOfTable(table); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // ExecDDLs executes the queries of the ddl jobs.
 func (rc *Client) ExecDDLs(ddlJobs []*model.Job) error {
 	// Sort the ddl jobs by schema version in ascending order.
@@ -622,7 +512,6 @@ func (rc *Client) setSpeedLimit() error {
 func (rc *Client) RestoreFiles(
 	files []*backup.File,
 	rewriteRules *RewriteRules,
-	rejectStoreMap map[uint64]bool,
 	updateCh glue.Progress,
 ) (err error) {
 	start := time.Now()
@@ -649,7 +538,7 @@ func (rc *Client) RestoreFiles(
 		rc.workerPool.ApplyOnErrorGroup(eg,
 			func() error {
 				defer updateCh.Inc()
-				return rc.fileImporter.Import(ectx, fileReplica, rejectStoreMap, rewriteRules)
+				return rc.fileImporter.Import(ectx, fileReplica, rewriteRules)
 			})
 	}
 	if err := eg.Wait(); err != nil {
@@ -682,13 +571,12 @@ func (rc *Client) RestoreRaw(startKey []byte, endKey []byte, files []*backup.Fil
 		return errors.Trace(err)
 	}
 
-	emptyRules := &RewriteRules{}
 	for _, file := range files {
 		fileReplica := file
 		rc.workerPool.ApplyOnErrorGroup(eg,
 			func() error {
 				defer updateCh.Inc()
-				return rc.fileImporter.Import(ectx, fileReplica, nil, emptyRules)
+				return rc.fileImporter.Import(ectx, fileReplica, EmptyRewriteRule())
 			})
 	}
 	if err := eg.Wait(); err != nil {

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -176,7 +176,6 @@ func (importer *FileImporter) SetRawRange(startKey, endKey []byte) error {
 func (importer *FileImporter) Import(
 	ctx context.Context,
 	file *backup.File,
-	rejectStoreMap map[uint64]bool,
 	rewriteRules *RewriteRules,
 ) error {
 	log.Debug("import file", utils.ZapFile(file))
@@ -201,8 +200,6 @@ func (importer *FileImporter) Import(
 		zap.Stringer("startKey", utils.WrapKey(startKey)),
 		zap.Stringer("endKey", utils.WrapKey(endKey)))
 
-	needReject := len(rejectStoreMap) > 0
-
 	err = utils.WithRetry(ctx, func() error {
 		tctx, cancel := context.WithTimeout(ctx, importScanRegionTime)
 		defer cancel()
@@ -211,22 +208,6 @@ func (importer *FileImporter) Import(
 			tctx, importer.metaClient, startKey, endKey, scanRegionPaginationLimit)
 		if errScanRegion != nil {
 			return errors.Trace(errScanRegion)
-		}
-
-		if needReject {
-			// TODO remove when TiFlash support restore
-			startTime := time.Now()
-			log.Info("start to wait for removing rejected stores", zap.Reflect("rejectStores", rejectStoreMap))
-			for _, region := range regionInfos {
-				if !waitForRemoveRejectStores(ctx, importer.metaClient, region, rejectStoreMap) {
-					log.Error("waiting for removing rejected stores failed",
-						utils.ZapRegion(region.Region))
-					return errors.New("waiting for removing rejected stores failed")
-				}
-			}
-			log.Info("waiting for removing rejected stores done",
-				zap.Int("regions", len(regionInfos)), zap.Duration("take", time.Since(startTime)))
-			needReject = false
 		}
 
 		log.Debug("scan regions", utils.ZapFile(file), zap.Int("count", len(regionInfos)))

--- a/pkg/restore/pipeline_items.go
+++ b/pkg/restore/pipeline_items.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pingcap/parser/model"
 	"go.uber.org/zap"
 
-	"github.com/pingcap/br/pkg/conn"
 	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/rtree"
 	"github.com/pingcap/br/pkg/utils"
@@ -135,9 +134,8 @@ type BatchSender interface {
 }
 
 type tikvSender struct {
-	client         *Client
-	updateCh       glue.Progress
-	rejectStoreMap map[uint64]bool
+	client   *Client
+	updateCh glue.Progress
 }
 
 // NewTiKVSender make a sender that send restore requests to TiKV.
@@ -145,25 +143,10 @@ func NewTiKVSender(
 	ctx context.Context,
 	cli *Client,
 	updateCh glue.Progress,
-	// TODO remove this field after we support TiFlash.
-	removeTiFlash bool,
 ) (BatchSender, error) {
-	rejectStoreMap := make(map[uint64]bool)
-	if removeTiFlash {
-		tiflashStores, err := conn.GetAllTiKVStores(ctx, cli.GetPDClient(), conn.TiFlashOnly)
-		if err != nil {
-			log.Error("failed to get and remove TiFlash replicas", zap.Error(err))
-			return nil, err
-		}
-		for _, store := range tiflashStores {
-			rejectStoreMap[store.GetId()] = true
-		}
-	}
-
 	return &tikvSender{
-		client:         cli,
-		updateCh:       updateCh,
-		rejectStoreMap: rejectStoreMap,
+		client:   cli,
+		updateCh: updateCh,
 	}, nil
 }
 
@@ -181,7 +164,7 @@ func (b *tikvSender) RestoreBatch(ctx context.Context, ranges []rtree.Range, rew
 		files = append(files, fs.Files...)
 	}
 
-	if err := b.client.RestoreFiles(files, rewriteRules, b.rejectStoreMap, b.updateCh); err != nil {
+	if err := b.client.RestoreFiles(files, rewriteRules, b.updateCh); err != nil {
 		return err
 	}
 

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -498,62 +498,6 @@ func PaginateScanRegion(
 	return regions, nil
 }
 
-func hasRejectStorePeer(
-	ctx context.Context,
-	client SplitClient,
-	regionID uint64,
-	rejectStores map[uint64]bool,
-) (bool, error) {
-	regionInfo, err := client.GetRegionByID(ctx, regionID)
-	if err != nil {
-		return false, err
-	}
-	if regionInfo == nil {
-		return false, nil
-	}
-	for _, peer := range regionInfo.Region.GetPeers() {
-		if rejectStores[peer.GetStoreId()] {
-			return true, nil
-		}
-	}
-	retryTimes := ctx.Value(retryTimes).(int)
-	if retryTimes > 10 {
-		log.Warn("get region info", utils.ZapRegion(regionInfo.Region))
-	}
-	return false, nil
-}
-
-func waitForRemoveRejectStores(
-	ctx context.Context,
-	client SplitClient,
-	regionInfo *RegionInfo,
-	rejectStores map[uint64]bool,
-) bool {
-	interval := RejectStoreCheckInterval
-	regionID := regionInfo.Region.GetId()
-	for i := 0; i < RejectStoreCheckRetryTimes; i++ {
-		ctx1 := context.WithValue(ctx, retryTimes, i)
-		ok, err := hasRejectStorePeer(ctx1, client, regionID, rejectStores)
-		if err != nil {
-			log.Warn("wait for rejecting store failed",
-				utils.ZapRegion(regionInfo.Region),
-				zap.Error(err))
-			return false
-		}
-		// Do not have any peer in the rejected store, return true
-		if !ok {
-			return true
-		}
-		interval = 2 * interval
-		if interval > RejectStoreMaxCheckInterval {
-			interval = RejectStoreMaxCheckInterval
-		}
-		time.Sleep(interval)
-	}
-
-	return false
-}
-
 // ZapTables make zap field of table for debuging, including table names.
 func ZapTables(tables []CreatedTable) zapcore.Field {
 	tableNames := make([]string, 0, len(tables))

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -21,7 +21,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/pingcap/br/pkg/backup"
-	"github.com/pingcap/br/pkg/conn"
 	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/storage"
 	"github.com/pingcap/br/pkg/summary"
@@ -176,7 +175,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err != nil {
 		return err
 	}
-	mgr, err := newMgr(ctx, g, cfg.PD, cfg.TLS, conn.SkipTiFlash, cfg.CheckRequirements)
+	mgr, err := newMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/pingcap/br/pkg/backup"
-	"github.com/pingcap/br/pkg/conn"
 	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/rtree"
 	"github.com/pingcap/br/pkg/storage"
@@ -126,7 +125,7 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	if err != nil {
 		return err
 	}
-	mgr, err := newMgr(ctx, g, cfg.PD, cfg.TLS, conn.SkipTiFlash, cfg.CheckRequirements)
+	mgr, err := newMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -110,7 +110,6 @@ type Config struct {
 	Filter filter.MySQLReplicationRules
 
 	TableFilter        filter.Filter `json:"-" toml:"-"`
-	RemoveTiFlash      bool          `json:"remove-tiflash" toml:"remove-tiflash"`
 	CheckRequirements  bool          `json:"check-requirements" toml:"check-requirements"`
 	SwitchModeInterval time.Duration `json:"switch-mode-interval" toml:"switch-mode-interval"`
 }
@@ -137,6 +136,8 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 	flags.Uint64(flagRateLimitUnit, utils.MB, "The unit of rate limit")
 	_ = flags.MarkHidden(flagRateLimitUnit)
+	_ = flags.MarkDeprecated(flagRemoveTiFlash,
+		"TiFlash is fully supported by BR now, removing TiFlash isn't needed any more. This flag would be ignored.")
 
 	flags.Bool(flagCheckRequirement, true,
 		"Whether start version check before execute command")
@@ -221,11 +222,6 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	}
 	cfg.RateLimit = rateLimit * rateLimitUnit
 
-	cfg.RemoveTiFlash, err = flags.GetBool(flagRemoveTiFlash)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	var caseSensitive bool
 	if filterFlag := flags.Lookup(flagFilter); filterFlag != nil {
 		f, err := filter.Parse(filterFlag.Value.(pflag.SliceValue).GetSlice())
@@ -282,14 +278,10 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 }
 
 // newMgr creates a new mgr at the given PD address.
-func newMgr(
-	ctx context.Context,
-	g glue.Glue,
-	pds []string,
+func newMgr(ctx context.Context,
+	g glue.Glue, pds []string,
 	tlsConfig TLSConfig,
-	storeBehavior conn.StoreBehavior,
-	checkRequirements bool,
-) (*conn.Mgr, error) {
+	checkRequirements bool) (*conn.Mgr, error) {
 	var (
 		tlsConf *tls.Config
 		err     error
@@ -315,7 +307,12 @@ func newMgr(
 	if err != nil {
 		return nil, err
 	}
-	return conn.NewMgr(ctx, g, pdAddress, store.(tikv.Storage), tlsConf, securityOption, storeBehavior, checkRequirements)
+
+	// Is it necessary to remove `StoreBehavior`?
+	return conn.NewMgr(ctx, g,
+		pdAddress, store.(tikv.Storage),
+		tlsConf, securityOption,
+		conn.SkipTiFlash, checkRequirements)
 }
 
 // GetStorage gets the storage backend from the config.

--- a/pkg/task/restore_raw.go
+++ b/pkg/task/restore_raw.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/pingcap/br/pkg/conn"
 	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/restore"
 	"github.com/pingcap/br/pkg/summary"
@@ -51,7 +50,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
-	mgr, err := newMgr(ctx, g, cfg.PD, cfg.TLS, conn.ErrorOnTiFlash, cfg.CheckRequirements)
+	mgr, err := newMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/pd.go
+++ b/pkg/utils/pd.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/tikv/pd/pkg/codec"
@@ -112,4 +114,14 @@ func SearchPlacementRule(tableID int64, placementRules []placement.Rule, role pl
 		}
 	}
 	return nil
+}
+
+// IsTiFlash tests whether the store is based on tiflash engine.
+func IsTiFlash(store *metapb.Store) bool {
+	for _, label := range store.Labels {
+		if label.Key == "engine" && label.Value == "tiflash" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -97,6 +97,7 @@ func CheckClusterVersion(ctx context.Context, client pd.Client) error {
 	for _, s := range stores {
 		isTiFlash := IsTiFlash(s)
 		log.Debug("checking compatibility of store in cluster",
+			zap.Uint64("ID", s.GetId()),
 			zap.Bool("TiFlash?", isTiFlash),
 			zap.String("address", s.GetAddress()),
 			zap.String("version", s.GetVersion()),

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -95,7 +95,13 @@ func CheckClusterVersion(ctx context.Context, client pd.Client) error {
 		return errors.Trace(err)
 	}
 	for _, s := range stores {
-		if IsTiFlash(s) {
+		isTiFlash := IsTiFlash(s)
+		log.Debug("checking compatibility of store in cluster",
+			zap.Bool("TiFlash?", isTiFlash),
+			zap.String("address", s.GetAddress()),
+			zap.String("version", s.GetVersion()),
+		)
+		if isTiFlash {
 			if err := checkTiFlashVersion(s); err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: Hillium <maruruku@stu.csust.edu.cn>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Historically, we must remove all TiFlash nodes or the restore progress sticks. How ever, for now, TiFlash can support all RPCs BR needs.
The code handling TiFlash nodes costs and can bring many useless logs. It's time to remove it.

### What is changed and how it works?
I removed all (I hope) logic removing the TiFlash nodes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release Note

 - BR doesn't remove TiFlash nodes anymore.

<!-- fill in the release note, or just write "No release note" -->
