### PR TITLE
[cherry-pick] restore: restore tidb config after restoring(#509)

### DIFF
--- a/pkg/task/common_test.go
+++ b/pkg/task/common_test.go
@@ -5,6 +5,8 @@ package task
 import (
 	"fmt"
 
+	"github.com/pingcap/tidb/config"
+
 	. "github.com/pingcap/check"
 	"github.com/spf13/pflag"
 )
@@ -36,4 +38,12 @@ func (*testCommonSuite) TestUrlNoQuery(c *C) {
 	field := flagToZapField(flag)
 	c.Assert(field.Key, Equals, flagStorage)
 	c.Assert(field.Interface.(fmt.Stringer).String(), Equals, "s3://some/what")
+}
+
+func (s *testCommonSuite) TestTiDBConfigUnchanged(c *C) {
+	cfg := config.GetGlobalConfig()
+	restoreConfig := enableTiDBConfig()
+	c.Assert(cfg, Not(DeepEquals), config.GetGlobalConfig())
+	restoreConfig()
+	c.Assert(cfg, DeepEquals, config.GetGlobalConfig())
 }

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -154,7 +154,8 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	ddlJobs := restore.FilterDDLJobs(client.GetDDLJobs(), tables)
 
 	// pre-set TiDB config for restore
-	enableTiDBConfig()
+	restoreDBConfig := enableTiDBConfig()
+	defer restoreDBConfig()
 
 	// execute DDL first
 	err = client.ExecDDLs(ddlJobs)
@@ -413,21 +414,23 @@ func RunRestoreTiflashReplica(c context.Context, g glue.Glue, cmdName string, cf
 	return nil
 }
 
-func enableTiDBConfig() {
-	// set max-index-length before execute DDLs and create tables
-	// we set this value to max(3072*4), otherwise we might not restore table
-	// when upstream and downstream both set this value greater than default(3072)
-	conf := config.GetGlobalConfig()
-	conf.MaxIndexLength = config.DefMaxOfMaxIndexLength
-	log.Warn("set max-index-length to max(3072*4) to skip check index length in DDL")
+// enableTiDBConfig tweaks some of configs of TiDB to make the restore progress go well.
+// return a function that could restore the config to origin.
+func enableTiDBConfig() func() {
+	restoreConfig := config.RestoreFunc()
+	config.UpdateGlobal(func(conf *config.Config) {
+		// set max-index-length before execute DDLs and create tables
+		// we set this value to max(3072*4), otherwise we might not restore table
+		// when upstream and downstream both set this value greater than default(3072)
+		conf.MaxIndexLength = config.DefMaxOfMaxIndexLength
+		log.Warn("set max-index-length to max(3072*4) to skip check index length in DDL")
 
-	// we need set this to true, since all create table DDLs will create with tableInfo
-	// and we can handle alter drop pk/add pk DDLs with no impact
-	conf.AlterPrimaryKey = true
+		// we need set this to true, since all create table DDLs will create with tableInfo
+		// and we can handle alter drop pk/add pk DDLs with no impact
+		conf.AlterPrimaryKey = true
+	})
 
-	conf.Experimental.AllowsExpressionIndex = true
-
-	config.StoreGlobalConfig(conf)
+	return restoreConfig
 }
 
 // restoreTableStream blocks current goroutine and restore a stream of tables,

--- a/tests/br_full/run.sh
+++ b/tests/br_full/run.sh
@@ -17,6 +17,7 @@ set -eu
 DB="$TEST_NAME"
 TABLE="usertable"
 DB_COUNT=3
+old_conf=$(run_sql "show config where name = 'alter-primary-key'")
 
 for i in $(seq $DB_COUNT); do
     run_sql "CREATE DATABASE $DB${i};"
@@ -70,6 +71,9 @@ for ct in lz4 zstd; do
       echo "TEST: [$TEST_NAME] successed!"
   fi
 done
+
+# test whether we have changed the cluster config.
+test "$old_conf" = "$(run_sql "show config where name = 'alter-primary-key'")"
 
 for i in $(seq $DB_COUNT); do
     run_sql "DROP DATABASE $DB${i};"


### PR DESCRIPTION
cherry-picking #509

=== 

Signed-off-by: Hillium <maruruku@stu.csust.edu.cn>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
half-fixed [tidb#20037](https://github.com/pingcap/tidb/issues/20037)

### What is changed and how it works?
we restore the changed config after restoring.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
<img width="763" alt="image" src="https://user-images.githubusercontent.com/36239017/93412778-6c2d1000-f8d0-11ea-9675-e6b7943c110b.png">


### Release Note

 - fix a bug that caused the TiDB config changed after restoring

<!-- fill in the release note, or just write "No release note" -->