### PR TITLE
[cherry-pick] backup: add retry when tikv is down (#508)

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/btree"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	kvproto "github.com/pingcap/kvproto/pkg/backup"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
@@ -31,6 +32,8 @@ import (
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/br/pkg/conn"
 	"github.com/pingcap/br/pkg/glue"
@@ -43,6 +46,7 @@ import (
 // ClientMgr manages connections needed by backup.
 type ClientMgr interface {
 	GetBackupClient(ctx context.Context, storeID uint64) (kvproto.BackupClient, error)
+	ResetBackupClient(ctx context.Context, storeID uint64) (kvproto.BackupClient, error)
 	GetPDClient() pd.Client
 	GetTiKV() tikv.Storage
 	GetLockResolver() *tikv.LockResolver
@@ -59,6 +63,7 @@ type Checksum struct {
 // Maximum total sleep time(in ms) for kv/cop commands.
 const (
 	backupFineGrainedMaxBackoff = 80000
+	backupRetryTimes            = 5
 )
 
 // Client is a client instructs TiKV how to do a backup.
@@ -780,6 +785,10 @@ func (bc *Client) handleFineGrained(
 				respCh <- response
 			}
 			return nil
+		},
+		func() (kvproto.BackupClient, error) {
+			log.Warn("reset the connection in handleFineGrained", zap.Uint64("storeID", storeID))
+			return bc.mgr.ResetBackupClient(ctx, storeID)
 		})
 	if err != nil {
 		return 0, err
@@ -795,36 +804,70 @@ func SendBackup(
 	client kvproto.BackupClient,
 	req kvproto.BackupRequest,
 	respFn func(*kvproto.BackupResponse) error,
+	resetFn func() (kvproto.BackupClient, error),
 ) error {
-	log.Info("try backup",
-		zap.Stringer("StartKey", utils.WrapKey(req.StartKey)),
-		zap.Stringer("EndKey", utils.WrapKey(req.EndKey)),
-		zap.Uint64("storeID", storeID),
-	)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	bcli, err := client.Backup(ctx, &req)
-	if err != nil {
-		log.Error("fail to backup", zap.Uint64("StoreID", storeID))
-		return err
-	}
-	for {
-		resp, err := bcli.Recv()
-		if err != nil {
-			if err == io.EOF {
-				log.Info("backup streaming finish",
-					zap.Uint64("StoreID", storeID))
-				break
+	var errReset error
+backupLoop:
+	for retry := 0; retry < backupRetryTimes; retry++ {
+		log.Info("try backup",
+			zap.Stringer("StartKey", utils.WrapKey(req.StartKey)),
+			zap.Stringer("EndKey", utils.WrapKey(req.EndKey)),
+			zap.Uint64("storeID", storeID),
+			zap.Int("retry time", retry),
+		)
+		bcli, err := client.Backup(ctx, &req)
+		failpoint.Inject("reset-retryable-error", func(val failpoint.Value) {
+			if val.(bool) {
+				log.Debug("failpoint reset-retryable-error injected.")
+				err = status.Errorf(codes.Unavailable, "Unavailable error")
 			}
-			return errors.Annotatef(err, "Store: %d close the connection", storeID)
-		}
-		// TODO: handle errors in the resp.
-		log.Info("range backuped",
-			zap.Stringer("StartKey", utils.WrapKey(resp.GetStartKey())),
-			zap.Stringer("EndKey", utils.WrapKey(resp.GetEndKey())))
-		err = respFn(resp)
+		})
 		if err != nil {
-			return err
+			if isRetryableError(err) {
+				time.Sleep(3 * time.Second)
+				client, errReset = resetFn()
+				if errReset != nil {
+					return errors.Annotatef(errReset, "failed to reset backup connection on store:%d "+
+						"please check the tikv status", storeID)
+				}
+				continue
+			}
+			log.Error("fail to backup", zap.Uint64("StoreID", storeID),
+				zap.Int("retry time", retry))
+			return errors.Trace(err)
+		}
+
+		for {
+			resp, err := bcli.Recv()
+			if err != nil {
+				if err == io.EOF {
+					log.Info("backup streaming finish",
+						zap.Uint64("StoreID", storeID),
+						zap.Int("retry time", retry))
+					break backupLoop
+				}
+				if isRetryableError(err) {
+					time.Sleep(3 * time.Second)
+					// current tikv is unavailable
+					client, errReset = resetFn()
+					if errReset != nil {
+						return errors.Annotatef(errReset, "failed to reset recv connection on store:%d "+
+							"please check the tikv status", storeID)
+					}
+					break
+				}
+				return errors.Annotatef(err, "failed to connect to store: %d with retry times:%d", storeID, retry)
+			}
+			// TODO: handle errors in the resp.
+			log.Info("range backuped",
+				zap.Stringer("StartKey", utils.WrapKey(resp.GetStartKey())),
+				zap.Stringer("EndKey", utils.WrapKey(resp.GetEndKey())))
+			err = respFn(resp)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -956,4 +999,9 @@ func FilterSchema(backupMeta *kvproto.BackupMeta) error {
 	}
 	backupMeta.Schemas = schemas
 	return nil
+}
+
+// isRetryableError represents whether we should retry reset grpc connection.
+func isRetryableError(err error) bool {
+	return status.Code(err) == codes.Unavailable || status.Code(err) == codes.Canceled
 }

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -64,6 +64,10 @@ func (push *pushDown) pushBackup(
 					// Forward all responses (including error).
 					push.respCh <- resp
 					return nil
+				},
+				func() (backup.BackupClient, error) {
+					log.Warn("reset the connection in push", zap.Uint64("storeID", storeID))
+					return push.mgr.ResetBackupClient(push.ctx, storeID)
 				})
 			if err != nil {
 				push.errCh <- err

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -36,12 +36,14 @@ import (
 )
 
 const (
-	dialTimeout          = 5 * time.Second
+	dialTimeout          = 30 * time.Second
 	clusterVersionPrefix = "pd/api/v1/config/cluster-version"
 	regionCountPrefix    = "pd/api/v1/stats/region"
 	schdulerPrefix       = "pd/api/v1/schedulers"
 	maxMsgSize           = int(128 * utils.MB) // pd.ScanRegion may return a large response
 	scheduleConfigPrefix = "pd/api/v1/config/schedule"
+
+	resetRetryTimes = 3
 )
 
 // Mgr manages connections to a TiDB cluster.
@@ -331,6 +333,7 @@ func (mgr *Mgr) getGrpcConnLocked(ctx context.Context, storeID uint64) (*grpc.Cl
 		ctx,
 		addr,
 		opt,
+		grpc.WithBlock(),
 		grpc.WithConnectParams(grpc.ConnectParams{Backoff: bfConf}),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:    time.Duration(keepAlive) * time.Second,
@@ -341,8 +344,6 @@ func (mgr *Mgr) getGrpcConnLocked(ctx context.Context, storeID uint64) (*grpc.Cl
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	// Cache the conn.
-	mgr.grpcClis.clis[storeID] = conn
 	return conn, nil
 }
 
@@ -357,6 +358,43 @@ func (mgr *Mgr) GetBackupClient(ctx context.Context, storeID uint64) (backup.Bac
 	}
 
 	conn, err := mgr.getGrpcConnLocked(ctx, storeID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// Cache the conn.
+	mgr.grpcClis.clis[storeID] = conn
+	return backup.NewBackupClient(conn), nil
+}
+
+// ResetBackupClient reset the connection for backup client.
+func (mgr *Mgr) ResetBackupClient(ctx context.Context, storeID uint64) (backup.BackupClient, error) {
+	mgr.grpcClis.mu.Lock()
+	defer mgr.grpcClis.mu.Unlock()
+
+	if conn, ok := mgr.grpcClis.clis[storeID]; ok {
+		// Find a cached backup client.
+		log.Info("Reset backup client", zap.Uint64("storeID", storeID))
+		err := conn.Close()
+		if err != nil {
+			log.Warn("close backup connection failed, ignore it", zap.Uint64("storeID", storeID))
+		}
+		delete(mgr.grpcClis.clis, storeID)
+	}
+	var (
+		conn *grpc.ClientConn
+		err  error
+	)
+	for retry := 0; retry < resetRetryTimes; retry++ {
+		conn, err = mgr.getGrpcConnLocked(ctx, storeID)
+		if err != nil {
+			log.Warn("failed to reset grpc connection, retry it",
+				zap.Int("retry time", retry), zap.Error(err))
+			time.Sleep(time.Duration(retry+3) * time.Second)
+			continue
+		}
+		mgr.grpcClis.clis[storeID] = conn
+		break
+	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
cherry-pick #508 to release-4.0
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
reset connection when tikv is down during backup.

### What is changed and how it works?
add reset function for client.Mgr

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
