### PR TITLE
raw_restore: set concurrency to default when no config here

### DIFF
--- a/pkg/task/restore_raw.go
+++ b/pkg/task/restore_raw.go
@@ -44,8 +44,16 @@ func (cfg *RestoreRawConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 	return cfg.RawKvConfig.ParseFromFlags(flags)
 }
 
+func (cfg *RestoreRawConfig) adjust() {
+	if cfg.Concurrency == 0 {
+		cfg.Concurrency = defaultRestoreConcurrency
+	}
+}
+
 // RunRestoreRaw starts a raw kv restore task inside the current goroutine.
 func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreRawConfig) (err error) {
+	cfg.adjust()
+
 	defer summary.Summary(cmdName)
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()

--- a/tests/br_rawkv/run.sh
+++ b/tests/br_rawkv/run.sh
@@ -58,7 +58,7 @@ fi
 
 # restore rawkv
 echo "restore start..."
-run_br --pd $PD_ADDR restore raw -s "local://$TEST_DIR/$BACKUP_DIR" --start 31 --end 3130303030303030 --format hex --concurrency 4
+run_br --pd $PD_ADDR restore raw -s "local://$TEST_DIR/$BACKUP_DIR" --start 31 --end 3130303030303030 --format hex
 
 checksum_new=$(checksum 31 3130303030303030)
 


### PR DESCRIPTION
Signed-off-by: Hillium <maruruku@stu.csust.edu.cn>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When we don't provide the `concurrency` config in raw restoring, the `file` worker pool size would be 0, and then block all the restore process.

probably relative to #534 

### What is changed and how it works?
Set concurrency to default when no config here.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release Note

 - Fixed a bug that caused restoring blocks when no `concurrency` provided.

<!-- fill in the release note, or just write "No release note" -->
