### PR TITLE
Support the AWS_REGION env var

### DIFF
--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -228,8 +228,10 @@ func NewS3Storage( // revive:disable-line:flag-parameter
 	qs := *backend
 	awsConfig := aws.NewConfig().
 		WithMaxRetries(maxRetries).
-		WithS3ForcePathStyle(qs.ForcePathStyle).
-		WithRegion(qs.Region)
+		WithS3ForcePathStyle(qs.ForcePathStyle)
+	if qs.Region != "" {
+		awsConfig.WithRegion(qs.Region)
+	}
 	if qs.Endpoint != "" {
 		awsConfig.WithEndpoint(qs.Endpoint)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Only override the region if it has been explicitly set, otherwise we clobber the standard AWS_REGION env var

https://github.com/pingcap/dumpling/pull/155#issuecomment-700136706

### What is changed and how it works?

Support the standard AWS_REGION env var


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

