### PR TITLE
Fix the issue that rawkv restore's end key is incorrectly inclusive when restoring partial of backed up data (#201)

### DIFF
--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -415,9 +415,10 @@ func (importer *FileImporter) downloadRawKVSST(
 	if bytes.Compare(importer.rawStartKey, sstMeta.Range.GetStart()) > 0 {
 		sstMeta.Range.Start = importer.rawStartKey
 	}
-	// TODO: importer.RawEndKey is exclusive but sstMeta.Range.End is inclusive. How to exclude importer.RawEndKey?
-	if len(importer.rawEndKey) > 0 && bytes.Compare(importer.rawEndKey, sstMeta.Range.GetEnd()) < 0 {
+	if len(importer.rawEndKey) > 0 &&
+		(len(sstMeta.Range.GetEnd()) == 0 || bytes.Compare(importer.rawEndKey, sstMeta.Range.GetEnd()) <= 0) {
 		sstMeta.Range.End = importer.rawEndKey
+		sstMeta.EndKeyExclusive = true
 	}
 	if bytes.Compare(sstMeta.Range.GetStart(), sstMeta.Range.GetEnd()) > 0 {
 		return nil, errors.Trace(berrors.ErrKVRangeIsEmpty)
@@ -428,6 +429,7 @@ func (importer *FileImporter) downloadRawKVSST(
 		StorageBackend: importer.backend,
 		Name:           file.GetName(),
 		RewriteRule:    rule,
+		IsRawKv:        true,
 	}
 	log.Debug("download SST", logutil.SSTMeta(&sstMeta), logutil.Region(regionInfo.Region))
 	var err error

--- a/tests/br_rawkv/client.go
+++ b/tests/br_rawkv/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/crc64"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -18,12 +19,14 @@ import (
 
 var (
 	pdAddr      = flag.String("pd", "127.0.0.1:2379", "Address of PD")
-	runMode     = flag.String("mode", "", "Mode. One of 'rand-gen', 'checksum', 'scan' and 'diff'")
+	runMode     = flag.String("mode", "", "Mode. One of 'rand-gen', 'checksum', 'scan', 'diff', 'delete' and 'put'")
 	startKeyStr = flag.String("start-key", "", "Start key in hex")
 	endKeyStr   = flag.String("end-key", "", "End key in hex")
 	keyMaxLen   = flag.Int("key-max-len", 32, "Max length of keys for rand-gen mode")
 	concurrency = flag.Int("concurrency", 32, "Concurrency to run rand-gen")
 	duration    = flag.Int("duration", 10, "duration(second) of rand-gen")
+	putDataStr  = flag.String("put-data", "", "Kv pairs to put to the cluster in hex. "+
+		"kv pairs are separated by commas, key and value in a pair are separated by a colon")
 )
 
 func createClient(addr string) (*tikv.RawKVClient, error) {
@@ -42,8 +45,8 @@ func main() {
 	if err != nil {
 		log.Panic("Invalid endKey: %v, err: %+v", zap.String("endkey", *endKeyStr), zap.Error(err))
 	}
-
-	if len(endKey) == 0 {
+	// For "put" mode, the key range is not used. So no need to throw error here.
+	if len(endKey) == 0 && *runMode != "put" {
 		log.Panic("Empty endKey is not supported yet")
 	}
 
@@ -66,6 +69,8 @@ func main() {
 		err = scan(client, startKey, endKey)
 	case "delete":
 		err = deleteRange(client, startKey, endKey)
+	case "put":
+		err = put(client, *putDataStr)
 	}
 
 	if err != nil {
@@ -233,6 +238,7 @@ func checksum(client *tikv.RawKVClient, startKey, endKey []byte) error {
 	}
 
 	log.Info("Checksum result", zap.Uint64("checksum", res))
+	fmt.Printf("Checksum result: %016x\n", res)
 	return nil
 }
 
@@ -266,6 +272,35 @@ func scan(client *tikv.RawKVClient, startKey, endKey []byte) error {
 
 	log.Info("Finished Scanning.")
 	return nil
+}
+
+func put(client *tikv.RawKVClient, dataStr string) error {
+	keys := make([][]byte, 0)
+	values := make([][]byte, 0)
+
+	for _, pairStr := range strings.Split(dataStr, ",") {
+		pair := strings.Split(pairStr, ":")
+		if len(pair) != 2 {
+			return errors.Errorf("invalid kv pair string %q", pairStr)
+		}
+
+		key, err := hex.DecodeString(strings.Trim(pair[0], " "))
+		if err != nil {
+			return errors.Annotatef(err, "invalid kv pair string %q", pairStr)
+		}
+		value, err := hex.DecodeString(strings.Trim(pair[1], " "))
+		if err != nil {
+			return errors.Annotatef(err, "invalid kv pair string %q", pairStr)
+		}
+
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+
+	log.Info("Put rawkv data", zap.ByteStrings("keys", keys), zap.ByteStrings("values", values))
+
+	err := client.BatchPut(keys, values)
+	return errors.Trace(err)
 }
 
 const defaultScanBatchSize = 128


### PR DESCRIPTION
cherry-picks https://github.com/pingcap/br/pull/201 to release-4.0

---

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR fixes the issue that rawkv restore's end key is incorrectly inclusive when restoring partial of backed up data. See https://github.com/tikv/tikv/issues/7163

### What is changed and how it works?

This PR adds is_raw_kv field to DownloadRequest and adds end_key_exclusive field to SstMeta. For SST files that contains the restoring end key in its range, it will cut the file's end key to the restoring endKey, and set end_key_exclusive.

- [x] kvproto: https://github.com/pingcap/kvproto/pull/581
- [x] tikv: https://github.com/tikv/tikv/pull/7196

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported variable/fields change
  - Added is_raw_kv to kvproto `DownlaodRequest`
  - Added end_key_exclusive to kvproto `SstMeta`

Side effects

\-

Related changes

 - Need to cherry-pick to the release branch
  - release-3.1 and release-4.0

### Release note

* Fix the issue that in rawkv mode, the end key of restoring range may be included, which is expected to be exclusive.