### PR TITLE
Refactor uploaderWriter to have a context

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -35,14 +35,6 @@ type Uploader interface {
 	CompleteUpload(ctx context.Context) error
 }
 
-// Writer is like io.Writer but with Context, create a new writer on top of Uploader with NewUploaderWriter.
-type Writer interface {
-	// Write writes to buffer and if chunk is filled will upload it
-	Write(ctx context.Context, p []byte) (int, error)
-	// Close writes final chunk and completes the upload
-	Close(ctx context.Context) error
-}
-
 // ExternalStorage represents a kind of file system storage.
 type ExternalStorage interface {
 	// Write file to storage

--- a/pkg/storage/writer_test.go
+++ b/pkg/storage/writer_test.go
@@ -29,14 +29,14 @@ func (r *testStorageSuite) TestUploaderWriter(c *C) {
 		fileName := strings.ReplaceAll(test.name, " ", "-") + ".txt"
 		uploader, err := storage.CreateUploader(ctx, fileName)
 		c.Assert(err, IsNil)
-		writer := newUploaderWriter(uploader, test.chunkSize)
+		writer := newUploaderWriter(ctx, uploader, test.chunkSize)
 		for _, str := range test.content {
 			p := []byte(str)
-			written, err2 := writer.Write(ctx, p)
+			written, err2 := writer.Write(p)
 			c.Assert(err2, IsNil)
 			c.Assert(written, Equals, len(p))
 		}
-		err = writer.Close(ctx)
+		err = writer.Close()
 		c.Assert(err, IsNil)
 		content, err := ioutil.ReadFile(filepath.Join(dir, fileName))
 		c.Assert(err, IsNil)


### PR DESCRIPTION
If we instead have a context as a struct field we can fully implement the io.Writer and io.Closer interfaces correctly which makes things much more flexible. This makes it match the s3ObjectReader which uses the same technique to implement io.Reader.
