### PR TITLE
br flags: --no-credentials and --skip-check-path

### DIFF
--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -152,9 +152,9 @@ func (bc *Client) GetGCTTL() int64 {
 }
 
 // SetStorage set ExternalStorage for client.
-func (bc *Client) SetStorage(ctx context.Context, backend *backuppb.StorageBackend, sendCreds bool) error {
+func (bc *Client) SetStorage(ctx context.Context, backend *backuppb.StorageBackend, opts *storage.ExternalStorageOptions) error {
 	var err error
-	bc.storage, err = storage.Create(ctx, backend, sendCreds)
+	bc.storage, err = storage.New(ctx, backend, opts)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -132,9 +132,9 @@ func (rc *Client) SetRateLimit(rateLimit uint64) {
 }
 
 // SetStorage set ExternalStorage for client.
-func (rc *Client) SetStorage(ctx context.Context, backend *backuppb.StorageBackend, sendCreds bool) error {
+func (rc *Client) SetStorage(ctx context.Context, backend *backuppb.StorageBackend, opts *storage.ExternalStorageOptions) error {
 	var err error
-	rc.storage, err = storage.Create(ctx, backend, sendCreds)
+	rc.storage, err = storage.New(ctx, backend, opts)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -101,6 +101,9 @@ type ExternalStorageOptions struct {
 	// downstream via external key managers, e.g. on K8s or cloud provider.
 	SendCredentials bool
 
+	// NoCredentials means that no cloud credentials are supplied to BR
+	NoCredentials bool
+
 	// SkipCheckPath marks whether to skip checking path's existence.
 	//
 	// This should only be set to true in testing, to avoid interacting with the

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -208,7 +208,12 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err = client.SetStorage(ctx, u, cfg.SendCreds); err != nil {
+	opts := storage.ExternalStorageOptions{
+		NoCredentials:   cfg.NoCreds,
+		SendCredentials: cfg.SendCreds,
+		SkipCheckPath:   cfg.SkipCheckPath,
+	}
+	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return errors.Trace(err)
 	}
 	err = client.SetLockFile(ctx)

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -145,7 +145,12 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err = client.SetStorage(ctx, u, cfg.SendCreds); err != nil {
+	opts := storage.ExternalStorageOptions{
+		NoCredentials:   cfg.NoCreds,
+		SendCredentials: cfg.SendCreds,
+		SkipCheckPath:   cfg.SkipCheckPath,
+	}
+	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -35,6 +35,8 @@ import (
 const (
 	// flagSendCreds specify whether to send credentials to tikv
 	flagSendCreds = "send-credentials-to-tikv"
+	// No credentials specifies that cloud credentials should not be loaded
+	flagNoCreds = "no-credentials"
 	// flagStorage is the name of storage flag.
 	flagStorage = "storage"
 	// flagPD is the name of PD url flag.
@@ -65,6 +67,7 @@ const (
 	flagGrpcKeepaliveTimeout = "grpc-keepalive-timeout"
 	// flagEnableOpenTracing is whether to enable opentracing
 	flagEnableOpenTracing = "enable-opentracing"
+	flagSkipCheckPath     = "skip-check-path"
 
 	defaultSwitchInterval       = 5 * time.Minute
 	defaultGRPCKeepaliveTime    = 10 * time.Second
@@ -117,16 +120,22 @@ type Config struct {
 	// Deprecated: This field is kept only to satisfy the cyclic dependency with TiDB. This field
 	// should be removed after TiDB upgrades the BR dependency.
 	CaseSensitive bool
+
+	// NoCreds means don't try to load cloud credentials
+	NoCreds bool `json:"no-credentials" toml:"no-credentials"`
+
+	CheckRequirements bool `json:"check-requirements" toml:"check-requirements"`
+	// EnableOpenTracing is whether to enable opentracing
+	EnableOpenTracing bool `json:"enable-opentracing" toml:"enable-opentracing"`
+	// SkipCheckPath skips verifying the path
+	SkipCheckPath bool `json:"skip-check-path" toml:"skip-check-path"`
 	// Filter should not be used, use TableFilter instead.
 	//
 	// Deprecated: This field is kept only to satisfy the cyclic dependency with TiDB. This field
 	// should be removed after TiDB upgrades the BR dependency.
 	Filter filter.MySQLReplicationRules
 
-	TableFilter       filter.Filter `json:"-" toml:"-"`
-	CheckRequirements bool          `json:"check-requirements" toml:"check-requirements"`
-	// EnableOpenTracing is whether to enable opentracing
-	EnableOpenTracing  bool          `json:"enable-opentracing" toml:"enable-opentracing"`
+	TableFilter        filter.Filter `json:"-" toml:"-"`
 	SwitchModeInterval time.Duration `json:"switch-mode-interval" toml:"switch-mode-interval"`
 
 	// GrpcKeepaliveTime is the interval of pinging the server.
@@ -174,6 +183,9 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 	flags.Bool(flagEnableOpenTracing, false,
 		"Set whether to enable opentracing during the backup/restore process")
+
+	flags.BoolP(flagNoCreds, "", false, "Don't load credentials")
+	flags.BoolP(flagSkipCheckPath, "", false, "Skip path verification")
 
 	storage.DefineFlags(flags)
 }
@@ -236,34 +248,30 @@ func (cfg *Config) normalizePDURLs() error {
 // ParseFromFlags parses the config from the flag set.
 func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	var err error
-	cfg.Storage, err = flags.GetString(flagStorage)
-	if err != nil {
+	if cfg.Storage, err = flags.GetString(flagStorage); err != nil {
 		return errors.Trace(err)
 	}
-	cfg.SendCreds, err = flags.GetBool(flagSendCreds)
-	if err != nil {
+	if cfg.SendCreds, err = flags.GetBool(flagSendCreds); err != nil {
 		return errors.Trace(err)
 	}
-	cfg.Concurrency, err = flags.GetUint32(flagConcurrency)
-	if err != nil {
+	if cfg.NoCreds, err = flags.GetBool(flagNoCreds); err != nil {
 		return errors.Trace(err)
 	}
-	cfg.Checksum, err = flags.GetBool(flagChecksum)
-	if err != nil {
+	if cfg.Concurrency, err = flags.GetUint32(flagConcurrency); err != nil {
 		return errors.Trace(err)
 	}
-	cfg.ChecksumConcurrency, err = flags.GetUint(flagChecksumConcurrency)
-	if err != nil {
+	if cfg.Checksum, err = flags.GetBool(flagChecksum); err != nil {
+		return errors.Trace(err)
+	}
+	if cfg.ChecksumConcurrency, err = flags.GetUint(flagChecksumConcurrency); err != nil {
 		return errors.Trace(err)
 	}
 
 	var rateLimit, rateLimitUnit uint64
-	rateLimit, err = flags.GetUint64(flagRateLimit)
-	if err != nil {
+	if rateLimit, err = flags.GetUint64(flagRateLimit); err != nil {
 		return errors.Trace(err)
 	}
-	rateLimitUnit, err = flags.GetUint64(flagRateLimitUnit)
-	if err != nil {
+	if rateLimitUnit, err = flags.GetUint64(flagRateLimitUnit); err != nil {
 		return errors.Trace(err)
 	}
 	cfg.RateLimit = rateLimit * rateLimitUnit
@@ -343,6 +351,9 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if len(cfg.PD) == 0 {
 		return errors.Annotate(berrors.ErrInvalidArgument, "must provide at least one PD server address")
 	}
+	if cfg.SkipCheckPath, err = flags.GetBool(flagSkipCheckPath); err != nil {
+		return errors.Trace(err)
+	}
 	return cfg.normalizePDURLs()
 }
 
@@ -394,11 +405,19 @@ func GetStorage(
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	s, err := storage.Create(ctx, u, cfg.SendCreds)
+	s, err := storage.New(ctx, u, storageOpts(cfg))
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "create storage failed")
 	}
 	return u, s, nil
+}
+
+func storageOpts(cfg *Config) *storage.ExternalStorageOptions {
+	return &storage.ExternalStorageOptions{
+		NoCredentials:   cfg.NoCreds,
+		SendCredentials: cfg.SendCreds,
+		SkipCheckPath:   cfg.SkipCheckPath,
+	}
 }
 
 // ReadBackupMeta reads the backupmeta file from the storage.
@@ -419,7 +438,7 @@ func ReadBackupMeta(
 			newPrefix, file := path.Split(oldPrefix)
 			newFileName := file + fileName
 			u.GetGcs().Prefix = newPrefix
-			s, err = storage.Create(ctx, u, cfg.SendCreds)
+			s, err = storage.New(ctx, u, storageOpts(cfg))
 			if err != nil {
 				return nil, nil, nil, errors.Trace(err)
 			}

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -185,7 +185,9 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 		"Set whether to enable opentracing during the backup/restore process")
 
 	flags.BoolP(flagNoCreds, "", false, "Don't load credentials")
+	_ = flags.MarkHidden(flagNoCreds)
 	flags.BoolP(flagSkipCheckPath, "", false, "Skip path verification")
+	_ = flags.MarkHidden(flagSkipCheckPath)
 
 	storage.DefineFlags(flags)
 }

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -180,7 +180,12 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err = client.SetStorage(ctx, u, cfg.SendCreds); err != nil {
+	opts := storage.ExternalStorageOptions{
+		NoCredentials:   cfg.NoCreds,
+		SendCredentials: cfg.SendCreds,
+		SkipCheckPath:   cfg.SkipCheckPath,
+	}
+	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return errors.Trace(err)
 	}
 	client.SetRateLimit(cfg.RateLimit)

--- a/pkg/task/restore_log.go
+++ b/pkg/task/restore_log.go
@@ -117,7 +117,12 @@ func RunLogRestore(c context.Context, g glue.Glue, cfg *LogRestoreConfig) error 
 	}
 	defer client.Close()
 
-	if err = client.SetStorage(ctx, u, false); err != nil {
+	opts := storage.ExternalStorageOptions{
+		NoCredentials:   cfg.NoCreds,
+		SendCredentials: cfg.SendCreds,
+		SkipCheckPath:   cfg.SkipCheckPath,
+	}
+	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION



### What problem does this PR solve?

This helps with local testing of GCS and might also be useful in other contexts.

### What is changed and how it works?

With gcs-fake-server running backup can be performed with these options:

```
br --gcs.endpoint http://localhost:4443/storage/v1 \
  --no-credentials --send-credentials-to-tikv=false --skip-check-path
```


### Check List <!--REMOVE the items that are not applicable-->

Tests

 - Manual test (see above)

Code changes

 - Has exported function/method change: no
 - Has exported variable/fields change: only additions
 - Has interface methods change: no
 - Has persistent data change: no

Side effects

- ?

Related changes

 - Need to update the documentation

### Release Note

 - Add testing options --no-credentials and --skip-check-path
