### PR TITLE
tests: fix oauth process is not killed in gcs test

### DIFF
--- a/tests/br_gcs/run.sh
+++ b/tests/br_gcs/run.sh
@@ -38,8 +38,8 @@ done
 bin/oauth &
 
 stop_gcs() {
-    killall -2 fake-gcs-server || true
-    killall -2 oauth || true
+    killall -9 fake-gcs-server || true
+    killall -9 oauth || true
 }
 trap stop_gcs EXIT
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

I happened to meet an unexpected port occupation in CI env.

```
[jenkins@test-go1130-memvolume-23ljz agent]$ lsof -i :5000
COMMAND   PID    USER   FD   TYPE     DEVICE SIZE/OFF NODE NAME
oauth   17595 jenkins    3u  IPv6 1974781415      0t0  TCP *:commplex-main (LISTEN)
[jenkins@test-go1130-memvolume-23ljz agent]$ pwdx 17595
17595: /home/jenkins/agent/workspace/br_ghpr_unit_and_integration_test/go/src/github.com/pingcap/br
```

### What is changed and how it works?

use `killall -9` to kill `oauth`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


### Release Note

No release note