### PR TITLE
cmd/: change redact log parameter name

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -43,8 +43,10 @@ const (
 	FlagStatusAddr = "status-addr"
 	// FlagSlowLogFile is the name of slow-log-file flag.
 	FlagSlowLogFile = "slow-log-file"
-	// FlagRedactLog is whether to redact sensitive information in log.
-	FlagRedactLog = "redact-info-log"
+	// FlagRedactLog is whether to redact sensitive information in log, already deprecated by FlagRedactInfoLog
+	FlagRedactLog = "redact-log"
+	// FlagRedactInfoLog is whether to redact sensitive information in log.
+	FlagRedactInfoLog = "redact-info-log"
 
 	flagVersion      = "version"
 	flagVersionShort = "V"
@@ -67,6 +69,8 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String(FlagLogFormat, "text",
 		"Set the log format")
 	cmd.PersistentFlags().Bool(FlagRedactLog, false,
+		"Set whether to redact sensitive info in log, already deprecated by --redact-info-log")
+	cmd.PersistentFlags().Bool(FlagRedactInfoLog, false,
 		"Set whether to redact sensitive info in log")
 	cmd.PersistentFlags().String(FlagStatusAddr, "",
 		"Set the HTTP listening address for the status report service. Set to empty string to disable")
@@ -75,6 +79,7 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP(FlagSlowLogFile, "", "",
 		"Set the slow log file path. If not set, discard slow logs")
 	_ = cmd.PersistentFlags().MarkHidden(FlagSlowLogFile)
+	_ = cmd.PersistentFlags().MarkHidden(FlagRedactLog)
 }
 
 // Init initializes BR cli.
@@ -117,7 +122,12 @@ func Init(cmd *cobra.Command) (err error) {
 			err = e
 			return
 		}
-		brlogutil.InitRedact(redactLog)
+		redactInfoLog, e := cmd.Flags().GetBool(FlagRedactInfoLog)
+		if e != nil {
+			err = e
+			return
+		}
+		brlogutil.InitRedact(redactLog || redactInfoLog)
 
 		slowLogFilename, e := cmd.Flags().GetString(FlagSlowLogFile)
 		if e != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -44,7 +44,7 @@ const (
 	// FlagSlowLogFile is the name of slow-log-file flag.
 	FlagSlowLogFile = "slow-log-file"
 	// FlagRedactLog is whether to redact sensitive information in log.
-	FlagRedactLog = "redact-log"
+	FlagRedactLog = "redact-info-log"
 
 	flagVersion      = "version"
 	flagVersionShort = "V"

--- a/tests/br_other/run.sh
+++ b/tests/br_other/run.sh
@@ -41,6 +41,10 @@ run_br -s "local://$TEST_DIR/$DB" debug decode --field "EndVersion"
 # Ensure compatibility
 run_br -s "local://$TEST_DIR/$DB" validate decode --field "end-version"
 
+# Test redact-log and redact-info-log compalibility
+run_br -s "local://$TEST_DIR/$DB" debug decode --field "Schemas" --redact-log=true
+run_br -s "local://$TEST_DIR/$DB" debug decode --field "Schemas" --redact-info-log=true
+
 # Test validate backupmeta
 run_br debug backupmeta validate -s "local://$TEST_DIR/$DB"
 run_br debug backupmeta validate -s "local://$TEST_DIR/$DB" --offset 100


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In https://github.com/pingcap/br/pull/653, we added the `redact-log` parameter.

The redact log parameter name is different from TiKV's and PD's.
https://github.com/tikv/tikv/blob/master/etc/config-template.toml#L846
In TiKV it's `redact-info-log` configuration in config file.
https://github.com/tikv/pd/blob/master/server/config/config.go#L1373
In PD it's `redact-info-log` configuration in config file.

### What is changed and how it works?
Change `redact-log` to `redact-info-log`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
