### PR TITLE
gcs: fix wrong path of gcs prefix

### DIFF
--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"strings"
 
 	"cloud.google.com/go/storage"
 	"github.com/pingcap/errors"
@@ -84,9 +85,16 @@ type gcsStorage struct {
 	bucket *storage.BucketHandle
 }
 
+func (s *gcsStorage) objectName(name string) string {
+	if strings.HasSuffix(s.gcs.Prefix, "/") {
+		return s.gcs.Prefix + name
+	}
+	return s.gcs.Prefix + "/" + name
+}
+
 // Write file to storage.
 func (s *gcsStorage) Write(ctx context.Context, name string, data []byte) error {
-	object := s.gcs.Prefix + name
+	object := s.objectName(name)
 	wc := s.bucket.Object(object).NewWriter(ctx)
 	wc.StorageClass = s.gcs.StorageClass
 	wc.PredefinedACL = s.gcs.PredefinedAcl
@@ -99,7 +107,7 @@ func (s *gcsStorage) Write(ctx context.Context, name string, data []byte) error 
 
 // Read storage file.
 func (s *gcsStorage) Read(ctx context.Context, name string) ([]byte, error) {
-	object := s.gcs.Prefix + name
+	object := s.objectName(name)
 	rc, err := s.bucket.Object(object).NewReader(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -113,7 +121,7 @@ func (s *gcsStorage) Read(ctx context.Context, name string) ([]byte, error) {
 
 // FileExists return true if file exists.
 func (s *gcsStorage) FileExists(ctx context.Context, name string) (bool, error) {
-	object := s.gcs.Prefix + name
+	object := s.objectName(name)
 	_, err := s.bucket.Object(object).Attrs(ctx)
 	if err != nil {
 		if errors.Cause(err) == storage.ErrObjectNotExist { // nolint:errorlint

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"strings"
+	"path"
 
 	"cloud.google.com/go/storage"
 	"github.com/pingcap/errors"
@@ -86,10 +86,7 @@ type gcsStorage struct {
 }
 
 func (s *gcsStorage) objectName(name string) string {
-	if strings.HasSuffix(s.gcs.Prefix, "/") {
-		return s.gcs.Prefix + name
-	}
-	return s.gcs.Prefix + "/" + name
+	return path.Join(s.gcs.Prefix, name)
 }
 
 // Write file to storage.

--- a/pkg/storage/gcs_test.go
+++ b/pkg/storage/gcs_test.go
@@ -156,13 +156,14 @@ func (r *testStorageSuite) TestNewGCSStorage(c *C) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "",
 		}
-		_, err = newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		s, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials: false,
 			SkipCheckPath:   false,
 			HTTPClient:      server.HTTPClient(),
 		})
 		c.Assert(err, IsNil)
 		c.Assert(gcs.CredentialsBlob, Equals, "")
+		c.Assert(s.objectName("x"), Equals, "a/b/x")
 	}
 
 	{
@@ -180,5 +181,23 @@ func (r *testStorageSuite) TestNewGCSStorage(c *C) {
 			HTTPClient:      server.HTTPClient(),
 		})
 		c.Assert(err, NotNil)
+	}
+
+	{
+		gcs := &backup.GCS{
+			Bucket:          bucketName,
+			Prefix:          "a/b",
+			StorageClass:    "NEARLINE",
+			PredefinedAcl:   "private",
+			CredentialsBlob: "FakeCredentials",
+		}
+		s, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+			SendCredentials: false,
+			SkipCheckPath:   false,
+			HTTPClient:      server.HTTPClient(),
+		})
+		c.Assert(err, IsNil)
+		c.Assert(gcs.CredentialsBlob, Equals, "")
+		c.Assert(s.objectName("x"), Equals, "a/b/x")
 	}
 }

--- a/pkg/storage/parse.go
+++ b/pkg/storage/parse.go
@@ -70,7 +70,8 @@ func ParseBackend(rawURL string, options *BackendOptions) (*backup.StorageBacken
 		return &backup.StorageBackend{Backend: &backup.StorageBackend_S3{S3: s3}}, nil
 
 	case "gs", "gcs":
-		gcs := &backup.GCS{Bucket: u.Host, Prefix: u.Path[1:]}
+		prefix := strings.Trim(u.Path[1:], "/")
+		gcs := &backup.GCS{Bucket: u.Host, Prefix: prefix}
 		if options == nil {
 			options = &BackendOptions{}
 		}

--- a/pkg/storage/parse_test.go
+++ b/pkg/storage/parse_test.go
@@ -88,7 +88,7 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	gcs := s.GetGcs()
 	c.Assert(gcs, NotNil)
 	c.Assert(gcs.Bucket, Equals, "bucket2")
-	c.Assert(gcs.Prefix, Equals, "prefix/")
+	c.Assert(gcs.Prefix, Equals, "prefix")
 	c.Assert(gcs.Endpoint, Equals, "https://gcs.example.com/")
 	c.Assert(gcs.CredentialsBlob, Equals, "")
 
@@ -104,7 +104,7 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	gcs = s.GetGcs()
 	c.Assert(gcs, NotNil)
 	c.Assert(gcs.Bucket, Equals, "bucket")
-	c.Assert(gcs.Prefix, Equals, "more/prefix/")
+	c.Assert(gcs.Prefix, Equals, "more/prefix")
 	c.Assert(gcs.Endpoint, Equals, "https://gcs.example.com/")
 	c.Assert(gcs.CredentialsBlob, Equals, "fakeCredentials")
 
@@ -115,7 +115,7 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	gcs = s.GetGcs()
 	c.Assert(gcs, NotNil)
 	c.Assert(gcs.Bucket, Equals, "bucket4")
-	c.Assert(gcs.Prefix, Equals, "backup/")
+	c.Assert(gcs.Prefix, Equals, "backup")
 	c.Assert(gcs.CredentialsBlob, Equals, "fakeCreds2")
 
 	s, err = ParseBackend("/test", nil)

--- a/tests/br_log_restore/run.sh
+++ b/tests/br_log_restore/run.sh
@@ -99,7 +99,7 @@ run_sql "insert into ${DB}_DDL2.t2 values (5, 'x');"
 # sleep wait cdc log sync to storage
 # TODO find another way to check cdc log has synced
 # need wait more time for cdc log synced, because we add some ddl.
-sleep 60
+sleep 80
 
 # remove the change feed, because we don't want to record the drop ddl.
 echo "Y" | bin/cdc cli unsafe reset --pd=http://$PD_ADDR


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
backup meta file out of backup directory in gcs storage.
### What is changed and how it works?
ensure gcs prefix endwith "/"


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
before:
![image](https://user-images.githubusercontent.com/5906259/102063124-9723f300-3e30-11eb-9e82-0bb934e4866d.png)
after:
![image](https://user-images.githubusercontent.com/5906259/102063140-9b501080-3e30-11eb-9a6d-6ed3360dde8a.png)

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Fix the issue that write backup meta file out of backup directory in gcs storage.

<!-- fill in the release note, or just write "No release note" -->
