### PR TITLE
pkg/kv:remove set/delete option from transaction

### DIFF
--- a/pkg/kv/session.go
+++ b/pkg/kv/session.go
@@ -167,12 +167,6 @@ func (t *transaction) Delete(k kv.Key) error {
 	return t.kvMemBuf.Delete(k)
 }
 
-// SetOption implements the kv.Transaction interface.
-func (t *transaction) SetOption(opt kv.Option, val interface{}) {}
-
-// DelOption implements the kv.Transaction interface.
-func (t *transaction) DelOption(kv.Option) {}
-
 // SetAssertion implements the kv.Transaction interface.
 func (t *transaction) SetAssertion(kv.Key, kv.AssertionType) {}
 

--- a/pkg/kv/session_test.go
+++ b/pkg/kv/session_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
-	tidbkv "github.com/pingcap/tidb/kv"
 )
 
 type kvSuite struct{}
@@ -29,9 +28,8 @@ func TestKV(t *testing.T) {
 	TestingT(t)
 }
 
-func (s *kvSuite) TestSetOption(c *C) {
+func (s *kvSuite) TestSession(c *C) {
 	session := newSession(&SessionOptions{SQLMode: mysql.ModeNone, Timestamp: 1234567890, RowFormatVersion: "1"})
-	txn, err := session.Txn(true)
+	_, err := session.Txn(true)
 	c.Assert(err, IsNil)
-	txn.SetOption(tidbkv.Priority, tidbkv.PriorityHigh)
 }

--- a/pkg/lightning/backend/session.go
+++ b/pkg/lightning/backend/session.go
@@ -150,12 +150,6 @@ func (t *transaction) Set(k kv.Key, v []byte) error {
 	return t.kvMemBuf.Set(k, v)
 }
 
-// SetOption implements the kv.Transaction interface
-func (t *transaction) SetOption(opt kv.Option, val interface{}) {}
-
-// DelOption implements the kv.Transaction interface
-func (t *transaction) DelOption(kv.Option) {}
-
 // SetAssertion implements the kv.Transaction interface
 func (t *transaction) SetAssertion(kv.Key, kv.AssertionType) {}
 

--- a/pkg/lightning/backend/session_test.go
+++ b/pkg/lightning/backend/session_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
-	tidbkv "github.com/pingcap/tidb/kv"
 )
 
 type kvSuite struct{}
@@ -29,9 +28,8 @@ func TestKV(t *testing.T) {
 	TestingT(t)
 }
 
-func (s *kvSuite) TestSetOption(c *C) {
+func (s *kvSuite) TestSession(c *C) {
 	session := newSession(&SessionOptions{SQLMode: mysql.ModeNone, Timestamp: 1234567890})
-	txn, err := session.Txn(true)
+	_, err := session.Txn(true)
 	c.Assert(err, IsNil)
-	txn.SetOption(tidbkv.Priority, tidbkv.PriorityHigh)
 }


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR removes setOption and delOption from the implementation of the transaction in br
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

 - Unit test



### Release Note

- No release note
