### PR TITLE
stats: disable stats by default

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/ddl"
+	"github.com/pingcap/tidb/session"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"sourcegraph.com/sourcegraph/appdash"
@@ -30,6 +31,11 @@ func runBackupCommand(command *cobra.Command, cmdName string) error {
 		ctx, store = trace.TracerStartSpan(ctx)
 		defer trace.TracerFinishSpan(ctx, store)
 	}
+	if cfg.IgnoreStats {
+		// Do not run stat worker in BR.
+		session.DisableStats4Test()
+	}
+
 	if err := task.RunBackup(ctx, tidbGlue, cmdName, &cfg); err != nil {
 		log.Error("failed to backup", zap.Error(err))
 		return errors.Trace(err)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/session"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"sourcegraph.com/sourcegraph/appdash"
@@ -90,6 +91,7 @@ func NewRestoreCommand() *cobra.Command {
 			}
 			utils.LogBRInfo()
 			task.LogArguments(c)
+			session.DisableStats4Test()
 
 			summary.SetUnit(summary.RestoreUnit)
 			return nil

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -83,7 +83,11 @@ func DefineBackupFlags(flags *pflag.FlagSet) {
 	// This flag can impact the online cluster, so hide it in case of abuse.
 	_ = flags.MarkHidden(flagRemoveSchedulers)
 
-	flags.Bool(flagIgnoreStats, false,
+	// Disable stats by default. because of
+	// 1. DumpStatsToJson is not stable
+	// 2. It increases memory usage may cause BR OOM
+	// TODO: we need a better way to backup/restore stats.
+	flags.Bool(flagIgnoreStats, true,
 		"ignore backup stats, used for test")
 	// This flag is used for test. we should backup stats all the time.
 	_ = flags.MarkHidden(flagIgnoreStats)

--- a/tests/br_full_ddl/run.sh
+++ b/tests/br_full_ddl/run.sh
@@ -71,7 +71,7 @@ echo "backup start..."
 unset BR_LOG_TO_TERM
 cluster_index_before_backup=$(run_sql "show variables like '%cluster%';" | awk '{print $2}')
 
-run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --log-file $LOG || cat $LOG
+run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4 --log-file $LOG --ignore-stats=false || cat $LOG
 checksum_count=$(cat $LOG | grep "checksum success" | wc -l | xargs)
 
 if [ "${checksum_count}" != "1" ];then

--- a/tests/br_full_ddl/run.sh
+++ b/tests/br_full_ddl/run.sh
@@ -66,7 +66,7 @@ run_sql "analyze table $DB.$TABLE;"
 curl $TIDB_IP:10080/stats/dump/$DB/$TABLE | jq '.columns.field0' | jq 'del(.last_update_version)' > $BACKUP_STAT
 
 # backup full
-echo "backup start..."
+echo "backup start with stats..."
 # Do not log to terminal
 unset BR_LOG_TO_TERM
 cluster_index_before_backup=$(run_sql "show variables like '%cluster%';" | awk '{print $2}')
@@ -80,6 +80,9 @@ if [ "${checksum_count}" != "1" ];then
     exit 1
 fi
 
+echo "backup start without stats..."
+run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/${DB}_disable_stats" --concurrency 4
+
 run_sql "DROP DATABASE $DB;"
 
 cluster_index_before_restore=$(run_sql "show variables like '%cluster%';" | awk '{print $2}')
@@ -90,6 +93,20 @@ if [[ "${cluster_index_before_backup}" != "${cluster_index_before_restore}" ]]; 
   echo "cluster index before restore is $cluster_index_before_restore"
   exit 1
 fi
+
+echo "restore full without stats..."
+run_br restore full -s "local://$TEST_DIR/${DB}_disable_stats" --pd $PD_ADDR
+curl $TIDB_IP:10080/stats/dump/$DB/$TABLE | jq '.columns.field0' | jq 'del(.last_update_version)' > $RESOTRE_STAT
+
+# stats should not be equal because we disable stats by default.
+if diff -q $BACKUP_STAT $RESOTRE_STAT > /dev/null
+then
+  echo "TEST: [$TEST_NAME] fail due to stats are equal"
+  exit 1
+fi
+
+# clear restore environment
+run_sql "DROP DATABASE $DB;"
 
 # restore full
 echo "restore start..."


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Disable backup stats by default. because of
1. DumpStatsToJson is not stable
2. It increases memory usage may cause BR OOM

### What is changed and how it works?
1. set `cfg.IgnoreStats` default to true
2. if `cfg.IgnoreStats` is true, set `statsLease` to -1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - Disable backup stats by default.

<!-- fill in the release note, or just write "No release note" -->
