### PR TITLE
conn,task: add config about keepalive

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -341,7 +341,7 @@ func setPDConfigCommand() *cobra.Command {
 				return err
 			}
 
-			mgr, err := task.NewMgr(ctx, tidbGlue, cfg.PD, cfg.TLS, cfg.CheckRequirements)
+			mgr, err := task.NewMgr(ctx, tidbGlue, cfg.PD, cfg.TLS, task.GetKeepalive(&cfg), cfg.CheckRequirements)
 			if err != nil {
 				return err
 			}

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -148,6 +148,7 @@ func parseCompressionFlags(flags *pflag.FlagSet) (*CompressionConfig, error) {
 // we should set proper value in this function.
 // so that both binary and TiDB will use same default value.
 func (cfg *BackupConfig) adjustBackupConfig() {
+	cfg.adjust()
 	if cfg.Config.Concurrency == 0 {
 		cfg.Config.Concurrency = defaultBackupConcurrency
 	}

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -176,7 +176,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err != nil {
 		return err
 	}
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -118,6 +118,8 @@ func (cfg *RawKvConfig) ParseBackupConfigFromFlags(flags *pflag.FlagSet) error {
 
 // RunBackupRaw starts a backup task inside the current goroutine.
 func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConfig) error {
+	cfg.adjust()
+
 	defer summary.Summary(cmdName)
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -126,7 +126,7 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	if err != nil {
 		return err
 	}
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -159,6 +159,8 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 		"the interval of pinging the server, must keep same value with TiKV and PD")
 	flags.Duration(flagGrpcKeepaliveTimeout, defaultGRPCKeepaliveTimeout,
 		"the max time a grpc conn can keep idel before killed, must keep same value with TiKV and PD")
+	_ = flags.MarkHidden(flagGrpcKeepaliveTime)
+	_ = flags.MarkHidden(flagGrpcKeepaliveTimeout)
 
 	storage.DefineFlags(flags)
 }

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -413,3 +413,14 @@ func GetKeepalive(cfg *Config) keepalive.ClientParameters {
 		Timeout: cfg.GRPCKeepaliveTimeout,
 	}
 }
+
+// adjust adjusts the abnormal config value in the current config.
+// useful when not starting BR from CLI (e.g. from BRIE in SQL).
+func (cfg *Config) adjust() {
+	if cfg.GRPCKeepaliveTime == 0 {
+		cfg.GRPCKeepaliveTime = defaultGRPCKeepaliveTime
+	}
+	if cfg.GRPCKeepaliveTimeout == 0 {
+		cfg.GRPCKeepaliveTimeout = defaultGRPCKeepaliveTimeout
+	}
+}

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -106,11 +106,6 @@ type Config struct {
 	// LogProgress is true means the progress bar is printed to the log instead of stdout.
 	LogProgress bool `json:"log-progress" toml:"log-progress"`
 
-	// GrpcKeepaliveTime is the interval of pinging the server.
-	GRPCKeepaliveTime time.Duration `json:"grpc-keepalive-time" toml:"grpc-keepalive-time"`
-	// GrpcKeepaliveTimeout is the max time a grpc conn can keep idel before killed.
-	GRPCKeepaliveTimeout time.Duration `json:"grpc-keepalive-timeout" toml:"grpc-keepalive-timeout"`
-
 	// CaseSensitive should not be used.
 	//
 	// Deprecated: This field is kept only to satisfy the cyclic dependency with TiDB. This field
@@ -125,6 +120,11 @@ type Config struct {
 	TableFilter        filter.Filter `json:"-" toml:"-"`
 	CheckRequirements  bool          `json:"check-requirements" toml:"check-requirements"`
 	SwitchModeInterval time.Duration `json:"switch-mode-interval" toml:"switch-mode-interval"`
+
+	// GrpcKeepaliveTime is the interval of pinging the server.
+	GRPCKeepaliveTime time.Duration `json:"grpc-keepalive-time" toml:"grpc-keepalive-time"`
+	// GrpcKeepaliveTimeout is the max time a grpc conn can keep idel before killed.
+	GRPCKeepaliveTimeout time.Duration `json:"grpc-keepalive-timeout" toml:"grpc-keepalive-timeout"`
 }
 
 // DefineCommonFlags defines the flags common to all BRIE commands.
@@ -404,7 +404,7 @@ func LogArguments(cmd *cobra.Command) {
 	log.Info("arguments", fields...)
 }
 
-// GetKeepalive get the keepalive info from the config
+// GetKeepalive get the keepalive info from the config.
 func GetKeepalive(cfg *Config) keepalive.ClientParameters {
 	return keepalive.ClientParameters{
 		Time:    cfg.GRPCKeepaliveTime,

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -156,9 +156,9 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 		"Whether start version check before execute command")
 	flags.Duration(flagSwitchModeInterval, defaultSwitchInterval, "maintain import mode on TiKV during restore")
 	flags.Duration(flagGrpcKeepaliveTime, defaultGRPCKeepaliveTime,
-		"the interval of pinging the server, must keep same value with TiKV and PD")
+		"the interval of pinging gRPC peer, must keep the same value with TiKV and PD")
 	flags.Duration(flagGrpcKeepaliveTimeout, defaultGRPCKeepaliveTimeout,
-		"the max time a grpc conn can keep idel before killed, must keep same value with TiKV and PD")
+		"the max time a gRPC connection can keep idle before killed, must keep the same value with TiKV and PD")
 	_ = flags.MarkHidden(flagGrpcKeepaliveTime)
 	_ = flags.MarkHidden(flagGrpcKeepaliveTimeout)
 

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -94,7 +94,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}
@@ -370,7 +370,7 @@ func RunRestoreTiflashReplica(c context.Context, g glue.Glue, cmdName string, cf
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -78,6 +78,8 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 // we should set proper value in this function.
 // so that both binary and TiDB will use same default value.
 func (cfg *RestoreConfig) adjustRestoreConfig() {
+	cfg.adjust()
+
 	if cfg.Config.Concurrency == 0 {
 		cfg.Config.Concurrency = defaultRestoreConcurrency
 	}

--- a/pkg/task/restore_log.go
+++ b/pkg/task/restore_log.go
@@ -72,6 +72,8 @@ func (cfg *LogRestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 // we should set proper value in this function.
 // so that both binary and TiDB will use same default value.
 func (cfg *LogRestoreConfig) adjustRestoreConfig() {
+	cfg.adjust()
+
 	if cfg.Config.Concurrency == 0 {
 		cfg.Config.Concurrency = defaultRestoreConcurrency
 	}

--- a/pkg/task/restore_log.go
+++ b/pkg/task/restore_log.go
@@ -97,7 +97,7 @@ func RunLogRestore(c context.Context, g glue.Glue, cfg *LogRestoreConfig) error 
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/restore_raw.go
+++ b/pkg/task/restore_raw.go
@@ -47,6 +47,8 @@ func (cfg *RestoreRawConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 }
 
 func (cfg *RestoreRawConfig) adjust() {
+	cfg.Config.adjust()
+
 	if cfg.Concurrency == 0 {
 		cfg.Concurrency = defaultRestoreConcurrency
 	}

--- a/pkg/task/restore_raw.go
+++ b/pkg/task/restore_raw.go
@@ -60,7 +60,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, cfg.CheckRequirements)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently, keepalive time and timeout in both TiKV and TiDB are configurable. According to the `keepalive.ClientParameters`:

> Make sure these parameters are set in coordination with the keepalive policy on the server, as incompatible settings can result in closing of connection.

We should make those variables in BR configurable too so when they are changed, BR won't make confusing behavior.

### What is changed and how it works?
Added two flags: `grpc-keepalive-time` and `grpc-keepalive-timeout`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test 

### Release Note

 - Added config `grpc-keepalive-time` and `grpc-keepalive-timeout`.

<!-- fill in the release note, or just write "No release note" -->
