### PR TITLE
restore: fix false analyze failed error

### DIFF
--- a/pkg/utils/schema.go
+++ b/pkg/utils/schema.go
@@ -101,8 +101,9 @@ func LoadBackupTables(meta *backuppb.BackupMeta) (map[string]*Database, error) {
 			return nil, errors.Trace(err)
 		}
 		// stats maybe nil from old backup file.
-		stats := &handle.JSONTable{}
+		var stats *handle.JSONTable
 		if schema.Stats != nil {
+			stats = &handle.JSONTable{}
 			// Parse the stats table.
 			err = json.Unmarshal(schema.Stats, stats)
 			if err != nil {


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the false 'analyze table failed' error.

![image](https://user-images.githubusercontent.com/36239017/112790480-021cd100-9092-11eb-9046-97e425acad7c.png)

### What is changed and how it works?
Before, we store `new(handle.JSONTable)` into `Table.Stats` in any condition, which would make the guard at `restore.go` invalid.
Now, store `nil` to `Table.Stats` default.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Run `br_gcs`, no error anymore.
<img width="501" alt="image" src="https://user-images.githubusercontent.com/36239017/112790806-c0d8f100-9092-11eb-9c3f-143d7f560f72.png">


### Release Note

 - Fix a bug that caused restore would always report a false error

<!-- fill in the release note, or just write "No release note" -->
