### PR TITLE
error: record store id when backup connection failed

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -818,7 +818,7 @@ func SendBackup(
 					zap.Uint64("StoreID", storeID))
 				break
 			}
-			return errors.Trace(err)
+			return errors.Annotatef(err, "Store: %d close the connection", storeID)
 		}
 		// TODO: handle errors in the resp.
 		log.Info("range backuped",


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
record store id when `cli.Recv()` failed, to reduce to the cost of debug TiKV node.

### What is changed and how it works?
add store id on return error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
