### PR TITLE
Make Lightning S3 use force-path-style=true by default 

### DIFF
--- a/pkg/lightning/lightning.go
+++ b/pkg/lightning/lightning.go
@@ -267,7 +267,7 @@ func (l *Lightning) run(taskCtx context.Context, taskCfg *config.Config, g glue.
 		g = glue.NewExternalTiDBGlue(db, taskCfg.TiDB.SQLMode)
 	}
 
-	u, err := storage.ParseBackend(taskCfg.Mydumper.SourceDir, &storage.BackendOptions{})
+	u, err := storage.ParseBackend(taskCfg.Mydumper.SourceDir, nil)
 	if err != nil {
 		return errors.Annotate(err, "parse backend failed")
 	}

--- a/pkg/storage/compress_test.go
+++ b/pkg/storage/compress_test.go
@@ -14,7 +14,7 @@ import (
 
 func (r *testStorageSuite) TestWithCompressReadWriteFile(c *C) {
 	dir := c.MkDir()
-	backend, err := ParseBackend("local:///"+dir, nil)
+	backend, err := ParseBackend("local://"+filepath.ToSlash(dir), nil)
 	c.Assert(err, IsNil)
 	ctx := context.Background()
 	storage, err := Create(ctx, backend, true)

--- a/pkg/storage/parse.go
+++ b/pkg/storage/parse.go
@@ -69,7 +69,7 @@ func ParseBackend(rawURL string, options *BackendOptions) (*backuppb.StorageBack
 		prefix := strings.Trim(u.Path, "/")
 		s3 := &backuppb.S3{Bucket: u.Host, Prefix: prefix}
 		if options == nil {
-			options = &BackendOptions{}
+			options = &BackendOptions{S3: S3BackendOptions{ForcePathStyle: true}}
 		}
 		ExtractQueryParameters(u, &options.S3)
 		if err := options.S3.Apply(s3); err != nil {

--- a/pkg/storage/parse_test.go
+++ b/pkg/storage/parse_test.go
@@ -55,16 +55,17 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	c.Assert(s3.Bucket, Equals, "bucket2")
 	c.Assert(s3.Prefix, Equals, "prefix")
 	c.Assert(s3.Endpoint, Equals, "https://s3.example.com/")
+	c.Assert(s3.ForcePathStyle, IsFalse)
 
 	// nolint:lll
-	s, err = ParseBackend(`s3://bucket3/prefix/path?endpoint=https://127.0.0.1:9000&force_path_style=1&SSE=aws:kms&sse-kms-key-id=TestKey&xyz=abc`, nil)
+	s, err = ParseBackend(`s3://bucket3/prefix/path?endpoint=https://127.0.0.1:9000&force_path_style=0&SSE=aws:kms&sse-kms-key-id=TestKey&xyz=abc`, nil)
 	c.Assert(err, IsNil)
 	s3 = s.GetS3()
 	c.Assert(s3, NotNil)
 	c.Assert(s3.Bucket, Equals, "bucket3")
 	c.Assert(s3.Prefix, Equals, "prefix/path")
 	c.Assert(s3.Endpoint, Equals, "https://127.0.0.1:9000")
-	c.Assert(s3.ForcePathStyle, IsTrue)
+	c.Assert(s3.ForcePathStyle, IsFalse)
 	c.Assert(s3.Sse, Equals, "aws:kms")
 	c.Assert(s3.SseKmsKeyId, Equals, "TestKey")
 
@@ -77,6 +78,7 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	c.Assert(s3.Prefix, Equals, "prefix/path")
 	c.Assert(s3.AccessKey, Equals, "NXN7IPIOSAAKDEEOLMAF")
 	c.Assert(s3.SecretAccessKey, Equals, "nREY/7Dt+PaIbYKrKlEEMMF/ExCiJEX=XMLPUANw")
+	c.Assert(s3.ForcePathStyle, IsTrue)
 
 	gcsOpt := &BackendOptions{
 		GCS: GCSBackendOptions{

--- a/pkg/storage/parse_test.go
+++ b/pkg/storage/parse_test.go
@@ -133,7 +133,9 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	c.Assert(err, IsNil)
 	local := s.GetLocal()
 	c.Assert(local, NotNil)
-	c.Assert(local.GetPath(), Equals, "/test")
+	expectedLocalPath, err := filepath.Abs("/test")
+	c.Assert(err, IsNil)
+	c.Assert(local.GetPath(), Equals, expectedLocalPath)
 }
 
 func (r *testStorageSuite) TestFormatBackendURL(c *C) {

--- a/pkg/storage/writer_test.go
+++ b/pkg/storage/writer_test.go
@@ -22,7 +22,7 @@ func (r *testStorageSuite) TestExternalFileWriter(c *C) {
 	}
 	testFn := func(test *testcase, c *C) {
 		c.Log(test.name)
-		backend, err := ParseBackend("local:///"+dir, nil)
+		backend, err := ParseBackend("local://"+filepath.ToSlash(dir), nil)
 		c.Assert(err, IsNil)
 		ctx := context.Background()
 		storage, err := Create(ctx, backend, true)
@@ -96,7 +96,7 @@ func (r *testStorageSuite) TestCompressReaderWriter(c *C) {
 	}
 	testFn := func(test *testcase, c *C) {
 		c.Log(test.name)
-		backend, err := ParseBackend("local:///"+dir, nil)
+		backend, err := ParseBackend("local://"+filepath.ToSlash(dir), nil)
 		c.Assert(err, IsNil)
 		ctx := context.Background()
 		storage, err := Create(ctx, backend, true)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Lightning is different from BR and Dumpling that `force-path-style` is false by default. This is because both BR and Dumpling reads the storage URL through `(*BackendOptions).ParseFromFlags` which sets `ForcePathStyle` to true:

https://github.com/pingcap/br/blob/0b223bc5358cbe7ef6a54ad10fdd7aca81bf547f/pkg/storage/s3.go#L203

but such adjustment is absent from Lightning.

### What is changed and how it works?

We set the default `ForcePathStyle` to true inside `storage.ParseBackend` so Lightning, starting with the default backend options, will also use `force-path-style=true` by default.

Also fixed the unit tests on Windows.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

 - Breaking backward compatibility
    * Lightning uses `force-path-style=true` by default, instead of `force-path-style=false`.

Related changes

### Release Note

 - Then importing from S3, Lightning now uses `force-path-style=true` by default, aligning with BR and Dumpling. To use the virtual host addressing style, explicitly set the `force-path-style` option like:

    ```sh
    ./tidb-lightning -d 's3://bucket/path?force-path-style=0&...'
    ```

