### PR TITLE
restore: set tiflash replica to nil when tiflash node is not satified

### DIFF
--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -1006,7 +1006,7 @@ func (rc *Client) IsSkipCreateSQL() bool {
 	return rc.noSchema
 }
 
-// PreCheckTable checks whether TiFlash replica is less than TiFlash node.
+// PreCheckTableTiFlashReplica checks whether TiFlash replica is less than TiFlash node.
 func (rc *Client) PreCheckTableTiFlashReplica(
 	ctx context.Context,
 	tables []*utils.Table,

--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -1006,6 +1006,27 @@ func (rc *Client) IsSkipCreateSQL() bool {
 	return rc.noSchema
 }
 
+// PreCheckTable checks whether TiFlash replica is less than TiFlash node.
+func (rc *Client) PreCheckTableTiFlashReplica(
+	ctx context.Context,
+	tables []*utils.Table,
+) error {
+	tiFlashStores, err := conn.GetAllTiKVStores(ctx, rc.pdClient, conn.TiFlashOnly)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	tiFlashStoreCount := len(tiFlashStores)
+	for _, table := range tables {
+		if table.Info.TiFlashReplica != nil && table.Info.TiFlashReplica.Count > uint64(tiFlashStoreCount) {
+			// we cannot satisfy TiFlash replica in restore cluster. so we should
+			// set TiFlashReplica to unavailable in tableInfo, to avoid TiDB cannot sense TiFlash and make plan to TiFlash
+			// see details at https://github.com/pingcap/br/issues/931
+			table.Info.TiFlashReplica = nil
+		}
+	}
+	return nil
+}
+
 // PreCheckTableClusterIndex checks whether backup tables and existed tables have different cluster index options。
 func (rc *Client) PreCheckTableClusterIndex(
 	tables []*utils.Table,

--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -693,7 +693,7 @@ func (rc *Client) switchTiKVMode(ctx context.Context, mode import_sstpb.SwitchMo
 			opt = grpc.WithTransportCredentials(credentials.NewTLS(rc.tlsConf))
 		}
 		gctx, cancel := context.WithTimeout(ctx, time.Second*5)
-		conn, err := grpc.DialContext(
+		connection, err := grpc.DialContext(
 			gctx,
 			store.GetAddress(),
 			opt,
@@ -705,14 +705,14 @@ func (rc *Client) switchTiKVMode(ctx context.Context, mode import_sstpb.SwitchMo
 		if err != nil {
 			return errors.Trace(err)
 		}
-		client := import_sstpb.NewImportSSTClient(conn)
+		client := import_sstpb.NewImportSSTClient(connection)
 		_, err = client.SwitchMode(ctx, &import_sstpb.SwitchModeRequest{
 			Mode: mode,
 		})
 		if err != nil {
 			return errors.Trace(err)
 		}
-		err = conn.Close()
+		err = connection.Close()
 		if err != nil {
 			log.Error("close grpc connection failed in switch mode", zap.Error(err))
 			continue

--- a/pkg/restore/client_test.go
+++ b/pkg/restore/client_test.go
@@ -189,46 +189,46 @@ func (s *testRestoreClientSuite) TestPreCheckTableTiFlashReplicas(c *C) {
 	c.Assert(s.mock.Start(), IsNil)
 	defer s.mock.Stop()
 
-	mockStores := []*metapb.Store {
+	mockStores := []*metapb.Store{
 		{
 			Id: 1,
-			Labels: []*metapb.StoreLabel {
+			Labels: []*metapb.StoreLabel{
 				{
-					Key: "engine",
+					Key:   "engine",
 					Value: "tiflash",
 				},
 			},
 		},
 		{
 			Id: 2,
-			Labels: []*metapb.StoreLabel {
+			Labels: []*metapb.StoreLabel{
 				{
-					Key: "engine",
+					Key:   "engine",
 					Value: "tiflash",
 				},
 			},
 		},
 	}
 
-	client, err := restore.NewRestoreClient(gluetidb.New(),fakePDClient{
+	client, err := restore.NewRestoreClient(gluetidb.New(), fakePDClient{
 		stores: mockStores,
-	} , s.mock.Storage, nil, defaultKeepaliveCfg)
+	}, s.mock.Storage, nil, defaultKeepaliveCfg)
 	c.Assert(err, IsNil)
 
 	tables := make([]*utils.Table, 4)
 	for i := 0; i < len(tables); i++ {
-		tiflashReplica :=  &model.TiFlashReplicaInfo{
+		tiflashReplica := &model.TiFlashReplicaInfo{
 			Count: uint64(i),
 		}
-		if  i == 0 {
+		if i == 0 {
 			tiflashReplica = nil
 		}
 
 		tables[i] = &utils.Table{
 			DB: nil,
 			Info: &model.TableInfo{
-				ID:   int64(i),
-				Name: model.NewCIStr("test" + strconv.Itoa(i)),
+				ID:             int64(i),
+				Name:           model.NewCIStr("test" + strconv.Itoa(i)),
 				TiFlashReplica: tiflashReplica,
 			},
 		}

--- a/pkg/restore/util_test.go
+++ b/pkg/restore/util_test.go
@@ -97,7 +97,7 @@ func (s *testRestoreUtilSuite) TestMapTableToFiles(c *C) {
 
 func (s *testRestoreUtilSuite) TestValidateFileRewriteRule(c *C) {
 	rules := &restore.RewriteRules{
-		Table: []*import_sstpb.RewriteRule{&import_sstpb.RewriteRule{
+		Table: []*import_sstpb.RewriteRule{{
 			OldKeyPrefix: []byte(tablecodec.EncodeTablePrefix(1)),
 			NewKeyPrefix: []byte(tablecodec.EncodeTablePrefix(2)),
 		}},

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -247,6 +247,11 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	}
 	ddlJobs := restore.FilterDDLJobs(client.GetDDLJobs(), tables)
 
+	err = client.PreCheckTableTiFlashReplica(ctx, tables)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	err = client.PreCheckTableClusterIndex(tables, ddlJobs, mgr.GetDomain())
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #931

### What is changed and how it works?
Set TiFlash replica to nil when restore cluster's TiFlash nodes are not satisfied.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Fix the issue when BR restore TiFlash Info not satisfied with the cluster.

<!-- fill in the release note, or just write "No release note" -->
