### PR TITLE
restore: set configed keepalive for restore

### DIFF
--- a/pkg/restore/client_test.go
+++ b/pkg/restore/client_test.go
@@ -5,6 +5,7 @@ package restore_test
 import (
 	"math"
 	"strconv"
+	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
@@ -12,6 +13,7 @@ import (
 	"github.com/pingcap/parser/types"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/testleak"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/pingcap/br/pkg/gluetidb"
 	"github.com/pingcap/br/pkg/mock"
@@ -20,6 +22,11 @@ import (
 )
 
 var _ = Suite(&testRestoreClientSuite{})
+
+var defaultKeepaliveCfg = keepalive.ClientParameters{
+	Time:    3 * time.Second,
+	Timeout: 10 * time.Second,
+}
 
 type testRestoreClientSuite struct {
 	mock *mock.Cluster
@@ -38,8 +45,7 @@ func (s *testRestoreClientSuite) TearDownTest(c *C) {
 func (s *testRestoreClientSuite) TestCreateTables(c *C) {
 	c.Assert(s.mock.Start(), IsNil)
 	defer s.mock.Stop()
-
-	client, err := restore.NewRestoreClient(gluetidb.New(), s.mock.PDClient, s.mock.Storage, nil)
+	client, err := restore.NewRestoreClient(gluetidb.New(), s.mock.PDClient, s.mock.Storage, nil, defaultKeepaliveCfg)
 	c.Assert(err, IsNil)
 
 	info, err := s.mock.Domain.GetSnapshotInfoSchema(math.MaxUint64)
@@ -97,7 +103,7 @@ func (s *testRestoreClientSuite) TestIsOnline(c *C) {
 	c.Assert(s.mock.Start(), IsNil)
 	defer s.mock.Stop()
 
-	client, err := restore.NewRestoreClient(gluetidb.New(), s.mock.PDClient, s.mock.Storage, nil)
+	client, err := restore.NewRestoreClient(gluetidb.New(), s.mock.PDClient, s.mock.Storage, nil, defaultKeepaliveCfg)
 	c.Assert(err, IsNil)
 
 	c.Assert(client.IsOnline(), IsFalse)

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -31,8 +31,6 @@ import (
 const (
 	importScanRegionTime      = 10 * time.Second
 	scanRegionPaginationLimit = int(128)
-	gRPCKeepAliveTime         = 10 * time.Second
-	gRPCKeepAliveTimeout      = 3 * time.Second
 	gRPCBackOffMaxDelay       = 3 * time.Second
 )
 
@@ -67,14 +65,27 @@ type importClient struct {
 	metaClient SplitClient
 	clients    map[uint64]import_sstpb.ImportSSTClient
 	tlsConf    *tls.Config
+
+	keepaliveConf keepalive.ClientParameters
 }
 
 // NewImportClient returns a new ImporterClient.
-func NewImportClient(metaClient SplitClient, tlsConf *tls.Config) ImporterClient {
+func NewImportClient(metaClient SplitClient, tlsConf *tls.Config, keepaliveConf keepalive.ClientParameters) ImporterClient {
 	return &importClient{
-		metaClient: metaClient,
-		clients:    make(map[uint64]import_sstpb.ImportSSTClient),
-		tlsConf:    tlsConf,
+		metaClient:    metaClient,
+		clients:       make(map[uint64]import_sstpb.ImportSSTClient),
+		tlsConf:       tlsConf,
+		keepaliveConf: keepaliveConf,
+	}
+}
+
+// SetKeepalive sets the time and timeout for the keepalive.ClientParameters.
+func (ic *importClient) SetKeepalive(time, timeout time.Duration) {
+	ic.keepaliveConf = keepalive.ClientParameters{
+		Time:    time,
+		Timeout: timeout,
+
+		PermitWithoutStream: true,
 	}
 }
 
@@ -143,11 +154,7 @@ func (ic *importClient) GetImportClient(
 		addr,
 		opt,
 		grpc.WithConnectParams(grpc.ConnectParams{Backoff: bfConf}),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                gRPCKeepAliveTime,
-			Timeout:             gRPCKeepAliveTimeout,
-			PermitWithoutStream: true,
-		}),
+		grpc.WithKeepaliveParams(ic.keepaliveConf),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -79,16 +79,6 @@ func NewImportClient(metaClient SplitClient, tlsConf *tls.Config, keepaliveConf 
 	}
 }
 
-// SetKeepalive sets the time and timeout for the keepalive.ClientParameters.
-func (ic *importClient) SetKeepalive(time, timeout time.Duration) {
-	ic.keepaliveConf = keepalive.ClientParameters{
-		Time:    time,
-		Timeout: timeout,
-
-		PermitWithoutStream: true,
-	}
-}
-
 func (ic *importClient) DownloadSST(
 	ctx context.Context,
 	storeID uint64,

--- a/pkg/restore/log_client.go
+++ b/pkg/restore/log_client.go
@@ -113,7 +113,7 @@ func NewLogRestoreClient(
 	}
 
 	splitClient := NewSplitClient(restoreClient.GetPDClient(), restoreClient.GetTLSConfig())
-	importClient := NewImportClient(splitClient, restoreClient.tlsConf)
+	importClient := NewImportClient(splitClient, restoreClient.tlsConf, restoreClient.keepaliveConf)
 
 	cfg := concurrencyCfg{
 		Concurrency:       concurrency,

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -102,7 +102,9 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	}
 	defer mgr.Close()
 
-	client, err := restore.NewRestoreClient(g, mgr.GetPDClient(), mgr.GetTiKV(), mgr.GetTLSConfig())
+	keepaliveCfg := GetKeepalive(&cfg.Config)
+	keepaliveCfg.PermitWithoutStream = true
+	client, err := restore.NewRestoreClient(g, mgr.GetPDClient(), mgr.GetTiKV(), mgr.GetTLSConfig(), keepaliveCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/restore_log.go
+++ b/pkg/task/restore_log.go
@@ -109,7 +109,9 @@ func RunLogRestore(c context.Context, g glue.Glue, cfg *LogRestoreConfig) error 
 	if err != nil {
 		return err
 	}
-	client, err := restore.NewRestoreClient(g, mgr.GetPDClient(), mgr.GetTiKV(), mgr.GetTLSConfig())
+	keepaliveCfg := GetKeepalive(&cfg.Config)
+	keepaliveCfg.PermitWithoutStream = true
+	client, err := restore.NewRestoreClient(g, mgr.GetPDClient(), mgr.GetTiKV(), mgr.GetTLSConfig(), keepaliveCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/task/restore_raw.go
+++ b/pkg/task/restore_raw.go
@@ -68,7 +68,11 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	}
 	defer mgr.Close()
 
-	client, err := restore.NewRestoreClient(g, mgr.GetPDClient(), mgr.GetTiKV(), mgr.GetTLSConfig())
+	keepaliveCfg := GetKeepalive(&cfg.Config)
+	// sometimes we have pooled the connections.
+	// sending heartbeats in idle times is useful.
+	keepaliveCfg.PermitWithoutStream = true
+	client, err := restore.NewRestoreClient(g, mgr.GetPDClient(), mgr.GetTiKV(), mgr.GetTLSConfig(), keepaliveCfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#545 added the config value of keepalive, but it has forgotten the restore part(!).

### What is changed and how it works?
Apply the config to restoring.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
(If the old tests passed, then the default config should be applied.)

### Release Note

 - Fix a bug that causes the keepalive configs don't apply to restore.

<!-- fill in the release note, or just write "No release note" -->
