### PR TITLE
tests: fix lightning integration test checkpoint_engines

### DIFF
--- a/tests/lightning_checkpoint_engines/run.sh
+++ b/tests/lightning_checkpoint_engines/run.sh
@@ -79,6 +79,7 @@ for BACKEND in importer local; do
 
   run_sql 'DROP DATABASE cpeng;'
   run_sql 'DROP DATABASE IF EXISTS tidb_lightning_checkpoint;'
+  rm -rf $TEST_DIR/lightning_checkpoint_engines.sorted
 
   set +e
   for i in $(seq "$ENGINE_COUNT"); do


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix lightning integration test `checkpoint_engines` by clean up useless files.
Close #768 

### What is changed and how it works?
#768 is caused by when lightning was killed after import engine success but before engine clean up, files in pebble db directory are not fully deleted, thus open pebble db with the remaining files may return unexpected errors.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
   - Run target integration test in a local environment more than 100 times and this error didn't appear. 
 - No code

Code changes


Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
