### PR TITLE
backup: dump stats to json should not be fatal

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -292,6 +292,12 @@ func BuildBackupRangeAndSchema(
 				// Skip tables other than the given table.
 				continue
 			}
+
+			logger := log.With(
+				zap.String("db", dbInfo.Name.O),
+				zap.String("table", tableInfo.Name.O),
+			)
+
 			var globalAutoID int64
 			switch {
 			case tableInfo.IsSequence():
@@ -314,14 +320,10 @@ func BuildBackupRangeAndSchema(
 					return nil, nil, errors.Trace(err)
 				}
 				tableInfo.AutoRandID = globalAutoRandID
-				log.Info("change table AutoRandID",
-					zap.Stringer("db", dbInfo.Name),
-					zap.Stringer("table", tableInfo.Name),
+				logger.Info("change table AutoRandID",
 					zap.Int64("AutoRandID", globalAutoRandID))
 			}
-			log.Info("change table AutoIncID",
-				zap.Stringer("db", dbInfo.Name),
-				zap.Stringer("table", tableInfo.Name),
+			logger.Info("change table AutoIncID",
 				zap.Int64("AutoIncID", globalAutoID))
 
 			// remove all non-public indices
@@ -349,11 +351,12 @@ func BuildBackupRangeAndSchema(
 			if !ignoreStats {
 				jsonTable, err := h.DumpStatsToJSON(dbInfo.Name.String(), tableInfo, nil)
 				if err != nil {
-					return nil, nil, errors.Trace(err)
-				}
-				stats, err = json.Marshal(jsonTable)
-				if err != nil {
-					return nil, nil, errors.Trace(err)
+					logger.Error("dump table stats failed", logutil.ShortError(err))
+				} else {
+					stats, err = json.Marshal(jsonTable)
+					if err != nil {
+						logger.Error("dump table stats failed (cannot serialize)", logutil.ShortError(err))
+					}
 				}
 			}
 


### PR DESCRIPTION
also improved some logs

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Part 1 of #679. 

### What is changed and how it works?

If the stats is broken, we just log and skip it instead of bailing out.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Failing to backup statistics is no longer fatal.

<!-- fill in the release note, or just write "No release note" -->
