### PR TITLE
Log fold is unstable when doing create and drop table operation and thus affect br restore using cdc log

### DIFF
--- a/pkg/restore/log_client_test.go
+++ b/pkg/restore/log_client_test.go
@@ -96,3 +96,34 @@ func (s *testLogRestoreSuite) TestTsInRange(c *C) {
 		c.Assert(collected, IsFalse)
 	}
 }
+
+func (s *testLogRestoreSuite) TestCollectRowChangeFiles(c *C) {
+	meta := s.client.GetMeta()
+
+	// t1 with three table id
+	meta.Names[1] = "`db1`.`t1`"
+	meta.Names[2] = "`db1`.`t1`"
+	meta.Names[23] = "`db1`.`t1`"
+
+	maps := s.client.GetNameIdMap()
+	ids, err = maps["`db1`.`t1`"]
+
+	c.Assert(err, IsNil)
+
+	l := len(ids)
+
+	c.Assert(l, 3)
+
+	c.Assert(contains(ids, 1), true)
+	c.Assert(contains(ids, 2), true)
+	c.Assert(contains(ids, 3), true)
+}
+
+func contains(s []int64, e int64) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION


<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
see https://github.com/pingcap/ticdc/issues/1415

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 -

<!-- fill in the release note, or just write "No release note" -->
