### PR TITLE
tests: extend minio wait time to stable minio slow start

### DIFF
--- a/tests/br_log_restore/run.sh
+++ b/tests/br_log_restore/run.sh
@@ -33,7 +33,7 @@ bin/minio server --address $S3_ENDPOINT "$TEST_DIR/$DB" &
 i=0
 while ! curl -o /dev/null -s "http://$S3_ENDPOINT/"; do
     i=$(($i+1))
-    if [ $i -gt 7 ]; then
+    if [ $i -gt 30 ]; then
         echo 'Failed to start minio'
         exit 1
     fi

--- a/tests/br_s3/run.sh
+++ b/tests/br_s3/run.sh
@@ -31,7 +31,7 @@ bin/minio server --address $S3_ENDPOINT "$TEST_DIR/$DB" &
 i=0
 while ! curl -o /dev/null -v -s "http://$S3_ENDPOINT/"; do
     i=$(($i+1))
-    if [ $i -gt 7 ]; then
+    if [ $i -gt 30 ]; then
         echo 'Failed to start minio'
         exit 1
     fi

--- a/tests/lightning_s3/run.sh
+++ b/tests/lightning_s3/run.sh
@@ -32,21 +32,15 @@ export S3_ENDPOINT=127.0.0.1:9900
 rm -rf "$TEST_DIR/$DB"
 mkdir -p "$TEST_DIR/$DB"
 bin/minio server --address $S3_ENDPOINT "$DBPATH" &
-MINIO_PID=$!
 i=0
 while ! curl -o /dev/null -v -s "http://$S3_ENDPOINT/"; do
     i=$(($i+1))
-    if [ $i -gt 7 ]; then
+    if [ $i -gt 30 ]; then
         echo 'Failed to start minio'
         exit 1
     fi
     sleep 2
 done
-
-stop_minio() {
-    kill -2 $MINIO_PID
-}
-trap stop_minio EXIT
 
 BUCKET=test-bucket
 DATA_PATH=$DBPATH/$BUCKET


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Minio server may be slow to start, so extend wait time to stable tests.

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/br_ghpr_unit_and_integration_test/detail/br_ghpr_unit_and_integration_test/5239/pipeline/#step-1448-log-88

The test above shows starting a minio server may require 14 seconds or more.

Close #799 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
