### PR TITLE
backup: add retry when tikv is down

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -784,7 +784,6 @@ func (bc *Client) handleFineGrained(
 		},
 		func() (kvproto.BackupClient, error) {
 			log.Warn("reset the connection in handleFineGrained", zap.Uint64("storeID", storeID))
-			time.Sleep(time.Second)
 			return bc.mgr.ResetBackupClient(ctx, storeID)
 		})
 	if err != nil {
@@ -821,6 +820,7 @@ backupLoop:
 		})
 		if err != nil {
 			if isRetryableError(err) {
+				time.Sleep(3 * time.Second)
 				client, errReset = resetFn()
 				if errReset != nil {
 					return errors.Annotatef(errReset, "failed to reset backup connection on store:%d "+
@@ -843,6 +843,7 @@ backupLoop:
 					break backupLoop
 				}
 				if isRetryableError(err) {
+					time.Sleep(3 * time.Second)
 					// current tikv is unavailable
 					client, errReset = resetFn()
 					if errReset != nil {

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -825,14 +825,15 @@ backupLoop:
 						zap.Int("retry time", retry))
 					break backupLoop
 				}
+				var errReset error
 				if isRetryableError(err) {
 					// current tikv is unavailable
 					log.Warn("current tikv is not available, reset the connection",
 						zap.Uint64("storeID", storeID), zap.Int("retry time", retry))
 					time.Sleep(time.Duration(retry+1) * time.Second)
-					client, err = resetFn()
-					if err != nil {
-						return errors.Annotatef(err, "failed to reset connection on store:%d "+
+					client, errReset = resetFn()
+					if errReset != nil {
+						return errors.Annotatef(errReset, "failed to reset connection on store:%d "+
 							"please check the tikv status", storeID)
 					}
 					break

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -825,7 +825,7 @@ backupLoop:
 					// current tikv is unavailable
 					log.Warn("current tikv is not available, reset the connection",
 						zap.Uint64("storeID", storeID), zap.Int("retry time", retry))
-					time.Sleep(time.Duration(retry + 1) * time.Second)
+					time.Sleep(time.Duration(retry+1) * time.Second)
 					client, err = resetFn()
 					if err != nil {
 						log.Error("reset the connection failed, please check the tikv status",

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -813,9 +813,11 @@ backupLoop:
 			zap.Int("retry time", retry),
 		)
 		bcli, err := client.Backup(ctx, &req)
-		failpoint.Inject("reset-retryable-error", func() {
-			log.Debug("failpoint reset-retryable-error injected.")
-			err = status.Errorf(codes.Unavailable, "Unavailable error")
+		failpoint.Inject("reset-retryable-error", func(val failpoint.Value) {
+			if val.(bool) {
+				log.Debug("failpoint reset-retryable-error injected.")
+				err = status.Errorf(codes.Unavailable, "Unavailable error")
+			}
 		})
 		if err != nil {
 			if isRetryableError(err) {

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -811,13 +811,9 @@ backupLoop:
 		)
 		bcli, err := client.Backup(ctx, &req)
 		if err != nil {
-			if isRetryableError(err) {
-				continue
-			} else {
-				log.Error("fail to backup", zap.Uint64("StoreID", storeID),
-					zap.Int("retry time", retry))
-				return err
-			}
+			log.Error("fail to backup", zap.Uint64("StoreID", storeID),
+				zap.Int("retry time", retry))
+			return errors.Trace(err)
 		}
 
 		for {
@@ -957,5 +953,5 @@ func CollectChecksums(backupMeta *kvproto.BackupMeta) ([]Checksum, error) {
 
 // isRetryableError represents whether we should retry reset grpc connection
 func isRetryableError(err error) bool {
-	return status.Code(err) == codes.Unavailable || status.Code(err) == codes.Canceled
+	return status.Code(err) == codes.Unavailable
 }

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -815,7 +815,7 @@ backupLoop:
 		bcli, err := client.Backup(ctx, &req)
 		failpoint.Inject("reset-retryable-error", func() {
 			log.Debug("failpoint reset-retryable-error injected.")
-			err = status.Errorf(codes.Unavailable, "unavaliable error")
+			err = status.Errorf(codes.Unavailable, "Unavailable error")
 		})
 		if err != nil {
 			if isRetryableError(err) {

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -65,7 +65,7 @@ func (push *pushDown) pushBackup(
 				},
 				func() (backup.BackupClient, error) {
 					log.Info("reset the connection in push", zap.Uint64("storeID", storeID))
-					return push.mgr.ResetBackupClient(push.ctx, storeID)
+					return push.mgr.ResetBackupClient(ctx, storeID)
 				})
 			if err != nil {
 				push.errCh <- err

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -5,6 +5,7 @@ package backup
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/backup"
@@ -64,7 +65,8 @@ func (push *pushDown) pushBackup(
 					return nil
 				},
 				func() (backup.BackupClient, error) {
-					log.Info("reset the connection in push", zap.Uint64("storeID", storeID))
+					log.Warn("reset the connection in push", zap.Uint64("storeID", storeID))
+					time.Sleep(3 * time.Second)
 					return push.mgr.ResetBackupClient(ctx, storeID)
 				})
 			if err != nil {

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -5,7 +5,6 @@ package backup
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/backup"
@@ -66,7 +65,6 @@ func (push *pushDown) pushBackup(
 				},
 				func() (backup.BackupClient, error) {
 					log.Warn("reset the connection in push", zap.Uint64("storeID", storeID))
-					time.Sleep(3 * time.Second)
 					return push.mgr.ResetBackupClient(ctx, storeID)
 				})
 			if err != nil {

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -62,6 +62,10 @@ func (push *pushDown) pushBackup(
 					// Forward all responses (including error).
 					push.respCh <- resp
 					return nil
+				},
+				func() (backup.BackupClient, error) {
+					log.Info("reset the connection in push", zap.Uint64("storeID", storeID))
+					return push.mgr.ResetBackupClient(push.ctx, storeID)
 				})
 			if err != nil {
 				push.errCh <- err

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -389,7 +389,7 @@ func (mgr *Mgr) ResetBackupClient(ctx context.Context, storeID uint64) (backup.B
 	)
 	for retry := 0; retry < resetRetryTimes; retry++ {
 		conn, err = mgr.getGrpcConnLocked(ctx, storeID)
-		if err != nil && retry < resetRetryTimes {
+		if err != nil {
 			log.Warn("failed to reset grpc connection, retry it",
 				zap.Int("retry time", retry), zap.Error(err))
 			time.Sleep(time.Duration(retry+3) * time.Second)
@@ -398,7 +398,10 @@ func (mgr *Mgr) ResetBackupClient(ctx context.Context, storeID uint64) (backup.B
 		mgr.grpcClis.clis[storeID] = conn
 		break
 	}
-	return backup.NewBackupClient(conn), err
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return backup.NewBackupClient(conn), nil
 }
 
 // GetPDClient returns a pd client.

--- a/tests/br_full/run.sh
+++ b/tests/br_full/run.sh
@@ -30,23 +30,9 @@ done
 
 # backup full and kill tikv to test reset connection
 echo "backup with limit start..."
-run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-limit" --ratelimit 5 --concurrency 4 --ratelimit-unit 1024 &
-br_pid=$!
-
-# wait br start to backup
-sleep 1
-# record tikv pid
-tikv_pid=$(ps -ef | grep tikv-server | grep -v grep | awk '{print $2}')
-kill -9 $tikv_pid
-
-if ps -p $br_pid > /dev/null
-then
-   echo "$br_pid is running"
-   wait $br_pid
-else
-   echo "TEST: [$TEST_NAME] test backup reset connection failed! the backup shouldn't finished"
-   exit 1
-fi
+GO_FAILPOINTS="github.com/pingcap/br/pkg/backup/reset-retryable-error"
+run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-limit" --ratelimit 5 --concurrency 4 --ratelimit-unit 1024
+GO_FAILPOINTS=""
 
 # backup full
 echo "backup with lz4 start..."

--- a/tests/br_full/run.sh
+++ b/tests/br_full/run.sh
@@ -30,17 +30,17 @@ done
 
 # backup full and kill tikv to test reset connection
 echo "backup with limit start..."
-GO_FAILPOINTS="github.com/pingcap/br/pkg/backup/reset-retryable-error"
-run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-limit" --ratelimit 5 --concurrency 4 --ratelimit-unit 1024
-GO_FAILPOINTS=""
+export GO_FAILPOINTS="github.com/pingcap/br/pkg/backup/reset-retryable-error=1*return(true)"
+run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-limit" --concurrency 4
+export GO_FAILPOINTS=""
 
 # backup full
 echo "backup with lz4 start..."
-run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-lz4" --ratelimit 5 --concurrency 4 --compression lz4
+run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-lz4" --concurrency 4 --compression lz4
 size_lz4=$(du -d 0 $TEST_DIR/$DB-lz4 | awk '{print $1}')
 
 echo "backup with zstd start..."
-run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-zstd" --ratelimit 5 --concurrency 4 --compression zstd --compression-level 6
+run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-zstd" --concurrency 4 --compression zstd --compression-level 6
 size_zstd=$(du -d 0 $TEST_DIR/$DB-zstd | awk '{print $1}')
 
 if [ "$size_lz4" -le "$size_zstd" ]; then


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
reset connection when tikv is down during backup.

### What is changed and how it works?
add reset function for client.Mgr

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
