### PR TITLE
pkg/lightning: temporarily disable local-writer and disk-quota

### DIFF
--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -373,9 +373,10 @@ func NewConfig() *Config {
 			ChecksumTableConcurrency:   defaultChecksumTableConcurrency,
 		},
 		Cron: Cron{
-			SwitchMode:     Duration{Duration: 5 * time.Minute},
-			LogProgress:    Duration{Duration: 5 * time.Minute},
-			CheckDiskQuota: Duration{Duration: 1 * time.Minute},
+			SwitchMode:  Duration{Duration: 5 * time.Minute},
+			LogProgress: Duration{Duration: 5 * time.Minute},
+			// TODO: uncomment this after disk-quota is fully implemented.
+			// CheckDiskQuota: Duration{Duration: 1 * time.Minute},
 		},
 		Mydumper: MydumperRuntime{
 			ReadBlockSize: ReadBlockSize,

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -270,4 +270,4 @@ switch-mode = "5m"
 # the duration which the an import progress will be printed to the log.
 log-progress = "5m"
 # the duration which tikv-importer.sorted-kv-dir-capacity is checked.
-check-disk-quota = "1m"
+# check-disk-quota = "1m"

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -269,5 +269,6 @@ post-process-at-last = true
 switch-mode = "5m"
 # the duration which the an import progress will be printed to the log.
 log-progress = "5m"
-# the duration which tikv-importer.sorted-kv-dir-capacity is checked.
-# check-disk-quota = "1m"
+# the duration which tikv-importer.sorted-kv-dir-capacity is checked. set to 0 to disable.
+# NOTE: the disk-quota feature is not fully implemented, do not use it unless you know what you are doing.
+#check-disk-quota = "0s"


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Disable local-writer and disk-quota by：
- Set check-disk-quota interval to 0 by default to disable disk-quota
- Replace local-writer `AppendRows` function with the original write-batch approach.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
