### PR TITLE
backup,restore: fix panic when pd.GetRegion return nil

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -546,8 +546,8 @@ func (bc *Client) findRegionLeader(
 	for i := 0; i < 5; i++ {
 		// better backoff.
 		region, err := bc.mgr.GetPDClient().GetRegion(ctx, key)
-		if err != nil {
-			log.Error("find leader failed", zap.Error(err))
+		if err != nil || region == nil {
+			log.Error("find leader failed", zap.Error(err), zap.Reflect("region", region))
 			time.Sleep(time.Millisecond * time.Duration(100*i))
 			continue
 		}

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -273,8 +273,10 @@ func (importer *FileImporter) Import(
 						if errIngest != nil {
 							break ingestRetry
 						}
+						// do not get region info, wait a second and continue
 						if newInfo == nil {
-							errIngest = errors.Annotatef(ErrIngestFailed, "region '%d' not found", info.Region.Id)
+							log.Warn("get region by key return nil", zap.Reflect("region", info.Region))
+							time.Sleep(time.Second)
 							continue
 						}
 					}

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -270,7 +270,7 @@ func (importer *FileImporter) Import(
 						// Slow path, get region from PD
 						newInfo, errIngest = importer.metaClient.GetRegion(
 							ctx, info.Region.GetStartKey())
-						if errIngest != nil {
+						if errIngest != nil || newInfo == nil {
 							break ingestRetry
 						}
 					}

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -270,8 +270,12 @@ func (importer *FileImporter) Import(
 						// Slow path, get region from PD
 						newInfo, errIngest = importer.metaClient.GetRegion(
 							ctx, info.Region.GetStartKey())
-						if errIngest != nil || newInfo == nil {
+						if errIngest != nil {
 							break ingestRetry
+						}
+						if newInfo == nil {
+							errIngest = errors.Annotatef(ErrIngestFailed, "region '%d' not found", info.Region.Id)
+							continue
 						}
 					}
 					log.Debug("ingest sst returns not leader error, retry it",


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Check if pd.GetRegion return region value is nil to avoid panic

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

### Release Note

 -

<!-- fill in the release note, or just write "No release note" -->
