### PR TITLE
pkg/lightning: check context canceled error for aws error

### DIFF
--- a/pkg/lightning/backend/local/local_unix.go
+++ b/pkg/lightning/backend/local/local_unix.go
@@ -55,6 +55,8 @@ func VerifyRLimit(estimateMaxFiles uint64) error {
 		return errors.Trace(err)
 	}
 	if rLimit.Cur >= estimateMaxFiles {
+		log.L().Info("Check maximum number of open file descriptors(rlimit)",
+			zap.Uint64("estimated", estimateMaxFiles), zap.Uint64("current", rLimit.Cur))
 		return nil
 	}
 	if rLimit.Max < estimateMaxFiles {

--- a/tests/lightning_checkpoint_engines_order/run.sh
+++ b/tests/lightning_checkpoint_engines_order/run.sh
@@ -20,7 +20,8 @@ for i in $(seq 5); do
     run_lightning --enable-checkpoint=1 2> /dev/null
     [ $? -ne 0 ] || exit 1
     set -e
-    [ $(ls -1q "$TEST_DIR/$TEST_NAME.sorted" | wc -l) -eq 2 ]
+    # engine sorted kv dir name is 36 length (UUID4).
+    [ $(ls -1q "$TEST_DIR/$TEST_NAME.sorted"| grep -E "^\S{36}$" | wc -l) -eq 2 ]
 done
 
 # allow one file to be written at a time,
@@ -31,7 +32,8 @@ set +e
 run_lightning --enable-checkpoint=1 2> /dev/null
 [ $? -ne 0 ] || exit 1
 set -e
-[ $(ls -1q "$TEST_DIR/$TEST_NAME.sorted" | wc -l) -eq 3 ]
+# engine sorted kv dir name is 36 length (UUID4).
+[ $(ls -1q "$TEST_DIR/$TEST_NAME.sorted"| grep -E "^\S{36}$" | wc -l) -eq 3 ]
 
 # allow everything to be written,
 export GO_FAILPOINTS=''


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Add extra check `context canceled` error for aws-sdk error. Avoid output a lot of error log when lightning exit.  Close #918 
- Add a `no-file` info log to output the current system no-file number. This is easier to debug when lightning failed due to rLimit setting is too small
- fix integration test `lightning_checkpoint_engines_order` by make the `ls` check more stable.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
