### PR TITLE
metrics: use tidb_cluster label get variable values

### DIFF
--- a/metrics/grafana/br.json
+++ b/metrics/grafana/br.json
@@ -2897,7 +2897,7 @@
         "options": [
 
         ],
-        "query": "label_values(tikv_engine_size_bytes, cluster)",
+        "query": "label_values(tikv_engine_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The latest version of tidb-operator will use the instance name as the cluster label. The previous expression uses the cluster label got the value of the tidb_cluster variable. It will cause Grafana can not to display the data.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - No effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
