### PR TITLE
test: remove the -d  parameter since pd-ctl doesn't support it anymore

### DIFF
--- a/tests/br_shuffle_leader/run.sh
+++ b/tests/br_shuffle_leader/run.sh
@@ -25,7 +25,7 @@ row_count_ori=$(run_sql "SELECT COUNT(*) FROM $DB.$TABLE;" | awk '/COUNT/{print 
 
 # add shuffle leader scheduler
 echo "add shuffle-leader-scheduler"
-echo "-u $PD_ADDR -d sched add shuffle-leader-scheduler" | pd-ctl
+echo "-u $PD_ADDR sched add shuffle-leader-scheduler" | pd-ctl
 
 # backup with shuffle leader
 echo "backup start..."
@@ -38,7 +38,7 @@ echo "restore start..."
 run_br restore table --db $DB --table $TABLE -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 
 # remove shuffle leader scheduler
-echo "-u $PD_ADDR -d sched remove shuffle-leader-scheduler" | pd-ctl
+echo "-u $PD_ADDR sched remove shuffle-leader-scheduler" | pd-ctl
 
 row_count_new=$(run_sql "SELECT COUNT(*) FROM $DB.$TABLE;" | awk '/COUNT/{print $2}')
 

--- a/tests/br_shuffle_region/run.sh
+++ b/tests/br_shuffle_region/run.sh
@@ -25,7 +25,7 @@ row_count_ori=$(run_sql "SELECT COUNT(*) FROM $DB.$TABLE;" | awk '/COUNT/{print 
 
 # add shuffle region scheduler
 echo "add shuffle-region-scheduler"
-echo "-u $PD_ADDR -d sched add shuffle-region-scheduler" | pd-ctl
+echo "-u $PD_ADDR sched add shuffle-region-scheduler" | pd-ctl
 
 # backup with shuffle region
 echo "backup start..."
@@ -38,7 +38,7 @@ echo "restore start..."
 run_br restore table --db $DB --table $TABLE -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 
 # remove shuffle region scheduler
-echo "-u $PD_ADDR -d sched remove shuffle-region-scheduler" | pd-ctl
+echo "-u $PD_ADDR sched remove shuffle-region-scheduler" | pd-ctl
 
 row_count_new=$(run_sql "SELECT COUNT(*) FROM $DB.$TABLE;" | awk '/COUNT/{print $2}')
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix integration test error by pd-ctl does not support -d parameter anymore.

This error may be cause by  https://github.com/tikv/pd/pull/3337, but seems pd-ctl does not support -d for a long time. (don't know why, but -d seems to always have no effect)

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects


Related changes

### Release Note

 - No Release Note

<!-- fill in the release note, or just write "No release note" -->
