### PR TITLE
cdclog: Fix serval bugs about restore cdclog feature. (#568)

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -141,15 +141,13 @@ func newTableRestoreCommand() *cobra.Command {
 func newLogRestoreCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "cdclog",
-		Short: "restore data from cdc log backup",
+		Short: "(experimental) restore data from cdc log backup",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runLogRestoreCommand(cmd)
 		},
 	}
 	task.DefineFilterFlags(command)
 	task.DefineLogRestoreFlags(command)
-	// TODO remove hidden if it's ready.
-	command.Hidden = true
 	return command
 }
 

--- a/pkg/cdclog/decoder.go
+++ b/pkg/cdclog/decoder.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"strconv"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -46,6 +47,9 @@ const (
 const (
 	// BatchVersion1 represents the version of batch format.
 	BatchVersion1 uint64 = 1
+)
+
+const (
 	// BinaryFlag means the Column charset is binary.
 	BinaryFlag ColumnFlagType = 1 << ColumnFlagType(iota)
 	// HandleKeyFlag means the Column is selected as the handle key.
@@ -99,6 +103,20 @@ func (c Column) ToDatum() (types.Datum, error) {
 
 func formatColumnVal(c Column) Column {
 	switch c.Type {
+	case mysql.TypeVarchar, mysql.TypeString:
+		if s, ok := c.Value.(string); ok {
+			// according to open protocol https://docs.pingcap.com/tidb/dev/ticdc-open-protocol
+			// CHAR/BINARY have the same type: 254
+			// VARCHAR/VARBINARY have the same type: 15
+			// we need to process it by its flag.
+			if c.Flag&BinaryFlag != 0 {
+				val, err := strconv.Unquote("\"" + s + "\"")
+				if err != nil {
+					log.Fatal("invalid Column value, please report a bug", zap.Any("col", c), zap.Error(err))
+				}
+				c.Value = val
+			}
+		}
 	case mysql.TypeTinyBlob, mysql.TypeMediumBlob,
 		mysql.TypeLongBlob, mysql.TypeBlob:
 		if s, ok := c.Value.(string); ok {
@@ -267,6 +285,9 @@ func (b *JSONEventBatchMixedDecoder) HasNext() bool {
 
 // NewJSONEventBatchDecoder creates a new JSONEventBatchDecoder.
 func NewJSONEventBatchDecoder(data []byte) (*JSONEventBatchMixedDecoder, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
 	version := binary.BigEndian.Uint64(data[:8])
 	data = data[8:]
 	if version != BatchVersion1 {

--- a/pkg/cdclog/puller.go
+++ b/pkg/cdclog/puller.go
@@ -61,10 +61,12 @@ func NewEventPuller(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ddlFileIndex++
-		ddlDecoder, err = NewJSONEventBatchDecoder(data)
-		if err != nil {
-			return nil, errors.Trace(err)
+		if len(data) != 0 {
+			ddlFileIndex++
+			ddlDecoder, err = NewJSONEventBatchDecoder(data)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 	}
 
@@ -75,10 +77,12 @@ func NewEventPuller(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		rowFileIndex++
-		rowChangedDecoder, err = NewJSONEventBatchDecoder(data)
-		if err != nil {
-			return nil, errors.Trace(err)
+		if len(data) != 0 {
+			rowFileIndex++
+			rowChangedDecoder, err = NewJSONEventBatchDecoder(data)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 	}
 

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -45,6 +45,10 @@ func (l *LocalStorage) FileExists(ctx context.Context, name string) (bool, error
 func (l *LocalStorage) WalkDir(ctx context.Context, opt *WalkOption, fn func(string, int64) error) error {
 	base := filepath.Join(l.base, opt.SubDir)
 	return filepath.Walk(base, func(path string, f os.FileInfo, err error) error {
+		if os.IsNotExist(err) {
+			// if path not exists, we should return nil to continue.
+			return nil
+		}
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
cherry-pick #568 to release-4.0
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix serval bugs about restore cdclog feature.
### What is changed and how it works?
1. Fix the issue that when restore binary/varbinary field will lost bytes.
2. Fix the issue that wrong events filtered by ts range filter.
3. Fix panic by add the length check for cdclog data.
4. Change the hidden parameter to the experimental feature.
5. Add more log for debug.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
