### PR TITLE
adjust rawURL to local path if no u.Schema is given

### DIFF
--- a/pkg/storage/parse.go
+++ b/pkg/storage/parse.go
@@ -4,6 +4,7 @@ package storage
 
 import (
 	"net/url"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -32,7 +33,12 @@ func ParseBackend(rawURL string, options *BackendOptions) (*backup.StorageBacken
 	}
 	switch u.Scheme {
 	case "":
-		return nil, errors.Errorf("please specify the storage type (e.g. --storage 'local://%s')", u.Path)
+		absPath, err := filepath.Abs(rawURL)
+		if err != nil {
+			return nil, errors.Annotatef(err, "covert data-source-dir '%s' to absolute path failed", rawURL)
+		}
+		local := &backup.Local{Path: absPath}
+		return &backup.StorageBackend{Backend: &backup.StorageBackend_Local{Local: local}}, nil
 
 	case "local", "file":
 		local := &backup.Local{Path: u.Path}

--- a/pkg/storage/parse_test.go
+++ b/pkg/storage/parse_test.go
@@ -106,8 +106,11 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	c.Assert(gcs.Prefix, Equals, "backup/")
 	c.Assert(gcs.CredentialsBlob, Equals, "fakeCreds2")
 
-	_, err = ParseBackend("/test", nil)
+	s, err = ParseBackend("/test", nil)
 	c.Assert(err, IsNil)
+	local := s.GetLocal()
+	c.Assert(local, NotNil)
+	c.Assert(local.GetPath(), Equals, "/test")
 }
 
 func (r *testStorageSuite) TestFormatBackendURL(c *C) {

--- a/pkg/storage/parse_test.go
+++ b/pkg/storage/parse_test.go
@@ -105,6 +105,9 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	c.Assert(gcs.Bucket, Equals, "bucket4")
 	c.Assert(gcs.Prefix, Equals, "backup/")
 	c.Assert(gcs.CredentialsBlob, Equals, "fakeCreds2")
+
+	_, err = ParseBackend("/test", nil)
+	c.Assert(err, IsNil)
 }
 
 func (r *testStorageSuite) TestFormatBackendURL(c *C) {


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. If we don't specify for `rawURL`, it will return an error. 
2. If we use a relative path for `rawURL`, it will return a wrong path.

### What is changed and how it works?
1. adjust rawURL to local path if no u.Schema is given
2. Use `filepath.Abs` to make sure path is transferred.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
