### PR TITLE
checksum: fix checksum gc life time excceed issue

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -120,7 +120,7 @@ func (bc *Client) GetTS(ctx context.Context, duration time.Duration, ts uint64) 
 	}
 
 	// check backup time do not exceed GCSafePoint
-	err = CheckGCSafePoint(ctx, bc.mgr.GetPDClient(), backupTS)
+	err = utils.CheckGCSafePoint(ctx, bc.mgr.GetPDClient(), backupTS)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
@@ -138,7 +138,7 @@ func (bc *Client) SetLockFile(ctx context.Context) error {
 // SetGCTTL set gcTTL for client.
 func (bc *Client) SetGCTTL(ttl int64) {
 	if ttl <= 0 {
-		ttl = DefaultBRGCSafePointTTL
+		ttl = utils.DefaultBRGCSafePointTTL
 	}
 	bc.gcTTL = ttl
 }

--- a/pkg/restore/split_client.go
+++ b/pkg/restore/split_client.go
@@ -247,7 +247,7 @@ func (c *pdClient) sendSplitRegionRequest(
 		} else {
 			if len(regionInfo.Region.Peers) == 0 {
 				return nil, multierr.Append(splitErrors,
-					errors.Errorf("region[%d] doesn't have any peer", regionInfo.Region.GetId()))
+					errors.Annotatef(berrors.ErrRestoreNoPeer, "region[%d] doesn't have any peer", regionInfo.Region.GetId()))
 			}
 			peer = regionInfo.Region.Peers[0]
 		}
@@ -272,7 +272,7 @@ func (c *pdClient) sendSplitRegionRequest(
 		}
 		if resp.RegionError != nil {
 			splitErrors = multierr.Append(splitErrors,
-				errors.Errorf("split region failed: region=%v, err=%v",
+				errors.Annotatef(berrors.ErrRestoreSplitFailed, "split region failed: region=%v, err=%v",
 					regionInfo.Region, resp.RegionError))
 			if nl := resp.RegionError.NotLeader; nl != nil {
 				if leader := nl.GetLeader(); leader != nil {

--- a/pkg/utils/safe_point.go
+++ b/pkg/utils/safe_point.go
@@ -1,6 +1,6 @@
 // Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
 
-package backup
+package utils
 
 import (
 	"context"

--- a/pkg/utils/safe_point_test.go
+++ b/pkg/utils/safe_point_test.go
@@ -1,6 +1,6 @@
 // Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
 
-package backup_test
+package utils_test
 
 import (
 	"context"
@@ -10,8 +10,8 @@ import (
 	"github.com/pingcap/tidb/util/testleak"
 	pd "github.com/tikv/pd/client"
 
-	"github.com/pingcap/br/pkg/backup"
 	"github.com/pingcap/br/pkg/mock"
+	"github.com/pingcap/br/pkg/utils"
 )
 
 var _ = Suite(&testSafePointSuite{})
@@ -37,19 +37,19 @@ func (s *testSafePointSuite) TestCheckGCSafepoint(c *C) {
 	ctx := context.Background()
 	pdClient := &mockSafePoint{Client: s.mock.PDClient, safepoint: 2333}
 	{
-		err := backup.CheckGCSafePoint(ctx, pdClient, 2333+1)
+		err := utils.CheckGCSafePoint(ctx, pdClient, 2333+1)
 		c.Assert(err, IsNil)
 	}
 	{
-		err := backup.CheckGCSafePoint(ctx, pdClient, 2333)
+		err := utils.CheckGCSafePoint(ctx, pdClient, 2333)
 		c.Assert(err, NotNil)
 	}
 	{
-		err := backup.CheckGCSafePoint(ctx, pdClient, 2333-1)
+		err := utils.CheckGCSafePoint(ctx, pdClient, 2333-1)
 		c.Assert(err, NotNil)
 	}
 	{
-		err := backup.CheckGCSafePoint(ctx, pdClient, 0)
+		err := utils.CheckGCSafePoint(ctx, pdClient, 0)
 		c.Assert(err, ErrorMatches, ".*GC safepoint 2333 exceed TS 0.*")
 	}
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
br encountered the `GC life time is shorter than transaction duration` error. because of this [check](https://github.com/pingcap/tidb/blob/180c02127105bed73712050594da6ead4d70a85f/store/tikv/kv.go#L186-L190) in restore checksum.
### What is changed and how it works?
Add `StartServiceSafePointKeeper` for restore procedure just like backup.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Fix the issue that restore failed when restore checksum task time more than gc life time.

<!-- fill in the release note, or just write "No release note" -->
