### PR TITLE
*: strip PD urls with http or https

### DIFF
--- a/pkg/restore/split_client.go
+++ b/pkg/restore/split_client.go
@@ -247,7 +247,7 @@ func (c *pdClient) sendSplitRegionRequest(
 		} else {
 			if len(regionInfo.Region.Peers) == 0 {
 				return nil, multierr.Append(splitErrors,
-					errors.Errorf("region[%d] doesn't have any peer", regionInfo.Region.GetId()))
+					errors.Annotatef(berrors.ErrKVUnknown, "region[%d] doesn't have any peer", regionInfo.Region.GetId()))
 			}
 			peer = regionInfo.Region.Peers[0]
 		}
@@ -272,7 +272,7 @@ func (c *pdClient) sendSplitRegionRequest(
 		}
 		if resp.RegionError != nil {
 			splitErrors = multierr.Append(splitErrors,
-				errors.Errorf("split region failed: region=%v, err=%v",
+				errors.Annotatef(berrors.ErrRestoreSplitFailed, "split region failed: region=%v, err=%v",
 					regionInfo.Region, resp.RegionError))
 			if nl := resp.RegionError.NotLeader; nl != nil {
 				if leader := nl.GetLeader(); leader != nil {

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -230,16 +230,6 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	cfg.PD, err = flags.GetStringSlice(flagPD)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(cfg.PD) == 0 {
-		return errors.Annotate(berrors.ErrInvalidArgument, "must provide at least one PD server address")
-	}
-	if err2 := cfg.normalizePDURLs(); err2 != nil {
-		return err2
-	}
 	cfg.Concurrency, err = flags.GetUint32(flagConcurrency)
 	if err != nil {
 		return errors.Trace(err)
@@ -324,7 +314,17 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err := cfg.BackendOptions.ParseFromFlags(flags); err != nil {
 		return err
 	}
-	return cfg.TLS.ParseFromFlags(flags)
+	if err := cfg.TLS.ParseFromFlags(flags); err != nil {
+		return err
+	}
+	cfg.PD, err = flags.GetStringSlice(flagPD)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(cfg.PD) == 0 {
+		return errors.Annotate(berrors.ErrInvalidArgument, "must provide at least one PD server address")
+	}
+	return cfg.normalizePDURLs()
 }
 
 // NewMgr creates a new mgr at the given PD address.

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -311,10 +311,10 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 		return errors.Annotatef(berrors.ErrInvalidArgument, "--switch-mode-interval must be positive, %s is not allowed", cfg.SwitchModeInterval)
 	}
 
-	if err := cfg.BackendOptions.ParseFromFlags(flags); err != nil {
+	if err = cfg.BackendOptions.ParseFromFlags(flags); err != nil {
 		return err
 	}
-	if err := cfg.TLS.ParseFromFlags(flags); err != nil {
+	if err = cfg.TLS.ParseFromFlags(flags); err != nil {
 		return err
 	}
 	cfg.PD, err = flags.GetStringSlice(flagPD)

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -452,15 +452,17 @@ func (cfg *Config) adjust() {
 }
 
 func normalizePDURL(pd string, useTLS bool) (string, error) {
-	startsWithHTTP := strings.HasPrefix(pd, "http://")
-	startsWithHTTPS := strings.HasPrefix(pd, "https://")
-	if useTLS && startsWithHTTP {
-		return "", errors.Annotate(berrors.ErrInvalidArgument, "pd url starts with http while TLS enabled")
+	if strings.HasPrefix(pd, "http://") {
+		if useTLS {
+			return "", errors.Annotate(berrors.ErrInvalidArgument, "pd url starts with http while TLS enabled")
+		}
+		return strings.TrimPrefix(pd, "http://"), nil
 	}
-	if !useTLS && startsWithHTTPS {
-		return "", errors.Annotate(berrors.ErrInvalidArgument, "pd url starts with https while TLS disabled")
+	if strings.HasPrefix(pd, "https://") {
+		if !useTLS {
+			return "", errors.Annotate(berrors.ErrInvalidArgument, "pd url starts with https while TLS disabled")
+		}
+		return strings.TrimPrefix(pd, "https://"), nil
 	}
-
-	striped := strings.TrimPrefix(strings.TrimPrefix(pd, "https://"), "http://")
-	return striped, nil
+	return pd, nil
 }

--- a/pkg/task/common_test.go
+++ b/pkg/task/common_test.go
@@ -47,3 +47,19 @@ func (s *testCommonSuite) TestTiDBConfigUnchanged(c *C) {
 	restoreConfig()
 	c.Assert(cfg, DeepEquals, config.GetGlobalConfig())
 }
+
+func (s *testCommonSuite) TestStripingPDURL(c *C) {
+	nor1, err := normalizePDURL("https://pd:5432", true)
+	c.Assert(err, IsNil)
+	c.Assert(nor1, Equals, "pd:5432")
+	_, err = normalizePDURL("https://pd.pingcap.com", false)
+	c.Assert(err, ErrorMatches, ".*pd url starts with https while TLS disabled.*")
+	_, err = normalizePDURL("http://127.0.0.1:2379", true)
+	c.Assert(err, ErrorMatches, ".*pd url starts with http while TLS enabled.*")
+	nor, err := normalizePDURL("http://127.0.0.1", false)
+	c.Assert(nor, Equals, "127.0.0.1")
+	c.Assert(err, IsNil)
+	noChange, err := normalizePDURL("127.0.0.1:2379", false)
+	c.Assert(err, IsNil)
+	c.Assert(noChange, Equals, "127.0.0.1:2379")
+}

--- a/tests/br_full/run.sh
+++ b/tests/br_full/run.sh
@@ -36,11 +36,11 @@ export GO_FAILPOINTS=""
 
 # backup full
 echo "backup with lz4 start..."
-run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-lz4" --concurrency 4 --compression lz4
+run_br --pd "http://$PD_ADDR" backup full -s "local://$TEST_DIR/$DB-lz4" --concurrency 4 --compression lz4
 size_lz4=$(du -d 0 $TEST_DIR/$DB-lz4 | awk '{print $1}')
 
 echo "backup with zstd start..."
-run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-zstd" --concurrency 4 --compression zstd --compression-level 6
+run_br --pd "http://$PD_ADDR" backup full -s "local://$TEST_DIR/$DB-zstd" --concurrency 4 --compression zstd --compression-level 6
 size_zstd=$(du -d 0 $TEST_DIR/$DB-zstd | awk '{print $1}')
 
 if [ "$size_lz4" -le "$size_zstd" ]; then

--- a/tests/br_tls/run.sh
+++ b/tests/br_tls/run.sh
@@ -47,7 +47,9 @@ run_sql "INSERT INTO $DB.$TABLE2 VALUES (\"c\", \"d\");"
 
 # backup db
 echo "backup start..."
-run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem
+# should fail when use http with TLS
+! run_br --pd "http://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem
+run_br --pd "https://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem
 
 run_sql "DROP DATABASE $DB;"
 

--- a/tests/br_tls/run.sh
+++ b/tests/br_tls/run.sh
@@ -48,7 +48,9 @@ run_sql "INSERT INTO $DB.$TABLE2 VALUES (\"c\", \"d\");"
 # backup db
 echo "backup start..."
 # should fail when use http with TLS
-! run_br --pd "http://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem
+if run_br --pd "http://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem; then
+  echo "failure: success started with http prefix even tls enabled."
+fi
 run_br --pd "https://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem
 
 run_sql "DROP DATABASE $DB;"

--- a/tests/br_tls/run.sh
+++ b/tests/br_tls/run.sh
@@ -47,6 +47,10 @@ run_sql "INSERT INTO $DB.$TABLE2 VALUES (\"c\", \"d\");"
 
 # backup db
 echo "backup start..."
+# should fail when use http with TLS
+if run_br --pd "http://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem; then
+  echo "failure: success started with http prefix even tls enabled."
+fi
 run_br --pd "https://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem
 
 run_sql "DROP DATABASE $DB;"

--- a/tests/br_tls/run.sh
+++ b/tests/br_tls/run.sh
@@ -47,10 +47,6 @@ run_sql "INSERT INTO $DB.$TABLE2 VALUES (\"c\", \"d\");"
 
 # backup db
 echo "backup start..."
-# should fail when use http with TLS
-if run_br --pd "http://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem; then
-  echo "failure: success started with http prefix even tls enabled."
-fi
 run_br --pd "https://$PD_ADDR" backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --ca $cur/certificates/ca.pem --cert $cur/certificates/client.pem --key $cur/certificates/client-key.pem
 
 run_sql "DROP DATABASE $DB;"


### PR DESCRIPTION
Signed-off-by: Hillium <maruruku@stu.csust.edu.cn>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #536 

### What is changed and how it works?
We check PD URLs and strip prefix before running.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release Note

 - Fix a bug that caused failure when using `--pd` with urls starts with `http` or `https`.

<!-- fill in the release note, or just write "No release note" -->
