### PR TITLE
pd: add check when leader is empty

### DIFF
--- a/pkg/restore/split.go
+++ b/pkg/restore/split.go
@@ -131,7 +131,7 @@ SplitRegions:
 				}
 				time.Sleep(interval)
 				if i > 3 {
-					log.Warn("splitting regions failed, retry it", zap.Error(errSplit), zap.Array("keys", logutil.WrapKeys(keys)))
+					log.Warn("splitting regions failed, retry it", zap.Error(errSplit), zap.Any("region", region), zap.Array("keys", logutil.WrapKeys(keys)))
 				}
 				continue SplitRegions
 			}

--- a/pkg/restore/split_client.go
+++ b/pkg/restore/split_client.go
@@ -242,19 +242,19 @@ func (c *pdClient) sendSplitRegionRequest(
 	ctx context.Context, regionInfo *RegionInfo, keys [][]byte,
 ) (*kvrpcpb.SplitRegionResponse, error) {
 	var splitErrors error
-	var peer *metapb.Peer
-	// scanRegions may return empty Leader in https://github.com/tikv/pd/blob/v4.0.8/server/grpc_service.go#L524
-	// so wee also need check Leader.Id != 0
-	if regionInfo.Leader != nil && regionInfo.Leader.Id != 0 {
-		peer = regionInfo.Leader
-	} else {
-		if len(regionInfo.Region.Peers) == 0 {
-			return nil, multierr.Append(splitErrors,
-				errors.Annotatef(berrors.ErrRestoreNoPeer, "region[%d] doesn't have any peer", regionInfo.Region.GetId()))
-		}
-		peer = regionInfo.Region.Peers[0]
-	}
 	for i := 0; i < splitRegionMaxRetryTime; i++ {
+		var peer *metapb.Peer
+		// scanRegions may return empty Leader in https://github.com/tikv/pd/blob/v4.0.8/server/grpc_service.go#L524
+		// so wee also need check Leader.Id != 0
+		if regionInfo.Leader != nil && regionInfo.Leader.Id != 0 {
+			peer = regionInfo.Leader
+		} else {
+			if len(regionInfo.Region.Peers) == 0 {
+				return nil, multierr.Append(splitErrors,
+					errors.Annotatef(berrors.ErrRestoreNoPeer, "region[%d] doesn't have any peer", regionInfo.Region.GetId()))
+			}
+			peer = regionInfo.Region.Peers[0]
+		}
 		storeID := peer.GetStoreId()
 		store, err := c.GetStore(ctx, storeID)
 		if err != nil {

--- a/pkg/restore/split_client.go
+++ b/pkg/restore/split_client.go
@@ -242,17 +242,19 @@ func (c *pdClient) sendSplitRegionRequest(
 	ctx context.Context, regionInfo *RegionInfo, keys [][]byte,
 ) (*kvrpcpb.SplitRegionResponse, error) {
 	var splitErrors error
-	for i := 0; i < splitRegionMaxRetryTime; i++ {
-		var peer *metapb.Peer
-		if regionInfo.Leader != nil {
-			peer = regionInfo.Leader
-		} else {
-			if len(regionInfo.Region.Peers) == 0 {
-				return nil, multierr.Append(splitErrors,
-					errors.Annotatef(berrors.ErrRestoreNoPeer, "region[%d] doesn't have any peer", regionInfo.Region.GetId()))
-			}
-			peer = regionInfo.Region.Peers[0]
+	var peer *metapb.Peer
+	// scanRegions may return empty Leader in https://github.com/tikv/pd/blob/v4.0.8/server/grpc_service.go#L524
+	// so wee also need check Leader.Id != 0
+	if regionInfo.Leader != nil && regionInfo.Leader.Id != 0 {
+		peer = regionInfo.Leader
+	} else {
+		if len(regionInfo.Region.Peers) == 0 {
+			return nil, multierr.Append(splitErrors,
+				errors.Annotatef(berrors.ErrRestoreNoPeer, "region[%d] doesn't have any peer", regionInfo.Region.GetId()))
 		}
+		peer = regionInfo.Region.Peers[0]
+	}
+	for i := 0; i < splitRegionMaxRetryTime; i++ {
 		storeID := peer.GetStoreId()
 		store, err := c.GetStore(ctx, storeID)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
try to resolve https://github.com/pingcap/br/issues/634.

### What is changed and how it works?
add check when scanRegions return empty leader but have peer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

  - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - No release note.

<!-- fill in the release note, or just write "No release note" -->
