### PR TITLE
tests: fix br_tls failure and make stop_services more robust

### DIFF
--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -221,7 +221,7 @@ start_services_with_tls() {
           echo 'Failed to initialize TiKV cluster'
           exit 1
        fi
-       sleep 3
+       sleep 4
     done
 
     echo "Starting TiDB..."

--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -205,6 +205,7 @@ start_services_with_tls() {
         bin/tikv-server \
             --pd "$PD_ADDR" \
             -A "$TIKV_ADDR$i" \
+            --status-addr "$TIKV_STATUS_ADDR$i" \
             --log-file "$TEST_DIR/tikv${i}.log" \
             -C "$TIKV_CONFIG" \
             -s "$TEST_DIR/tikv${i}" &

--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -37,11 +37,13 @@ cleanup_data() {
 }
 
 stop_services() {
-    for svc in "br" "tidb" "tiflash" "tikv" "pd"; do
-        # tiflash and br do not have "-server"
-        killall -9 $svc-server &> /dev/null || true
-        killall -9 $svc &> /dev/null || true
+    for svc in "br" "tidb-server" "tiflash" "TiFlashManager" "tikv-server" "pd-server"; do
+        killall -v -1 $svc || continue
+        sleep 1 # give some grace shutdown period
+        killall -v -9 $svc || continue
     done
+    sleep 1 # give some time for the OS to reap all processes
+    lsof -n -P -i :2379 -i :4000 -i :10080 -i :20160 -i :20161 -i :20162 -i :20180 -i :20181 -i :20182 -i :17000 -i :8125 || true
 }
 
 start_services() {

--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -37,7 +37,7 @@ cleanup_data() {
 }
 
 stop_services() {
-    for svc in "br" "tidb-server" "tiflash" "TiFlashManager" "tikv-server" "pd-server"; do
+    for svc in "br" "tidb-server" "tiflash" "TiFlashMain" "tikv-server" "pd-server"; do
         killall -v -1 $svc || continue
         sleep 1 # give some grace shutdown period
         killall -v -9 $svc || continue

--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -43,7 +43,7 @@ stop_services() {
         killall -v -9 $svc || continue
     done
     sleep 1 # give some time for the OS to reap all processes
-    lsof -n -P -i :2379 -i :4000 -i :10080 -i :20160 -i :20161 -i :20162 -i :20180 -i :20181 -i :20182 -i :17000 -i :8125 || true
+    lsof -n -P -i :2379 -i :4000 -i :10080 -i :20161 -i :20162 -i :20163 -i :20181 -i :20182 -i :20183 -i :17000 -i :8125 || true
 }
 
 start_services() {


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

br_tls recently almost always fail because TiKV cannot restart due to occupied port.

### What is changed and how it works?

1. Change `stop_service` to first gracefully stop through a SIGHUP, before actually doing SIGKILL.
2. Insert some sleep to ensure OS has time to reap the ports from the process corpses.
3. Increase TiKV wait time for `start_services_with_tls` from 60s to 80s to workaround a certain bug caused by PD dashboard initialization which makes PD idle for 1 minute.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
