### PR TITLE
*: when cleaning up, use isolated context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,12 @@ lint: tools
 	CGO_ENABLED=0 tools/bin/revive -formatter friendly -config revive.toml $$($(PACKAGES))
 
 tidy: prepare
-	# tidy isn't a read-only task for go.mod, run FINISH_MOD always, 
-	# so our go.mod1 won't stick in old state
-	trap "$(FINISH_MOD)" EXIT
 	@echo "go mod tidy"
 	GO111MODULE=on go mod tidy
-	git diff --quiet go.mod go.sum
+	# tidy isn't a read-only task for go.mod, run FINISH_MOD always, 
+	# so our go.mod1 won't stick in old state
+	git diff --quiet go.mod go.sum || ("$(FINISH_MOD)" && exit 1)
+	$(FINISH_MOD)
 
 failpoint-enable: tools
 	tools/bin/failpoint-ctl enable

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,12 @@ lint: tools
 	CGO_ENABLED=0 tools/bin/revive -formatter friendly -config revive.toml $$($(PACKAGES))
 
 tidy: prepare
+	# tidy isn't a read-only task for go.mod, run FINISH_MOD always, 
+	# so our go.mod1 won't stick in old state
+	trap "$(FINISH_MOD)" EXIT
 	@echo "go mod tidy"
 	GO111MODULE=on go mod tidy
 	git diff --quiet go.mod go.sum
-	$(FINISH_MOD)
 
 failpoint-enable: tools
 	tools/bin/failpoint-ctl enable

--- a/main.go
+++ b/main.go
@@ -31,6 +31,11 @@ func main() {
 		fmt.Printf("\nGot signal [%v] to exit.\n", sig)
 		log.Warn("received signal to exit", zap.Stringer("signal", sig))
 		cancel()
+		fmt.Println("gracefully shuting down, press ^C again to force exit")
+		<-sc
+		// Even user use SIGTERM to exit, there isn't any checkpoint for resuming,
+		// hence returning fail exit code.
+		os.Exit(1)
 	}()
 
 	rootCmd := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 		fmt.Printf("\nGot signal [%v] to exit.\n", sig)
 		log.Warn("received signal to exit", zap.Stringer("signal", sig))
 		cancel()
-		fmt.Println("gracefully shuting down, press ^C again to force exit")
+		fmt.Fprintln(os.Stderr, "gracefully shuting down, press ^C again to force exit")
 		<-sc
 		// Even user use SIGTERM to exit, there isn't any checkpoint for resuming,
 		// hence returning fail exit code.

--- a/main.go
+++ b/main.go
@@ -30,14 +30,7 @@ func main() {
 		sig := <-sc
 		fmt.Printf("\nGot signal [%v] to exit.\n", sig)
 		log.Warn("received signal to exit", zap.Stringer("signal", sig))
-		switch sig {
-		case syscall.SIGTERM:
-			cancel()
-			os.Exit(0)
-		default:
-			cancel()
-			os.Exit(1)
-		}
+		cancel()
 	}()
 
 	rootCmd := &cobra.Command{

--- a/pkg/gluetikv/glue.go
+++ b/pkg/gluetikv/glue.go
@@ -51,7 +51,7 @@ func (Glue) OwnsStorage() bool {
 
 // StartProgress implements glue.Glue.
 func (Glue) StartProgress(ctx context.Context, cmdName string, total int64, redirectLog bool) glue.Progress {
-	return progress{ch: utils.StartProgress(ctx, cmdName, total, redirectLog), closed: new(atomic.Bool)}
+	return progress{ch: utils.StartProgress(ctx, cmdName, total, redirectLog), closed: 0}
 }
 
 // Record implements glue.Glue.

--- a/pkg/gluetikv/glue.go
+++ b/pkg/gluetikv/glue.go
@@ -4,7 +4,6 @@ package gluetikv
 
 import (
 	"context"
-
 	"sync/atomic"
 
 	"github.com/pingcap/tidb/config"

--- a/pkg/gluetikv/glue.go
+++ b/pkg/gluetikv/glue.go
@@ -5,13 +5,14 @@ package gluetikv
 import (
 	"context"
 
+	"sync/atomic"
+
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/prometheus/common/log"
 	pd "github.com/tikv/pd/client"
-	"github.com/uber-go/atomic"
 
 	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/summary"
@@ -60,19 +61,20 @@ func (Glue) Record(name string, val uint64) {
 
 type progress struct {
 	ch     chan<- struct{}
-	closed *atomic.Bool
+	closed int32
 }
 
 // Inc implements glue.Progress.
 func (p progress) Inc() {
-	if p.closed.Load() {
+	if atomic.LoadInt32(&p.closed) != 0 {
 		log.Warn("proposing a closed progress")
 		return
 	}
 	// there might be buggy if the thread is yielded here.
 	// however, there should not be gosched, at most time.
-	// so send here probably is safe, but not totally safe.
-	// but adding an extra lock should be costly, so just be optimistic.
+	// so send here probably is safe, even not totally safe.
+	// since adding an extra lock should be costly, we just be optimistic.
+	// (Maybe a spin lock here would be better?)
 	p.ch <- struct{}{}
 }
 
@@ -80,6 +82,6 @@ func (p progress) Inc() {
 func (p progress) Close() {
 	// set closed to true firstly,
 	// so we won't see a state that the channel is closed and the p.closed is false.
-	p.closed.Store(true)
+	atomic.StoreInt32(&p.closed, 1)
 	close(p.ch)
 }

--- a/pkg/pdutil/pd.go
+++ b/pkg/pdutil/pd.go
@@ -175,10 +175,12 @@ func NewPdController(
 	}
 
 	return &PdController{
-		addrs:            processedAddrs,
-		cli:              cli,
-		pdClient:         pdClient,
-		schedulerPauseCh: make(chan struct{}),
+		addrs:    processedAddrs,
+		cli:      cli,
+		pdClient: pdClient,
+		// We should make a buffered channel here otherwise when context canceled,
+		// gracefully shutdown will stick at resuming schedulers.
+		schedulerPauseCh: make(chan struct{}, 1),
 	}, nil
 }
 
@@ -416,6 +418,7 @@ func restoreSchedulers(ctx context.Context, pd *PdController, clusterCfg cluster
 	if err := pd.ResumeSchedulers(ctx, clusterCfg.scheduler); err != nil {
 		return errors.Annotate(err, "fail to add PD schedulers")
 	}
+	log.Info("restoring config", zap.Any("config", clusterCfg.scheduleCfg))
 	mergeCfg := make(map[string]interface{})
 	for _, cfgKey := range pdRegionMergeCfg {
 		value := clusterCfg.scheduleCfg[cfgKey]

--- a/pkg/restore/batcher.go
+++ b/pkg/restore/batcher.go
@@ -67,12 +67,8 @@ func (b *Batcher) Len() int {
 func (b *Batcher) contextCleaner(ctx context.Context, tables <-chan []CreatedTable) {
 	defer func() {
 		if ctx.Err() != nil {
-			timeout := 5 * time.Second
-			log.Info("restore canceled, cleaning in a context with timeout",
-				zap.Stringer("timeout", timeout))
-			limitedCtx, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-			b.manager.Close(limitedCtx)
+			log.Info("restore canceled, cleaning in background context")
+			b.manager.Close(context.Background())
 		} else {
 			b.manager.Close(ctx)
 		}

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -222,10 +222,8 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		restore, e := mgr.RemoveSchedulers(ctx)
 		defer func() {
 			if ctx.Err() != nil {
-				var cancel context.CancelFunc
-				log.Warn("context canceled, doing clean work with another context with timeout")
-				ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
-				defer cancel()
+				log.Warn("context canceled, doing clean work with background context")
+				ctx = context.Background()
 			}
 			if restoreE := restore(ctx); restoreE != nil {
 				log.Warn("failed to restore removed schedulers, you may need to restore them manually", zap.Error(restoreE))

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -221,6 +221,12 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		log.Debug("removing some PD schedulers")
 		restore, e := mgr.RemoveSchedulers(ctx)
 		defer func() {
+			if ctx.Err() != nil {
+				var cancel context.CancelFunc
+				log.Warn("context canceled, doing clean work with another context with timeout")
+				ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+			}
 			if restoreE := restore(ctx); restoreE != nil {
 				log.Warn("failed to restore removed schedulers, you may need to restore them manually", zap.Error(restoreE))
 			}

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -5,7 +5,6 @@ package task
 import (
 	"bytes"
 	"context"
-	"time"
 
 	"github.com/pingcap/errors"
 	kvproto "github.com/pingcap/kvproto/pkg/backup"
@@ -149,10 +148,8 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 		restore, e := mgr.RemoveSchedulers(ctx)
 		defer func() {
 			if ctx.Err() != nil {
-				var cancel context.CancelFunc
-				log.Warn("context canceled, doing clean work with another context with timeout")
-				ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
-				defer cancel()
+				log.Warn("context canceled, doing clean work with background context")
+				ctx = context.Background()
 			}
 			if restoreE := restore(ctx); restoreE != nil {
 				log.Warn("failed to restore removed schedulers, you may need to restore them manually", zap.Error(restoreE))

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -5,6 +5,7 @@ package task
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/pingcap/errors"
 	kvproto "github.com/pingcap/kvproto/pkg/backup"
@@ -147,6 +148,12 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	if cfg.RemoveSchedulers {
 		restore, e := mgr.RemoveSchedulers(ctx)
 		defer func() {
+			if ctx.Err() != nil {
+				var cancel context.CancelFunc
+				log.Warn("context canceled, doing clean work with another context with timeout")
+				ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+			}
 			if restoreE := restore(ctx); restoreE != nil {
 				log.Warn("failed to restore removed schedulers, you may need to restore them manually", zap.Error(restoreE))
 			}

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -148,7 +148,7 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 		restore, e := mgr.RemoveSchedulers(ctx)
 		defer func() {
 			if ctx.Err() != nil {
-				log.Warn("context canceled, doing clean work with background context")
+				log.Warn("context canceled, try shutdown")
 				ctx = context.Background()
 			}
 			if restoreE := restore(ctx); restoreE != nil {

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -368,10 +368,8 @@ func restorePostWork(
 	ctx context.Context, client *restore.Client, restoreSchedulers utils.UndoFunc,
 ) {
 	if ctx.Err() != nil {
-		var cancel context.CancelFunc
-		log.Warn("context canceled, doing clean work with another context with timeout")
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+		log.Warn("context canceled, doing clean work with background context")
+		ctx = context.Background()
 	}
 	if client.IsOnline() {
 		return

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -367,6 +367,12 @@ func restorePreWork(ctx context.Context, client *restore.Client, mgr *conn.Mgr) 
 func restorePostWork(
 	ctx context.Context, client *restore.Client, restoreSchedulers utils.UndoFunc,
 ) {
+	if ctx.Err() != nil {
+		var cancel context.CancelFunc
+		log.Warn("context canceled, doing clean work with another context with timeout")
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+	}
 	if client.IsOnline() {
 		return
 	}

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -368,7 +368,7 @@ func restorePostWork(
 	ctx context.Context, client *restore.Client, restoreSchedulers utils.UndoFunc,
 ) {
 	if ctx.Err() != nil {
-		log.Warn("context canceled, doing clean work with background context")
+		log.Warn("context canceled, try shutdown")
 		ctx = context.Background()
 	}
 	if client.IsOnline() {

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+apt update && apt install default-mysql-client jq --yes
+
+cd /brie
+TEST_NAME=br_other make integration_test

--- a/tests/br_other/run.sh
+++ b/tests/br_other/run.sh
@@ -64,7 +64,9 @@ fi
 echo "backup start to test lock file"
 PPROF_PORT=6080
 GO_FAILPOINTS="github.com/pingcap/br/pkg/utils/determined-pprof-port=return($PPROF_PORT)" \
-run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB/lock" --remove-schedulers --ratelimit 1 --ratelimit-unit 1 --concurrency 4 2>&1 >/dev/null &
+run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB/lock" --remove-schedulers --ratelimit 1 --ratelimit-unit 1 --concurrency 4 2>&1 > $TEST_DIR/br-other-stdout.log &
+trap "cat $TEST_DIR/br-other-stdout.log" EXIT
+
 # record last backup pid
 _pid=$!
 

--- a/tests/br_other/run.sh
+++ b/tests/br_other/run.sh
@@ -105,6 +105,7 @@ else
    exit 1
 fi
 
+
 # make sure we won't stuck in non-scheduler state, even we send a SIGTERM to it.
 # give enough time to BR so it can gracefully stop.
 sleep 5
@@ -113,6 +114,22 @@ then
   echo "TEST: [$TEST_NAME] failed because scheduler has been removed"
   exit 1
 fi
+
+default_pd_values='{
+  "max-merge-region-keys": 200000,
+  "max-merge-region-size": 20,
+  "leader-schedule-limit": 4,
+  "region-schedule-limit": 2048,
+  "max-snapshot-count":    3
+}'
+
+for key in $(echo $default_pd_values | jq 'keys[]'); do
+  if ! curl -s http://$PD_ADDR/pd/api/v1/config/schedule | jq ".[$key]" | grep -q $(echo $default_pd_values | jq ".[$key]"); 
+    curl -s http://$PD_ADDR/pd/api/v1/config/schedule
+    echo "[$TEST_NAME] failed due to PD config isn't reset after restore"
+    exit 1
+  fi
+done
 
 pd_settings=5
 

--- a/tests/br_other/run.sh
+++ b/tests/br_other/run.sh
@@ -124,7 +124,7 @@ default_pd_values='{
 }'
 
 for key in $(echo $default_pd_values | jq 'keys[]'); do
-  if ! curl -s http://$PD_ADDR/pd/api/v1/config/schedule | jq ".[$key]" | grep -q $(echo $default_pd_values | jq ".[$key]"); 
+  if ! curl -s http://$PD_ADDR/pd/api/v1/config/schedule | jq ".[$key]" | grep -q $(echo $default_pd_values | jq ".[$key]"); then
     curl -s http://$PD_ADDR/pd/api/v1/config/schedule
     echo "[$TEST_NAME] failed due to PD config isn't reset after restore"
     exit 1


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #557
This PR also added a guard for the `glue.Progress` implement, to prevent the `send on close channel` panics.

### What is changed and how it works?
see #557 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

### Release Note

 - Fixed a bug that caused BR won't do cleanup tasks when receiving SIGTERM.

<!-- fill in the release note, or just write "No release note" -->
