### PR TITLE
tests: create bucket only once and remove bucket via mc

### DIFF
--- a/tests/br_s3/run.sh
+++ b/tests/br_s3/run.sh
@@ -46,9 +46,10 @@ for i in $(seq $DB_COUNT); do
     run_sql "CREATE DATABASE $DB${i};"
     go-ycsb load mysql -P tests/$TEST_NAME/workload -p mysql.host=$TIDB_IP -p mysql.port=$TIDB_PORT -p mysql.user=root -p mysql.db=$DB${i}
 done
+
+bin/mc mb --config-dir "$TEST_DIR/$TEST_NAME" minio/mybucket
 S3_KEY=""
 for p in $(seq 2); do
-  bin/mc mb --config-dir "$TEST_DIR/$TEST_NAME" minio/mybucket
 
   for i in $(seq $DB_COUNT); do
       row_count_ori[${i}]=$(run_sql "SELECT COUNT(*) FROM $DB${i}.$TABLE;" | awk '/COUNT/{print $2}')
@@ -109,11 +110,10 @@ for p in $(seq 2); do
   fi
 
   # prepare for next test
+  bin/mc rm --config-dir "$TEST_DIR/$TEST_NAME" --recursive --force minio/mybucket
   S3_KEY="&access-key=$MINIO_ACCESS_KEY&secret-access-key=$MINIO_SECRET_KEY"
   export AWS_ACCESS_KEY_ID=""
   export AWS_SECRET_ACCESS_KEY=""
-  rm -rf "$TEST_DIR/$DB"
-  mkdir -p "$TEST_DIR/$DB"
 done
 
 for i in $(seq $DB_COUNT); do


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

create bucket only once and remove bucket via mc to fix CI failure

```
[2021-03-02T08:25:27.024Z] + bin/mc mb --config-dir /tmp/backup_restore_test/br_s3 minio/mybucket
[2021-03-02T08:25:27.024Z] mc: <ERROR> Unable to make bucket `minio/mybucket`. The specified bucket does not exist
```

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/br_ghpr_unit_and_integration_test/detail/br_ghpr_unit_and_integration_test/5038/pipeline/#step-987-log-442

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
