### PR TITLE
lightning/restore: save checkpoint as soon as local writers are sync

### DIFF
--- a/pkg/lightning/backend/backend.go
+++ b/pkg/lightning/backend/backend.go
@@ -371,6 +371,10 @@ func (w *LocalEngineWriter) WriteRows(ctx context.Context, columnNames []string,
 	return w.writer.AppendRows(ctx, w.tableName, columnNames, w.ts, rows)
 }
 
+func (w *LocalEngineWriter) IsSynchronized() bool {
+	return w.writer.IsSynchronized()
+}
+
 func (w *LocalEngineWriter) Close() error {
 	return w.writer.Close()
 }
@@ -486,5 +490,11 @@ type EngineWriter interface {
 		commitTS uint64,
 		rows Rows,
 	) error
+
+	// IsSynchronized returns whether the content of the writer has been
+	// entirely synchronized into a permanant storage which persists even after
+	// Lightning restarts.
+	IsSynchronized() bool
+
 	Close() error
 }

--- a/pkg/lightning/backend/importer.go
+++ b/pkg/lightning/backend/importer.go
@@ -408,3 +408,7 @@ func (w *ImporterWriter) Close() error {
 func (w *ImporterWriter) AppendRows(ctx context.Context, tableName string, columnNames []string, ts uint64, rows Rows) error {
 	return w.importer.WriteRows(ctx, w.engineUUID, tableName, columnNames, ts, rows)
 }
+
+func (w *ImporterWriter) IsSynchronized() bool {
+	return true
+}

--- a/pkg/lightning/backend/tidb.go
+++ b/pkg/lightning/backend/tidb.go
@@ -581,3 +581,7 @@ func (w *TiDBWriter) Close() error {
 func (w *TiDBWriter) AppendRows(ctx context.Context, tableName string, columnNames []string, arg1 uint64, rows Rows) error {
 	return w.be.WriteRows(ctx, w.engineUUID, tableName, columnNames, arg1, rows)
 }
+
+func (w *TiDBWriter) IsSynchronized() bool {
+	return true
+}

--- a/pkg/mock/backend.go
+++ b/pkg/mock/backend.go
@@ -456,3 +456,17 @@ func (mr *MockEngineWriterMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockEngineWriter)(nil).Close))
 }
+
+// IsSynchronized mocks base method
+func (m *MockEngineWriter) IsSynchronized() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSynchronized")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSynchronized indicates an expected call of IsSynchronized
+func (mr *MockEngineWriterMockRecorder) IsSynchronized() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSynchronized", reflect.TypeOf((*MockEngineWriter)(nil).IsSynchronized))
+}

--- a/tests/lightning_local_backend/run.sh
+++ b/tests/lightning_local_backend/run.sh
@@ -98,7 +98,7 @@ for ckpt in mysql file; do
 
   # when position of chunk file doesn't equal to offset, intermediate file should exist
   set +e
-  export GO_FAILPOINTS="github.com/pingcap/br/pkg/lightning/restore/LocalBackendSaveCheckpoint=return;github.com/pingcap/br/pkg/lightning/restore/FailIfImportedChunk=return(1)"
+  export GO_FAILPOINTS="github.com/pingcap/br/pkg/lightning/restore/FailIfImportedChunk=return(1)"
   run_lightning --backend local --enable-checkpoint=1 --log-file "$TEST_DIR/lightning-local.log" --config "tests/$TEST_NAME/$ckpt.toml"
   set -e
   run_lightning_ctl --check-local-storage \


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

(Split off from #815).

We now update the checkpoint based on the Local Writer's synchronization status instead of the disk quota status (the `deliverLoop` cannot see `diskQuotaStateImporting` during `diskQuotaLock.RLock()`). *This assumes Pebble's `Ingest()` will persist all content to disk.*

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test (TODO)

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
