### PR TITLE
lightning: reduce memory use

### DIFF
--- a/pkg/lightning/backend/backend.go
+++ b/pkg/lightning/backend/backend.go
@@ -163,7 +163,7 @@ type AbstractBackend interface {
 	ResetEngine(ctx context.Context, engineUUID uuid.UUID) error
 
 	// LocalWriter obtains a thread-local EngineWriter for writing rows into the given engine.
-	LocalWriter(ctx context.Context, engineUUID uuid.UUID, maxCacheSize int64) (EngineWriter, error)
+	LocalWriter(ctx context.Context, engineUUID uuid.UUID) (EngineWriter, error)
 }
 
 func fetchRemoteTableModelsFromTLS(ctx context.Context, tls *common.TLS, schema string) ([]*model.TableInfo, error) {
@@ -345,21 +345,8 @@ func (engine *OpenedEngine) Flush(ctx context.Context) error {
 	return engine.backend.FlushEngine(ctx, engine.uuid)
 }
 
-// WriteRows writes a collection of encoded rows into the engine.
-func (engine *OpenedEngine) WriteRows(ctx context.Context, columnNames []string, rows Rows) error {
-	writer, err := engine.backend.LocalWriter(ctx, engine.uuid, LocalMemoryTableSize)
-	if err != nil {
-		return err
-	}
-	if err = writer.AppendRows(ctx, engine.tableName, columnNames, engine.ts, rows); err != nil {
-		writer.Close()
-		return err
-	}
-	return writer.Close()
-}
-
-func (engine *OpenedEngine) LocalWriter(ctx context.Context, maxCacheSize int64) (*LocalEngineWriter, error) {
-	w, err := engine.backend.LocalWriter(ctx, engine.uuid, maxCacheSize)
+func (engine *OpenedEngine) LocalWriter(ctx context.Context) (*LocalEngineWriter, error) {
+	w, err := engine.backend.LocalWriter(ctx, engine.uuid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lightning/backend/backend_test.go
+++ b/pkg/lightning/backend/backend_test.go
@@ -125,20 +125,24 @@ func (s *backendSuite) TestWriteEngine(c *C) {
 		Return(nil)
 
 	mockWriter := mock.NewMockEngineWriter(s.controller)
-	s.mockBackend.EXPECT().LocalWriter(ctx, gomock.Any(), int64(kv.LocalMemoryTableSize)).Return(mockWriter, nil).AnyTimes()
+	s.mockBackend.EXPECT().LocalWriter(ctx, gomock.Any()).Return(mockWriter, nil)
 	mockWriter.EXPECT().
 		AppendRows(ctx, "`db`.`table`", []string{"c1", "c2"}, gomock.Any(), rows1).
 		Return(nil)
-	mockWriter.EXPECT().Close().Return(nil).AnyTimes()
 	mockWriter.EXPECT().
 		AppendRows(ctx, "`db`.`table`", []string{"c1", "c2"}, gomock.Any(), rows2).
 		Return(nil)
+	mockWriter.EXPECT().Close().Return(nil)
 
 	engine, err := s.backend.OpenEngine(ctx, "`db`.`table`", 1)
 	c.Assert(err, IsNil)
-	err = engine.WriteRows(ctx, []string{"c1", "c2"}, rows1)
+	writer, err := engine.LocalWriter(ctx)
 	c.Assert(err, IsNil)
-	err = engine.WriteRows(ctx, []string{"c1", "c2"}, rows2)
+	err = writer.WriteRows(ctx, []string{"c1", "c2"}, rows1)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(ctx, []string{"c1", "c2"}, rows2)
+	c.Assert(err, IsNil)
+	err = writer.Close()
 	c.Assert(err, IsNil)
 }
 
@@ -148,16 +152,20 @@ func (s *backendSuite) TestWriteToEngineWithNothing(c *C) {
 
 	ctx := context.Background()
 	emptyRows := mock.NewMockRows(s.controller)
-	writer := mock.NewMockEngineWriter(s.controller)
+	mockWriter := mock.NewMockEngineWriter(s.controller)
 
 	s.mockBackend.EXPECT().OpenEngine(ctx, gomock.Any()).Return(nil)
-	writer.EXPECT().AppendRows(ctx, gomock.Any(), gomock.Any(), gomock.Any(), emptyRows).Return(nil)
-	writer.EXPECT().Close().Return(nil)
-	s.mockBackend.EXPECT().LocalWriter(ctx, gomock.Any(), int64(kv.LocalMemoryTableSize)).Return(writer, nil)
+	mockWriter.EXPECT().AppendRows(ctx, gomock.Any(), gomock.Any(), gomock.Any(), emptyRows).Return(nil)
+	mockWriter.EXPECT().Close().Return(nil)
+	s.mockBackend.EXPECT().LocalWriter(ctx, gomock.Any()).Return(mockWriter, nil)
 
 	engine, err := s.backend.OpenEngine(ctx, "`db`.`table`", 1)
 	c.Assert(err, IsNil)
-	err = engine.WriteRows(ctx, nil, emptyRows)
+	writer, err := engine.LocalWriter(ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(ctx, nil, emptyRows)
+	c.Assert(err, IsNil)
+	err = writer.Close()
 	c.Assert(err, IsNil)
 }
 
@@ -183,7 +191,7 @@ func (s *backendSuite) TestWriteEngineFailed(c *C) {
 
 	s.mockBackend.EXPECT().OpenEngine(ctx, gomock.Any()).Return(nil)
 	mockWriter := mock.NewMockEngineWriter(s.controller)
-	s.mockBackend.EXPECT().LocalWriter(ctx, gomock.Any(), int64(kv.LocalMemoryTableSize)).Return(mockWriter, nil).AnyTimes()
+	s.mockBackend.EXPECT().LocalWriter(ctx, gomock.Any()).Return(mockWriter, nil).AnyTimes()
 	mockWriter.EXPECT().
 		AppendRows(ctx, gomock.Any(), gomock.Any(), gomock.Any(), rows).
 		Return(errors.Annotate(context.Canceled, "fake unrecoverable write error"))
@@ -191,8 +199,12 @@ func (s *backendSuite) TestWriteEngineFailed(c *C) {
 
 	engine, err := s.backend.OpenEngine(ctx, "`db`.`table`", 1)
 	c.Assert(err, IsNil)
-	err = engine.WriteRows(ctx, nil, rows)
+	writer, err := engine.LocalWriter(ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(ctx, nil, rows)
 	c.Assert(err, ErrorMatches, "fake unrecoverable write error.*")
+	err = writer.Close()
+	c.Assert(err, IsNil)
 }
 
 func (s *backendSuite) TestWriteBatchSendFailedWithRetry(c *C) {
@@ -204,7 +216,7 @@ func (s *backendSuite) TestWriteBatchSendFailedWithRetry(c *C) {
 
 	s.mockBackend.EXPECT().OpenEngine(ctx, gomock.Any()).Return(nil)
 	mockWriter := mock.NewMockEngineWriter(s.controller)
-	s.mockBackend.EXPECT().LocalWriter(ctx, gomock.Any(), int64(kv.LocalMemoryTableSize)).Return(mockWriter, nil).AnyTimes()
+	s.mockBackend.EXPECT().LocalWriter(ctx, gomock.Any()).Return(mockWriter, nil).AnyTimes()
 	mockWriter.EXPECT().AppendRows(ctx, gomock.Any(), gomock.Any(), gomock.Any(), rows).
 		Return(errors.New("fake recoverable write batch error")).
 		MinTimes(1)
@@ -212,8 +224,12 @@ func (s *backendSuite) TestWriteBatchSendFailedWithRetry(c *C) {
 
 	engine, err := s.backend.OpenEngine(ctx, "`db`.`table`", 1)
 	c.Assert(err, IsNil)
-	err = engine.WriteRows(ctx, nil, rows)
+	writer, err := engine.LocalWriter(ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(ctx, nil, rows)
 	c.Assert(err, ErrorMatches, ".*fake recoverable write batch error")
+	err = writer.Close()
+	c.Assert(err, IsNil)
 }
 
 func (s *backendSuite) TestImportFailedNoRetry(c *C) {

--- a/pkg/lightning/backend/importer.go
+++ b/pkg/lightning/backend/importer.go
@@ -389,7 +389,7 @@ func (importer *importer) ResetEngine(context.Context, uuid.UUID) error {
 	return errors.New("cannot reset an engine in importer backend")
 }
 
-func (importer *importer) LocalWriter(ctx context.Context, engineUUID uuid.UUID, maxCacheSize int64) (EngineWriter, error) {
+func (importer *importer) LocalWriter(ctx context.Context, engineUUID uuid.UUID) (EngineWriter, error) {
 	return &ImporterWriter{importer: importer, engineUUID: engineUUID}, nil
 }
 

--- a/pkg/lightning/backend/importer_test.go
+++ b/pkg/lightning/backend/importer_test.go
@@ -109,7 +109,11 @@ func (s *importerSuite) TestWriteRows(c *C) {
 		Return(nil, nil).
 		After(batchSendCall)
 
-	err := s.engine.WriteRows(s.ctx, nil, s.kvPairs)
+	writer, err := s.engine.LocalWriter(s.ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(s.ctx, nil, s.kvPairs)
+	c.Assert(err, IsNil)
+	err = writer.Close()
 	c.Assert(err, IsNil)
 }
 
@@ -130,7 +134,9 @@ func (s *importerSuite) TestWriteHeadSendFailed(c *C) {
 		Return(nil, errors.Annotate(context.Canceled, "fake unrecoverable close stream error")).
 		After(headSendCall)
 
-	err := s.engine.WriteRows(s.ctx, nil, s.kvPairs)
+	writer, err := s.engine.LocalWriter(s.ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(s.ctx, nil, s.kvPairs)
 	c.Assert(err, ErrorMatches, "fake unrecoverable write head error.*")
 }
 
@@ -158,7 +164,9 @@ func (s *importerSuite) TestWriteBatchSendFailed(c *C) {
 		Return(nil, errors.Annotate(context.Canceled, "fake unrecoverable close stream error")).
 		After(batchSendCall)
 
-	err := s.engine.WriteRows(s.ctx, nil, s.kvPairs)
+	writer, err := s.engine.LocalWriter(s.ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(s.ctx, nil, s.kvPairs)
 	c.Assert(err, ErrorMatches, "fake unrecoverable write batch error.*")
 }
 
@@ -186,7 +194,9 @@ func (s *importerSuite) TestWriteCloseFailed(c *C) {
 		Return(nil, errors.Annotate(context.Canceled, "fake unrecoverable close stream error")).
 		After(batchSendCall)
 
-	err := s.engine.WriteRows(s.ctx, nil, s.kvPairs)
+	writer, err := s.engine.LocalWriter(s.ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(s.ctx, nil, s.kvPairs)
 	c.Assert(err, ErrorMatches, "fake unrecoverable close stream error.*")
 }
 

--- a/pkg/lightning/backend/local.go
+++ b/pkg/lightning/backend/local.go
@@ -72,8 +72,6 @@ const (
 	gRPCKeepAliveTimeout = 3 * time.Second
 	gRPCBackOffMaxDelay  = 3 * time.Second
 
-	LocalMemoryTableSize = config.LocalMemoryTableSize
-
 	// See: https://github.com/tikv/tikv/blob/e030a0aae9622f3774df89c62f21b2171a72a69e/etc/config-template.toml#L360
 	regionMaxKeyCount = 1_440_000
 
@@ -344,6 +342,9 @@ type local struct {
 
 	tcpConcurrency int
 	maxOpenFiles   int
+
+	engineMemCacheSize      int
+	localWriterMemCacheSize int64
 }
 
 // connPool is a lazy pool of gRPC channels.
@@ -410,14 +411,14 @@ func NewLocalBackend(
 	ctx context.Context,
 	tls *common.TLS,
 	pdAddr string,
-	regionSplitSize int64,
-	localFile string,
-	rangeConcurrency int,
-	sendKVPairs int,
+	cfg *config.TikvImporter,
 	enableCheckpoint bool,
 	g glue.Glue,
 	maxOpenFiles int,
 ) (Backend, error) {
+	localFile := cfg.SortedKVDir
+	rangeConcurrency := cfg.RangeConcurrency
+
 	pdCli, err := pd.NewClientWithContext(ctx, []string{pdAddr}, tls.ToPDSecurityOption())
 	if err != nil {
 		return MakeBackend(nil), errors.Annotate(err, "construct pd client failed")
@@ -450,14 +451,17 @@ func NewLocalBackend(
 		g:        g,
 
 		localStoreDir:   localFile,
-		regionSplitSize: regionSplitSize,
+		regionSplitSize: int64(cfg.RegionSplitSize),
 
 		rangeConcurrency:  worker.NewPool(ctx, rangeConcurrency, "range"),
 		ingestConcurrency: worker.NewPool(ctx, rangeConcurrency*2, "ingest"),
 		tcpConcurrency:    rangeConcurrency,
-		batchWriteKVPairs: sendKVPairs,
+		batchWriteKVPairs: cfg.SendKVPairs,
 		checkpointEnabled: enableCheckpoint,
 		maxOpenFiles:      utils.MaxInt(maxOpenFiles, openFilesLowerThreshold),
+
+		engineMemCacheSize:      int(cfg.EngineMemCacheSize),
+		localWriterMemCacheSize: int64(cfg.LocalWriterMemCacheSize),
 	}
 	local.conns.conns = make(map[uint64]*connPool)
 	return MakeBackend(local), nil
@@ -599,7 +603,7 @@ func (local *local) ShouldPostProcess() bool {
 
 func (local *local) openEngineDB(engineUUID uuid.UUID, readOnly bool) (*pebble.DB, error) {
 	opt := &pebble.Options{
-		MemTableSize: LocalMemoryTableSize,
+		MemTableSize: local.engineMemCacheSize,
 		// the default threshold value may cause write stall.
 		MemTableStopWritesThreshold: 8,
 		MaxConcurrentCompactions:    16,
@@ -1452,13 +1456,13 @@ func (local *local) NewEncoder(tbl table.Table, options *SessionOptions) (Encode
 	return NewTableKVEncoder(tbl, options)
 }
 
-func (local *local) LocalWriter(ctx context.Context, engineUUID uuid.UUID, maxCacheSize int64) (EngineWriter, error) {
+func (local *local) LocalWriter(ctx context.Context, engineUUID uuid.UUID) (EngineWriter, error) {
 	e, ok := local.engines.Load(engineUUID)
 	if !ok {
 		return nil, errors.Errorf("could not find engine for %s", engineUUID.String())
 	}
 	engineFile := e.(*LocalFile)
-	return openLocalWriter(engineFile, local.localStoreDir, maxCacheSize), nil
+	return openLocalWriter(engineFile, local.localStoreDir, local.localWriterMemCacheSize), nil
 }
 
 func openLocalWriter(f *LocalFile, sstDir string, memtableSizeLimit int64) *LocalWriter {

--- a/pkg/lightning/backend/local_test.go
+++ b/pkg/lightning/backend/local_test.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/docker/go-units"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
@@ -234,7 +235,7 @@ func (s *localSuite) TestRangePropertiesWithPebble(c *C) {
 	sizeDistance := uint64(500)
 	keysDistance := uint64(20)
 	opt := &pebble.Options{
-		MemTableSize:             LocalMemoryTableSize,
+		MemTableSize:             512 * units.MiB,
 		MaxConcurrentCompactions: 16,
 		L0CompactionThreshold:    math.MaxInt32, // set to max try to disable compaction
 		L0StopWritesThreshold:    math.MaxInt32, // set to max try to disable compaction

--- a/pkg/lightning/backend/tidb.go
+++ b/pkg/lightning/backend/tidb.go
@@ -565,7 +565,7 @@ func (be *tidbBackend) ResetEngine(context.Context, uuid.UUID) error {
 	return errors.New("cannot reset an engine in TiDB backend")
 }
 
-func (be *tidbBackend) LocalWriter(ctx context.Context, engineUUID uuid.UUID, maxCacheSize int64) (EngineWriter, error) {
+func (be *tidbBackend) LocalWriter(ctx context.Context, engineUUID uuid.UUID) (EngineWriter, error) {
 	return &TiDBWriter{be: be, engineUUID: engineUUID}, nil
 }
 

--- a/pkg/lightning/backend/tidb_test.go
+++ b/pkg/lightning/backend/tidb_test.go
@@ -113,7 +113,11 @@ func (s *mysqlSuite) TestWriteRowsReplaceOnDup(c *C) {
 	c.Assert(err, IsNil)
 	row.ClassifyAndAppend(&dataRows, &dataChecksum, &indexRows, &indexChecksum)
 
-	err = engine.WriteRows(ctx, []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"}, dataRows)
+	writer, err := engine.LocalWriter(ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(ctx, []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"}, dataRows)
+	c.Assert(err, IsNil)
+	err = writer.Close()
 	c.Assert(err, IsNil)
 }
 
@@ -142,7 +146,11 @@ func (s *mysqlSuite) TestWriteRowsIgnoreOnDup(c *C) {
 	c.Assert(err, IsNil)
 	row.ClassifyAndAppend(&dataRows, &dataChecksum, &indexRows, &indexChecksum)
 
-	err = engine.WriteRows(ctx, []string{"a"}, dataRows)
+	writer, err := engine.LocalWriter(ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(ctx, []string{"a"}, dataRows)
+	c.Assert(err, IsNil)
+	err = writer.Close()
 	c.Assert(err, IsNil)
 
 	// test encode rows with _tidb_rowid
@@ -181,7 +189,11 @@ func (s *mysqlSuite) TestWriteRowsErrorOnDup(c *C) {
 
 	row.ClassifyAndAppend(&dataRows, &dataChecksum, &indexRows, &indexChecksum)
 
-	err = engine.WriteRows(ctx, []string{"a"}, dataRows)
+	writer, err := engine.LocalWriter(ctx)
+	c.Assert(err, IsNil)
+	err = writer.WriteRows(ctx, []string{"a"}, dataRows)
+	c.Assert(err, IsNil)
+	err = writer.Close()
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -614,9 +614,6 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 			}
 			cfg.TikvImporter.DiskQuota = ByteSize(storageSize.Available - reservedSize)
 		}
-		if cfg.TikvImporter.DiskQuota < cfg.TikvImporter.LocalWriterMemCacheSize {
-			cfg.TikvImporter.LocalWriterMemCacheSize = cfg.TikvImporter.DiskQuota
-		}
 	}
 
 	if cfg.TikvImporter.Backend == BackendTiDB {

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -70,19 +70,9 @@ const (
 	defaultBuildStatsConcurrency      = 20
 	defaultIndexSerialScanConcurrency = 20
 	defaultChecksumTableConcurrency   = 2
-)
 
-const (
-	LocalMemoryTableSize = 512 * units.MiB
-
-	// autoDiskQuotaLocalReservedSize is the estimated size a local-backend
-	// engine may gain after calling Flush(). This is currently defined by its
-	// max MemTable size (512 MiB). It is used to compensate for the soft limit
-	// of the disk quota against the hard limit of the disk free space.
-	//
-	// With a maximum of 8 engines, this should contribute 4.0 GiB to the
-	// reserved size.
-	autoDiskQuotaLocalReservedSize uint64 = LocalMemoryTableSize
+	defaultEngineMemCacheSize      = 512 * units.MiB
+	defaultLocalWriterMemCacheSize = 128 * units.MiB
 
 	// autoDiskQuotaLocalReservedSpeed is the estimated size increase per
 	// millisecond per write thread the local backend may gain on all engines.
@@ -286,6 +276,9 @@ type TikvImporter struct {
 	SortedKVDir      string   `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
 	DiskQuota        ByteSize `toml:"disk-quota" json:"disk-quota"`
 	RangeConcurrency int      `toml:"range-concurrency" json:"range-concurrency"`
+
+	EngineMemCacheSize      ByteSize `toml:"engine-mem-cache-size" json:"engine-mem-cache-size"`
+	LocalWriterMemCacheSize ByteSize `toml:"local-writer-mem-cache-size" json:"local-writer-mem-cache-size"`
 }
 
 type Checkpoint struct {
@@ -575,6 +568,14 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 		return errors.Errorf("invalid config: unsupported `tikv-importer.backend` (%s)", cfg.TikvImporter.Backend)
 	}
 
+	// TODO calculate these from the machine's free memory.
+	if cfg.TikvImporter.EngineMemCacheSize == 0 {
+		cfg.TikvImporter.EngineMemCacheSize = defaultEngineMemCacheSize
+	}
+	if cfg.TikvImporter.LocalWriterMemCacheSize == 0 {
+		cfg.TikvImporter.LocalWriterMemCacheSize = defaultLocalWriterMemCacheSize
+	}
+
 	if cfg.TikvImporter.Backend == BackendLocal {
 		if len(cfg.TikvImporter.SortedKVDir) == 0 {
 			return errors.Errorf("tikv-importer.sorted-kv-dir must not be empty!")
@@ -598,7 +599,7 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 		if cfg.TikvImporter.DiskQuota == 0 {
 			enginesCount := uint64(cfg.App.IndexConcurrency + cfg.App.TableConcurrency)
 			writeAmount := uint64(cfg.App.RegionConcurrency) * uint64(cfg.Cron.CheckDiskQuota.Milliseconds())
-			reservedSize := enginesCount*autoDiskQuotaLocalReservedSize + writeAmount*autoDiskQuotaLocalReservedSpeed
+			reservedSize := enginesCount*uint64(cfg.TikvImporter.EngineMemCacheSize) + writeAmount*autoDiskQuotaLocalReservedSpeed
 
 			storageSize, err := common.GetStorageSize(storageSizeDir)
 			if err != nil {
@@ -612,6 +613,9 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 					units.BytesSize(float64(reservedSize)))
 			}
 			cfg.TikvImporter.DiskQuota = ByteSize(storageSize.Available - reservedSize)
+		}
+		if cfg.TikvImporter.DiskQuota < cfg.TikvImporter.LocalWriterMemCacheSize {
+			cfg.TikvImporter.LocalWriterMemCacheSize = cfg.TikvImporter.DiskQuota
 		}
 	}
 

--- a/pkg/lightning/lightning.go
+++ b/pkg/lightning/lightning.go
@@ -666,7 +666,9 @@ func checkSystemRequirement(cfg *config.Config, dbsMeta []*mydump.MDDatabaseMeta
 			topNTotalSize += tableTotalSizes[i]
 		}
 
-		estimateMaxFiles := uint64(topNTotalSize/backend.LocalMemoryTableSize) * 2
+		// region-concurrency: number of LocalWriters writing SST files.
+		// 2*totalSize/memCacheSize: number of Pebble MemCache files.
+		estimateMaxFiles := uint64(cfg.App.RegionConcurrency) + uint64(topNTotalSize)/uint64(cfg.TikvImporter.EngineMemCacheSize)*2
 		if err := backend.VerifyRLimit(estimateMaxFiles); err != nil {
 			return err
 		}

--- a/pkg/lightning/lightning_test.go
+++ b/pkg/lightning/lightning_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-units"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 
@@ -429,6 +430,7 @@ func (s *lightningServerSuite) TestCheckSystemRequirement(c *C) {
 	cfg.App.CheckRequirements = true
 	cfg.App.TableConcurrency = 4
 	cfg.TikvImporter.Backend = config.BackendLocal
+	cfg.TikvImporter.EngineMemCacheSize = 512 * units.MiB
 
 	dbMetas := []*mydump.MDDatabaseMeta{
 		{

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	sstpb "github.com/pingcap/kvproto/pkg/import_sstpb"
@@ -2208,8 +2209,8 @@ func (tr *TableRestore) analyzeTable(ctx context.Context, g glue.SQLExecutor) er
 ////////////////////////////////////////////////////////////////
 
 var (
-	maxKVQueueSize         = 128   // Cache at most this number of rows before blocking the encode loop
-	minDeliverBytes uint64 = 65536 // 64 KB. batch at least this amount of bytes to reduce number of messages
+	maxKVQueueSize         = 128            // Cache at most this number of rows before blocking the encode loop
+	minDeliverBytes uint64 = 96 * units.KiB // 96 KB (data + index). batch at least this amount of bytes to reduce number of messages
 )
 
 type deliveredKVs struct {
@@ -2254,7 +2255,7 @@ func (cr *chunkRestore) deliverLoop(
 		indexKVs := rc.backend.MakeEmptyRows()
 
 	populate:
-		for dataChecksum.SumSize() < minDeliverBytes {
+		for dataChecksum.SumSize()+indexChecksum.SumSize() < minDeliverBytes {
 			select {
 			case kvPacket = <-kvsCh:
 				if len(kvPacket) == 0 {

--- a/pkg/lightning/restore/restore_test.go
+++ b/pkg/lightning/restore/restore_test.go
@@ -856,18 +856,18 @@ func (s *chunkRestoreSuite) TestDeliverLoopEmptyData(c *C) {
 	mockBackend.EXPECT().OpenEngine(ctx, gomock.Any()).Return(nil).Times(2)
 	mockBackend.EXPECT().MakeEmptyRows().Return(kv.MakeRowsFromKvPairs(nil)).AnyTimes()
 	mockWriter := mock.NewMockEngineWriter(controller)
-	mockBackend.EXPECT().LocalWriter(ctx, gomock.Any(), int64(2048)).Return(mockWriter, nil).AnyTimes()
+	mockBackend.EXPECT().LocalWriter(ctx, gomock.Any()).Return(mockWriter, nil).AnyTimes()
 	mockWriter.EXPECT().
 		AppendRows(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil).AnyTimes()
 
 	dataEngine, err := importer.OpenEngine(ctx, s.tr.tableName, 0)
 	c.Assert(err, IsNil)
-	dataWriter, err := dataEngine.LocalWriter(ctx, 2048)
+	dataWriter, err := dataEngine.LocalWriter(ctx)
 	c.Assert(err, IsNil)
 	indexEngine, err := importer.OpenEngine(ctx, s.tr.tableName, -1)
 	c.Assert(err, IsNil)
-	indexWriter, err := indexEngine.LocalWriter(ctx, 2048)
+	indexWriter, err := indexEngine.LocalWriter(ctx)
 	c.Assert(err, IsNil)
 
 	// Deliver nothing.
@@ -896,16 +896,16 @@ func (s *chunkRestoreSuite) TestDeliverLoop(c *C) {
 	mockBackend.EXPECT().OpenEngine(ctx, gomock.Any()).Return(nil).Times(2)
 	mockBackend.EXPECT().MakeEmptyRows().Return(kv.MakeRowsFromKvPairs(nil)).AnyTimes()
 	mockWriter := mock.NewMockEngineWriter(controller)
-	mockBackend.EXPECT().LocalWriter(ctx, gomock.Any(), int64(2048)).Return(mockWriter, nil).AnyTimes()
+	mockBackend.EXPECT().LocalWriter(ctx, gomock.Any()).Return(mockWriter, nil).AnyTimes()
 
 	dataEngine, err := importer.OpenEngine(ctx, s.tr.tableName, 0)
 	c.Assert(err, IsNil)
 	indexEngine, err := importer.OpenEngine(ctx, s.tr.tableName, -1)
 	c.Assert(err, IsNil)
 
-	dataWriter, err := dataEngine.LocalWriter(ctx, 2048)
+	dataWriter, err := dataEngine.LocalWriter(ctx)
 	c.Assert(err, IsNil)
-	indexWriter, err := indexEngine.LocalWriter(ctx, 2048)
+	indexWriter, err := indexEngine.LocalWriter(ctx)
 	c.Assert(err, IsNil)
 
 	// Set up the expected API calls to the data engine...
@@ -1117,9 +1117,9 @@ func (s *chunkRestoreSuite) TestRestore(c *C) {
 	c.Assert(err, IsNil)
 	indexEngine, err := importer.OpenEngine(ctx, s.tr.tableName, -1)
 	c.Assert(err, IsNil)
-	dataWriter, err := dataEngine.LocalWriter(ctx, 2048)
+	dataWriter, err := dataEngine.LocalWriter(ctx)
 	c.Assert(err, IsNil)
-	indexWriter, err := indexEngine.LocalWriter(ctx, 2048)
+	indexWriter, err := indexEngine.LocalWriter(ctx)
 	c.Assert(err, IsNil)
 
 	// Expected API sequence

--- a/pkg/mock/backend.go
+++ b/pkg/mock/backend.go
@@ -171,18 +171,18 @@ func (mr *MockBackendMockRecorder) ImportEngine(arg0, arg1 interface{}) *gomock.
 }
 
 // LocalWriter mocks base method
-func (m *MockBackend) LocalWriter(arg0 context.Context, arg1 uuid.UUID, arg2 int64) (backend.EngineWriter, error) {
+func (m *MockBackend) LocalWriter(arg0 context.Context, arg1 uuid.UUID) (backend.EngineWriter, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LocalWriter", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "LocalWriter", arg0, arg1)
 	ret0, _ := ret[0].(backend.EngineWriter)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LocalWriter indicates an expected call of LocalWriter
-func (mr *MockBackendMockRecorder) LocalWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBackendMockRecorder) LocalWriter(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalWriter", reflect.TypeOf((*MockBackend)(nil).LocalWriter), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalWriter", reflect.TypeOf((*MockBackend)(nil).LocalWriter), arg0, arg1)
 }
 
 // MakeEmptyRows mocks base method

--- a/tests/lightning_disk_quota/config.toml
+++ b/tests/lightning_disk_quota/config.toml
@@ -2,6 +2,7 @@
 backend = 'local'
 disk-quota = '75MB'
 max-kv-pairs = 50
+local-writer-mem-cache-size = '75MB'
 
 [cron]
 check-disk-quota = '1s'

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -105,6 +105,12 @@ addr = "127.0.0.1:8287"
 # this default config can make full use of a 10Gib bandwidth network, if the network bandwidth is higher, you can increase
 # this to gain better performance. Larger value will also increase the memory usage slightly.
 #range-concurrency = 16
+# The memory cache used in local backend for each engine. The memory usage during write-KV phase by the engines is bound
+# by (index-concurrency + table-concurrency) * engine-mem-cache-size.
+#engine-mem-cache-size = '512MiB'
+# The memory cache used in for local sorting during the encode-KV phase before flushing into the engines. The memory
+# usage is bound by region-concurrency * local-writer-mem-cache-size.
+#local-writer-mem-cache-size = '128MiB'
 
 [mydumper]
 # block size of file reading


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Lightning's Local Backend may OOM because some cache are too aggressive.

### What is changed and how it works?

(Split off from #815).

1. Make the engine's mem table size configurable (keep default at 512 MiB)
2. Make the local writer's mem table size configurable (reduce default from 512 MiB to 128 MiB)
3. Reduced capacity of `LocalWriter.kvsChan` from 1024 to 16. Originally this will make Lightning retain 1024 × (region-conc) × (encoded-kvs) in the channel buffer, which can hold over 3 GiB.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Added configurations `tikv-importer.engine-mem-cache-size` and `tikv-importer.local-writer-mem-cache-size` to tune between memory usage and performance.

<!-- fill in the release note, or just write "No release note" -->
