### PR TITLE
pkg/lightning: fix chunk restore may ignore error if ctx is canceled

### DIFF
--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -2549,14 +2549,18 @@ func (cr *chunkRestore) restore(
 	}
 
 	select {
-	case deliverResult := <-deliverCompleteCh:
-		logTask.End(zap.ErrorLevel, deliverResult.err,
-			zap.Duration("readDur", readTotalDur),
-			zap.Duration("encodeDur", encodeTotalDur),
-			zap.Duration("deliverDur", deliverResult.totalDur),
-			zap.Object("checksum", &cr.chunk.Checksum),
-		)
-		return errors.Trace(deliverResult.err)
+	case deliverResult, ok := <-deliverCompleteCh:
+		if ok {
+			logTask.End(zap.ErrorLevel, deliverResult.err,
+				zap.Duration("readDur", readTotalDur),
+				zap.Duration("encodeDur", encodeTotalDur),
+				zap.Duration("deliverDur", deliverResult.totalDur),
+				zap.Object("checksum", &cr.chunk.Checksum),
+			)
+			return errors.Trace(deliverResult.err)
+		}
+		// else, this must cause by ctx cancel
+		return ctx.Err()
 	case <-ctx.Done():
 		return ctx.Err()
 	}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the bug that lightning may ignore context cancel error and lose data.
Close #855.

### What is changed and how it works?
In the failed `lightning_checkpoint_chunks` integrations tests, there are logs as follows:
```
[2021-03-13T13:05:59.989Z] [2021/03/13 21:05:39.395 +08:00] [INFO] [restore.go:2553] ["restore file completed"] [table=`cpch_tsr`.`tbl`] [engineNumber=0] [fileIndex=3] [path=cpch_tsr.tbl.4.sql:0] [readDur=1.161606ms] [encodeDur=2.307684ms] [deliverDur=0s] [checksum="{cksum=0,size=0,kvs=0}"] [takeTime=4.021432ms] []
```
Note the deliverDur` is 0, this means the `deliverResult` is an object with the default parameter which is caused by reading from a closed channel.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - Fix a bug that chunk restore task may ignore context cancel error and causes data loss.

<!-- fill in the release note, or just write "No release note" -->
