### PR TITLE
makefile: fix the problem that `make` stuck in macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,8 @@ static: prepare tools
 		grep -vE "Normalize|Annotate|Trace|Cause|RedactLogEnabled" 2>&1 | $(CHECKER)
 	# The package name of "github.com/pingcap/kvproto/pkg/backup" collides
 	# "github.com/pingcap/br/pkg/backup", so we rename kvproto to backuppb.
-	grep -Rn --include="*.go" -E '"github.com/pingcap/kvproto/pkg/backup"' | \
+	grep -Rn --include="*.go" -E '"github.com/pingcap/kvproto/pkg/backup"' \
+		$$($(PACKAGE_DIRECTORIES)) | \
 		grep -vE "backuppb" | $(CHECKER)
 
 lint: prepare tools


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In macOS, `make` would stick at checking backuppb, with a warning 'recursive search from stdin.'

### What is changed and how it works?
When `-R` provided but no file provided, `grep` of macOS will wait for read from stdin, omit the `-R` flag. This PR make the make script provide the search target explicitly.

But `grep` of linux would implicit use current directory to search, so this bug won't appear in linux.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
