### PR TITLE
storage: fix walk dir file size

### DIFF
--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -57,7 +57,7 @@ func (l *LocalStorage) WalkDir(ctx context.Context, opt *WalkOption, fn func(str
 		size := f.Size()
 		// if not a regular file, we need to use os.stat to get the real file size
 		if !f.Mode().IsRegular() {
-			stat, err := os.Stat(path)
+			stat, err := os.Stat(filepath.Join(l.base, path))
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -53,7 +53,17 @@ func (l *LocalStorage) WalkDir(ctx context.Context, opt *WalkOption, fn func(str
 		// in mac osx, the path parameter is absolute path; in linux, the path is relative path to execution base dir,
 		// so use Rel to convert to relative path to l.base
 		path, _ = filepath.Rel(l.base, path)
-		return fn(path, f.Size())
+
+		size := f.Size()
+		// if not a regular file, we need to use os.stat to get the real file size
+		if !f.Mode().IsRegular() {
+			stat, err := os.Stat(path)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			size = stat.Size()
+		}
+		return fn(path, size)
 	})
 }
 

--- a/pkg/storage/local_test.go
+++ b/pkg/storage/local_test.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/pingcap/check"
+)
+
+type testLocalSuite struct{}
+
+var _ = Suite(&testLocalSuite{})
+
+func (r *testStorageSuite) TestWalkDirWithSoftLinkFile(c *C) {
+	dir1 := c.MkDir()
+	name1 := "test.warehouse.0.sql"
+	path1 := filepath.Join(dir1, name1)
+	f1, err := os.Create(path1)
+	c.Assert(err, IsNil)
+
+	data := "/* whatever pragmas */;" +
+		"INSERT INTO `namespaced`.`table` (columns, more, columns) VALUES (1,-2, 3),\n(4,5., 6);" +
+		"INSERT `namespaced`.`table` (x,y,z) VALUES (7,8,9);" +
+		"insert another_table values (10,11e1,12, '(13)', '(', 14, ')');"
+	_, err = f1.Write([]byte(data))
+	c.Assert(err, IsNil)
+	err = f1.Close()
+	c.Assert(err, IsNil)
+
+	dir2 := c.MkDir()
+	name2 := "test.warehouse.1.sql"
+	f2, err := os.Create(filepath.Join(dir2, name2))
+	c.Assert(err, IsNil)
+	_, err = f2.Write([]byte(data))
+	c.Assert(err, IsNil)
+	err = f2.Close()
+	c.Assert(err, IsNil)
+
+	err = os.Symlink(path1, filepath.Join(dir2, name1))
+	c.Assert(err, IsNil)
+
+	sb, err := ParseBackend(fmt.Sprintf("file://%s", dir2), &BackendOptions{})
+	c.Assert(err, IsNil)
+
+	store, err := Create(context.TODO(), sb, true)
+	c.Assert(err, IsNil)
+
+	i := 0
+	names := []string{name1, name2}
+	err = store.WalkDir(context.TODO(), &WalkOption{}, func(path string, size int64) error {
+		c.Assert(path, Equals, names[i])
+		c.Assert(size, Equals, int64(len(data)))
+		i++
+
+		return nil
+	})
+	c.Assert(err, IsNil)
+	c.Assert(i, Equals, 2)
+}

--- a/pkg/storage/local_test.go
+++ b/pkg/storage/local_test.go
@@ -1,3 +1,5 @@
+// Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
+
 package storage
 
 import (


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix local storage walk dir return invaild file size for soft link files

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 -

<!-- fill in the release note, or just write "No release note" -->
