### PR TITLE
lightning: fix several disk-quota-related bugs

### DIFF
--- a/pkg/lightning/backend/backend.go
+++ b/pkg/lightning/backend/backend.go
@@ -163,7 +163,7 @@ type AbstractBackend interface {
 	ResetEngine(ctx context.Context, engineUUID uuid.UUID) error
 
 	// LocalWriter obtains a thread-local EngineWriter for writing rows into the given engine.
-	LocalWriter(ctx context.Context, engineUUID uuid.UUID, maxCacheSize int64) (EngineWriter, error)
+	LocalWriter(ctx context.Context, engineUUID uuid.UUID) (EngineWriter, error)
 }
 
 func fetchRemoteTableModelsFromTLS(ctx context.Context, tls *common.TLS, schema string) ([]*model.TableInfo, error) {
@@ -345,21 +345,8 @@ func (engine *OpenedEngine) Flush(ctx context.Context) error {
 	return engine.backend.FlushEngine(ctx, engine.uuid)
 }
 
-// WriteRows writes a collection of encoded rows into the engine.
-func (engine *OpenedEngine) WriteRows(ctx context.Context, columnNames []string, rows Rows) error {
-	writer, err := engine.backend.LocalWriter(ctx, engine.uuid, LocalMemoryTableSize)
-	if err != nil {
-		return err
-	}
-	if err = writer.AppendRows(ctx, engine.tableName, columnNames, engine.ts, rows); err != nil {
-		writer.Close()
-		return err
-	}
-	return writer.Close()
-}
-
-func (engine *OpenedEngine) LocalWriter(ctx context.Context, maxCacheSize int64) (*LocalEngineWriter, error) {
-	w, err := engine.backend.LocalWriter(ctx, engine.uuid, maxCacheSize)
+func (engine *OpenedEngine) LocalWriter(ctx context.Context) (*LocalEngineWriter, error) {
+	w, err := engine.backend.LocalWriter(ctx, engine.uuid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lightning/backend/backend.go
+++ b/pkg/lightning/backend/backend.go
@@ -371,6 +371,10 @@ func (w *LocalEngineWriter) WriteRows(ctx context.Context, columnNames []string,
 	return w.writer.AppendRows(ctx, w.tableName, columnNames, w.ts, rows)
 }
 
+func (w *LocalEngineWriter) IsSynchronized() bool {
+	return w.writer.IsSynchronized()
+}
+
 func (w *LocalEngineWriter) Close() error {
 	return w.writer.Close()
 }
@@ -486,5 +490,10 @@ type EngineWriter interface {
 		commitTS uint64,
 		rows Rows,
 	) error
+
+	// IsSynchronized returns whether the content of the writer has been
+	// entirely synchronized into disk.
+	IsSynchronized() bool
+
 	Close() error
 }

--- a/pkg/lightning/backend/importer.go
+++ b/pkg/lightning/backend/importer.go
@@ -403,3 +403,7 @@ func (w *ImporterWriter) Close() error {
 func (w *ImporterWriter) AppendRows(ctx context.Context, tableName string, columnNames []string, ts uint64, rows Rows) error {
 	return w.importer.WriteRows(ctx, w.engineUUID, tableName, columnNames, ts, rows)
 }
+
+func (w *ImporterWriter) IsSynchronized() bool {
+	return true
+}

--- a/pkg/lightning/backend/importer.go
+++ b/pkg/lightning/backend/importer.go
@@ -387,7 +387,7 @@ func (importer *importer) ResetEngine(context.Context, uuid.UUID) error {
 	return errors.New("cannot reset an engine in importer backend")
 }
 
-func (importer *importer) LocalWriter(ctx context.Context, engineUUID uuid.UUID, maxCacheSize int64) (EngineWriter, error) {
+func (importer *importer) LocalWriter(ctx context.Context, engineUUID uuid.UUID) (EngineWriter, error) {
 	return &ImporterWriter{importer: importer, engineUUID: engineUUID}, nil
 }
 

--- a/pkg/lightning/backend/local.go
+++ b/pkg/lightning/backend/local.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/coreos/go-semver/semver"
+	"github.com/docker/go-units"
 	"github.com/google/btree"
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
@@ -76,8 +77,18 @@ const (
 
 	propRangeIndex = "tikv.range_index"
 
-	defaultPropSizeIndexDistance = 4 * 1024 * 1024 // 4MB
+	defaultPropSizeIndexDistance = 4 * units.MiB
 	defaultPropKeysIndexDistance = 40 * 1024
+
+	// defaultLocalWriterKVsChannelCap is the capacity of the
+	// LocalWriter.kvsChan field, which acts as the buffer between local writer
+	// and deliverLoop. Each entry in the channel can be observed from metrics
+	//
+	//		2 * sum(lightning_block_deliver_bytes_sum) / sum(lightning_block_deliver_bytes_count)
+	//
+	// which has a minimum size of 64 KB and a maximum size depending on the KV
+	// encoding of each row. It can be as high as 1 MiB.
+	defaultLocalWriterKVsChannelCap = 16
 
 	// the lower threshold of max open files for pebble db.
 	openFilesLowerThreshold = 128
@@ -1469,7 +1480,7 @@ func (local *local) LocalWriter(ctx context.Context, engineUUID uuid.UUID) (Engi
 func openLocalWriter(f *LocalFile, sstDir string, memtableSizeLimit int64) *LocalWriter {
 	w := &LocalWriter{
 		sstDir:            sstDir,
-		kvsChan:           make(chan []common.KvPair, 1024),
+		kvsChan:           make(chan []common.KvPair, defaultLocalWriterKVsChannelCap),
 		flushCh:           make(chan chan error),
 		consumeCh:         make(chan struct{}, 1),
 		local:             f,

--- a/pkg/lightning/backend/tidb.go
+++ b/pkg/lightning/backend/tidb.go
@@ -580,3 +580,7 @@ func (w *TiDBWriter) Close() error {
 func (w *TiDBWriter) AppendRows(ctx context.Context, tableName string, columnNames []string, arg1 uint64, rows Rows) error {
 	return w.be.WriteRows(ctx, w.engineUUID, tableName, columnNames, arg1, rows)
 }
+
+func (w *TiDBWriter) IsSynchronized() bool {
+	return true
+}

--- a/pkg/lightning/backend/tidb.go
+++ b/pkg/lightning/backend/tidb.go
@@ -564,7 +564,7 @@ func (be *tidbBackend) ResetEngine(context.Context, uuid.UUID) error {
 	return errors.New("cannot reset an engine in TiDB backend")
 }
 
-func (be *tidbBackend) LocalWriter(ctx context.Context, engineUUID uuid.UUID, maxCacheSize int64) (EngineWriter, error) {
+func (be *tidbBackend) LocalWriter(ctx context.Context, engineUUID uuid.UUID) (EngineWriter, error) {
 	return &TiDBWriter{be: be, engineUUID: engineUUID}, nil
 }
 

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -70,19 +70,9 @@ const (
 	defaultBuildStatsConcurrency      = 20
 	defaultIndexSerialScanConcurrency = 20
 	defaultChecksumTableConcurrency   = 2
-)
 
-const (
-	LocalMemoryTableSize = 512 * units.MiB
-
-	// autoDiskQuotaLocalReservedSize is the estimated size a local-backend
-	// engine may gain after calling Flush(). This is currently defined by its
-	// max MemTable size (512 MiB). It is used to compensate for the soft limit
-	// of the disk quota against the hard limit of the disk free space.
-	//
-	// With a maximum of 8 engines, this should contribute 4.0 GiB to the
-	// reserved size.
-	autoDiskQuotaLocalReservedSize uint64 = LocalMemoryTableSize
+	defaultEngineMemCacheSize      = 512 * units.MiB
+	defaultLocalWriterMemCacheSize = 128 * units.MiB
 
 	// autoDiskQuotaLocalReservedSpeed is the estimated size increase per
 	// millisecond per write thread the local backend may gain on all engines.
@@ -286,6 +276,9 @@ type TikvImporter struct {
 	SortedKVDir      string   `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
 	DiskQuota        ByteSize `toml:"disk-quota" json:"disk-quota"`
 	RangeConcurrency int      `toml:"range-concurrency" json:"range-concurrency"`
+
+	EngineMemCacheSize      ByteSize `toml:"engine-mem-cache-size" json:"engine-mem-cache-size"`
+	LocalWriterMemCacheSize ByteSize `toml:"local-writer-mem-cache-size" json:"local-writer-mem-cache-size"`
 }
 
 type Checkpoint struct {
@@ -575,6 +568,14 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 		return errors.Errorf("invalid config: unsupported `tikv-importer.backend` (%s)", cfg.TikvImporter.Backend)
 	}
 
+	// TODO calculate these from the machine's free memory.
+	if cfg.TikvImporter.EngineMemCacheSize == 0 {
+		cfg.TikvImporter.EngineMemCacheSize = defaultEngineMemCacheSize
+	}
+	if cfg.TikvImporter.LocalWriterMemCacheSize == 0 {
+		cfg.TikvImporter.LocalWriterMemCacheSize = defaultLocalWriterMemCacheSize
+	}
+
 	if cfg.TikvImporter.Backend == BackendLocal {
 		if len(cfg.TikvImporter.SortedKVDir) == 0 {
 			return errors.Errorf("tikv-importer.sorted-kv-dir must not be empty!")
@@ -598,7 +599,7 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 		if cfg.TikvImporter.DiskQuota == 0 {
 			enginesCount := uint64(cfg.App.IndexConcurrency + cfg.App.TableConcurrency)
 			writeAmount := uint64(cfg.App.RegionConcurrency) * uint64(cfg.Cron.CheckDiskQuota.Milliseconds())
-			reservedSize := enginesCount*autoDiskQuotaLocalReservedSize + writeAmount*autoDiskQuotaLocalReservedSpeed
+			reservedSize := enginesCount*uint64(cfg.TikvImporter.EngineMemCacheSize) + writeAmount*autoDiskQuotaLocalReservedSpeed
 
 			storageSize, err := common.GetStorageSize(storageSizeDir)
 			if err != nil {
@@ -612,6 +613,9 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 					units.BytesSize(float64(reservedSize)))
 			}
 			cfg.TikvImporter.DiskQuota = ByteSize(storageSize.Available - reservedSize)
+		}
+		if cfg.TikvImporter.DiskQuota < cfg.TikvImporter.LocalWriterMemCacheSize {
+			cfg.TikvImporter.LocalWriterMemCacheSize = cfg.TikvImporter.DiskQuota
 		}
 	}
 

--- a/pkg/lightning/lightning.go
+++ b/pkg/lightning/lightning.go
@@ -675,7 +675,9 @@ func checkSystemRequirement(cfg *config.Config, dbsMeta []*mydump.MDDatabaseMeta
 			topNTotalSize += tableTotalSizes[i]
 		}
 
-		estimateMaxFiles := uint64(topNTotalSize/backend.LocalMemoryTableSize) * 2
+		// region-concurrency: number of LocalWriters writing SST files.
+		// 2*totalSize/memCacheSize: number of Pebble MemCache files.
+		estimateMaxFiles := uint64(cfg.App.RegionConcurrency) + uint64(topNTotalSize)/uint64(cfg.TikvImporter.EngineMemCacheSize)*2
 		if err := backend.VerifyRLimit(estimateMaxFiles); err != nil {
 			return err
 		}

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -227,8 +227,7 @@ func NewRestoreControllerWithPauser(
 			maxOpenFiles = math.MaxInt32
 		}
 
-		backend, err = kv.NewLocalBackend(ctx, tls, cfg.TiDB.PdAddr, int64(cfg.TikvImporter.RegionSplitSize),
-			cfg.TikvImporter.SortedKVDir, cfg.TikvImporter.RangeConcurrency, cfg.TikvImporter.SendKVPairs,
+		backend, err = kv.NewLocalBackend(ctx, tls, cfg.TiDB.PdAddr, &cfg.TikvImporter,
 			cfg.Checkpoint.Enable, g, maxOpenFiles)
 		if err != nil {
 			return nil, errors.Annotate(err, "build local backend failed")
@@ -1429,19 +1428,7 @@ func (t *TableRestore) restoreEngine(
 		return closedEngine, nil
 	}
 
-	// In Local backend, the local writer will produce an SST file for batch
-	// ingest into the local DB every 1000 KV pairs or up to 512 MiB.
-	// There are (region-concurrency) data writers, and (index-concurrency) index writers.
-	// Thus, the disk size occupied by these writers are up to
-	// (region-concurrency + index-concurrency) * 512 MiB.
-	// This number should not exceed the disk quota.
-	// Therefore, we need to reduce that "512 MiB" to respect the disk quota:
-	localWriterMaxCacheSize := int64(rc.cfg.TikvImporter.DiskQuota) // int64(rc.cfg.App.IndexConcurrency+rc.cfg.App.RegionConcurrency)
-	if localWriterMaxCacheSize > config.LocalMemoryTableSize {
-		localWriterMaxCacheSize = config.LocalMemoryTableSize
-	}
-
-	indexWriter, err := indexEngine.LocalWriter(ctx, localWriterMaxCacheSize)
+	indexWriter, err := indexEngine.LocalWriter(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1490,7 +1477,7 @@ func (t *TableRestore) restoreEngine(
 
 		restoreWorker := rc.regionWorkers.Apply()
 		wg.Add(1)
-		dataWriter, err := dataEngine.LocalWriter(ctx, localWriterMaxCacheSize)
+		dataWriter, err := dataEngine.LocalWriter(ctx)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -105,6 +105,12 @@ addr = "127.0.0.1:8287"
 # this default config can make full use of a 10Gib bandwidth network, if the network bandwidth is higher, you can increase
 # this to gain better performance. Larger value will also increase the memory usage slightly.
 #range-concurrency = 16
+# The memory cache used in local backend for each engine. The memory usage during write-KV phase by the engines is bound
+# by (index-concurrency + table-concurrency) * engine-mem-cache-size.
+#engine-mem-cache-size = '512MiB'
+# The memory cache used in for local sorting during the encode-KV phase before flushing into the engines. The memory
+# usage is bound by region-concurrency * local-writer-mem-cache-size.
+#local-writer-mem-cache-size = '256MiB'
 
 [mydumper]
 # block size of file reading


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. Fix #812
2. Fix the bug where the checkpoints in local back-end are not advanced even after disk quota force-flushed all engines.

### What is changed and how it works?

1. For #812, it is caused by iterating `cp.Engines` in `restoreEngines()`, which is a hash map. We read the map into a sorted array and iterate that instead, so engines are always restored in deterministic order.
2. For the checkpoint issue, we now update the checkpoint based on the Local Writer's synchronization status instead of the disk quota status (the deliverLoop cannot see `diskQuotaStateImporting` during `diskQuotaLock.RLock()`). *This assumes Pebble's `Ingest()` will persist all content to disk*.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test (TODO)
 - Manual test (add detailed scripts or steps below)
    * Testing its effect in the 1T GA test.

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note.


