### PR TITLE
pdutil: set max-pending-peer-count to a large value in RemovePdScheduers

### DIFF
--- a/pkg/pdutil/pd_test.go
+++ b/pkg/pdutil/pd_test.go
@@ -53,6 +53,7 @@ func (s *testPDControllerSuite) TestScheduler(c *C) {
 		"max-merge-region-keys":       0,
 		"max-snapshot":                1,
 		"enable-location-replacement": false,
+		"max-pending-peer-count":      uint64(16),
 	}
 	_, err = pdController.pauseSchedulersAndConfigWith(ctx, []string{}, cfg, mock)
 	c.Assert(err, ErrorMatches, "failed to update PD.*")

--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -203,6 +203,7 @@ start_services_with_tls() {
         bin/tikv-server \
             --pd "$PD_ADDR" \
             -A "$TIKV_ADDR$i" \
+            --status-addr "$TIKV_STATUS_ADDR$i" \
             --log-file "$TEST_DIR/tikv${i}.log" \
             -C "$TIKV_CONFIG" \
             -s "$TEST_DIR/tikv${i}" &

--- a/tests/br_log_restore/run.sh
+++ b/tests/br_log_restore/run.sh
@@ -99,7 +99,7 @@ run_sql "insert into ${DB}_DDL2.t2 values (5, 'x');"
 # sleep wait cdc log sync to storage
 # TODO find another way to check cdc log has synced
 # need wait more time for cdc log synced, because we add some ddl.
-sleep 50
+sleep 60
 
 # remove the change feed, because we don't want to record the drop ddl.
 echo "Y" | bin/cdc cli unsafe reset --pd=http://$PD_ADDR

--- a/tests/br_other/run.sh
+++ b/tests/br_other/run.sh
@@ -84,6 +84,10 @@ echo "pprof started..."
 
 curl http://$PD_ADDR/pd/api/v1/config/schedule | grep '"disable": false'
 curl http://$PD_ADDR/pd/api/v1/config/schedule | jq '."enable-location-replacement"' | grep "false"
+curl http://$PD_ADDR/pd/api/v1/config/schedule | jq '."max-pending-peer-count"' | grep "2147483647"
+curl http://$PD_ADDR/pd/api/v1/config/schedule | jq '."max-merge-region-size"' | grep -E "^0$"
+curl http://$PD_ADDR/pd/api/v1/config/schedule | jq '."max-merge-region-keys"' | grep -E "^0$"
+
 backup_fail=0
 echo "another backup start expect to fail due to last backup add a lockfile"
 run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB/lock" --concurrency 4 || backup_fail=1
@@ -126,7 +130,8 @@ default_pd_values='{
   "max-merge-region-size": 20,
   "leader-schedule-limit": 4,
   "region-schedule-limit": 2048,
-  "max-snapshot-count":    3
+  "max-snapshot-count":    3,
+  "max-pending-peer-count": 16
 }'
 
 for key in $(echo $default_pd_values | jq 'keys[]'); do


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Set `max-pending-peer-count` to a large value (math.MaxInt32) during restore to avoid scatter regions failed due to pending peer filter.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has interface methods change
 - Has persistent data change

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - Enlarge pd `max-pending-peer-count` during restore

<!-- fill in the release note, or just write "No release note" -->
