### PR TITLE
tests: fix integration test checkpoint_error_destroy

### DIFF
--- a/pkg/lightning/backend/session.go
+++ b/pkg/lightning/backend/session.go
@@ -203,6 +203,7 @@ func newSession(options *SessionOptions) *session {
 	vars.StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	vars.StmtCtx.AllowInvalidDate = sqlMode.HasAllowInvalidDatesMode()
 	vars.StmtCtx.IgnoreZeroInDate = !sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()
+	vars.SQLMode = sqlMode
 	if options.SysVars != nil {
 		for k, v := range options.SysVars {
 			vars.SetSystemVar(k, v)

--- a/tests/lightning_checkpoint_error_destroy/file.toml
+++ b/tests/lightning_checkpoint_error_destroy/file.toml
@@ -2,3 +2,6 @@
 enable = true
 driver = "file"
 dsn = "/tmp/cp_error_destroy.pb"
+
+[tidb]
+sql-mode = 'STRICT_ALL_TABLES'

--- a/tests/lightning_checkpoint_error_destroy/mysql.toml
+++ b/tests/lightning_checkpoint_error_destroy/mysql.toml
@@ -1,3 +1,6 @@
 [checkpoint]
 enable = true
 driver = "mysql"
+
+[tidb]
+sql-mode = 'STRICT_ALL_TABLES'


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix integration test `lightning_checkpoint_error_destroy`

Close #789 

### What is changed and how it works?
- Set `SqlMode` to sessionctx, so CastValue can return error in strict-mode
- Add `sql-mode = 'STRICT_ALL_TABLES'` to `lightning_checkpoint_error_destroy` configure so encode can return error when meets invalid timestamp value.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
