### PR TITLE
pkg/lightning: check compatibility with  tiflash

### DIFF
--- a/pkg/lightning/backend/backend.go
+++ b/pkg/lightning/backend/backend.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/br/pkg/lightning/common"
 	"github.com/pingcap/br/pkg/lightning/log"
 	"github.com/pingcap/br/pkg/lightning/metric"
+	"github.com/pingcap/br/pkg/lightning/mydump"
 )
 
 const (
@@ -93,6 +94,11 @@ type EngineFileSize struct {
 	IsImporting bool
 }
 
+// CheckCtx contains all parameters used in CheckRequirements
+type CheckCtx struct {
+	DBMetas []*mydump.MDDatabaseMeta
+}
+
 // AbstractBackend is the abstract interface behind Backend.
 // Implementations of this interface must be goroutine safe: you can share an
 // instance and execute any method anywhere.
@@ -123,7 +129,7 @@ type AbstractBackend interface {
 
 	// CheckRequirements performs the check whether the backend satisfies the
 	// version requirements
-	CheckRequirements(ctx context.Context) error
+	CheckRequirements(ctx context.Context, checkCtx *CheckCtx) error
 
 	// FetchRemoteTableModels obtains the models of all tables given the schema
 	// name. The returned table info does not need to be precise if the encoder,
@@ -223,8 +229,8 @@ func (be Backend) ShouldPostProcess() bool {
 	return be.abstract.ShouldPostProcess()
 }
 
-func (be Backend) CheckRequirements(ctx context.Context) error {
-	return be.abstract.CheckRequirements(ctx)
+func (be Backend) CheckRequirements(ctx context.Context, checkCtx *CheckCtx) error {
+	return be.abstract.CheckRequirements(ctx, checkCtx)
 }
 
 func (be Backend) FetchRemoteTableModels(ctx context.Context, schemaName string) ([]*model.TableInfo, error) {

--- a/pkg/lightning/backend/importer/importer.go
+++ b/pkg/lightning/backend/importer/importer.go
@@ -282,7 +282,7 @@ func (*importer) NewEncoder(tbl table.Table, options *kv.SessionOptions) (kv.Enc
 	return kv.NewTableKVEncoder(tbl, options)
 }
 
-func (importer *importer) CheckRequirements(ctx context.Context) error {
+func (importer *importer) CheckRequirements(ctx context.Context, _ *backend.CheckCtx) error {
 	if err := checkTiDBVersionByTLS(ctx, importer.tls, requiredMinTiDBVersion, requiredMaxTiDBVersion); err != nil {
 		return err
 	}

--- a/pkg/lightning/backend/local/local_test.go
+++ b/pkg/lightning/backend/local/local_test.go
@@ -517,7 +517,7 @@ func (s *localSuite) TestCheckRequirementsTiFlash(c *C) {
 					DataFiles: []mydump.FileInfo{{}},
 				},
 				{
-					DB:        "test",
+					DB:        "test1",
 					Name:      "tbl",
 					DataFiles: []mydump.FileInfo{{}},
 				},
@@ -528,8 +528,8 @@ func (s *localSuite) TestCheckRequirementsTiFlash(c *C) {
 
 	glue.EXPECT().GetSQLExecutor().Return(exec)
 	exec.EXPECT().QueryStringsWithLog(ctx, tiFlashReplicaQuery, gomock.Any(), gomock.Any()).
-		Return([][]string{{"db", "tbl"}, {"test", "t2"}, {"test1", "tbl"}}, nil)
+		Return([][]string{{"db", "tbl"}, {"test", "t1"}, {"test1", "tbl"}}, nil)
 
 	err := checkTiFlashVersion(ctx, glue, checkCtx, *semver.New("4.0.2"))
-	c.Assert(err, ErrorMatches, "lightning local backend doesn't support TiFlash in this TiDB version. conflict table: `test1`.`tbl`.*")
+	c.Assert(err, ErrorMatches, "lightning local backend doesn't support TiFlash in this TiDB version. conflict tables: \\[`test`.`t1`, `test1`.`tbl`\\].*")
 }

--- a/pkg/lightning/backend/local/local_test.go
+++ b/pkg/lightning/backend/local/local_test.go
@@ -25,7 +25,9 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
+	"github.com/golang/mock/gomock"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
@@ -40,6 +42,8 @@ import (
 	"github.com/pingcap/br/pkg/lightning/backend"
 	"github.com/pingcap/br/pkg/lightning/backend/kv"
 	"github.com/pingcap/br/pkg/lightning/common"
+	"github.com/pingcap/br/pkg/lightning/mydump"
+	"github.com/pingcap/br/pkg/mock"
 	"github.com/pingcap/br/pkg/restore"
 )
 
@@ -479,4 +483,53 @@ func (s *localSuite) TestIsIngestRetryable(c *C) {
 	retryType, newRegion, err = local.isIngestRetryable(ctx, resp, region, meta)
 	c.Assert(retryType, Equals, retryNone)
 	c.Assert(err, ErrorMatches, "non-retryable error: unknown error")
+}
+
+func (s *localSuite) TestCheckRequirementsTiFlash(c *C) {
+	controller := gomock.NewController(c)
+	defer controller.Finish()
+	glue := mock.NewMockGlue(controller)
+	exec := mock.NewMockSQLExecutor(controller)
+	ctx := context.Background()
+
+	dbMetas := []*mydump.MDDatabaseMeta{
+		{
+			Name: "test",
+			Tables: []*mydump.MDTableMeta{
+				{
+					DB:        "test",
+					Name:      "t1",
+					DataFiles: []mydump.FileInfo{{}},
+				},
+				{
+					DB:        "test",
+					Name:      "tbl",
+					DataFiles: []mydump.FileInfo{{}},
+				},
+			},
+		},
+		{
+			Name: "test1",
+			Tables: []*mydump.MDTableMeta{
+				{
+					DB:        "test1",
+					Name:      "t",
+					DataFiles: []mydump.FileInfo{{}},
+				},
+				{
+					DB:        "test",
+					Name:      "tbl",
+					DataFiles: []mydump.FileInfo{{}},
+				},
+			},
+		},
+	}
+	checkCtx := &backend.CheckCtx{DBMetas: dbMetas}
+
+	glue.EXPECT().GetSQLExecutor().Return(exec)
+	exec.EXPECT().QueryStringsWithLog(ctx, tiFlashReplicaQuery, gomock.Any(), gomock.Any()).
+		Return([][]string{{"db", "tbl"}, {"test", "t2"}, {"test1", "tbl"}}, nil)
+
+	err := checkTiFlashVersion(ctx, glue, checkCtx, *semver.New("4.0.2"))
+	c.Assert(err, ErrorMatches, "lightning local backend doesn't support TiFlash in this TiDB version. conflict table: `test1`.`tbl`.*")
 }

--- a/pkg/lightning/backend/noop/noop.go
+++ b/pkg/lightning/backend/noop/noop.go
@@ -76,7 +76,7 @@ func (b noopBackend) CleanupEngine(ctx context.Context, engineUUID uuid.UUID) er
 
 // CheckRequirements performs the check whether the backend satisfies the
 // version requirements
-func (b noopBackend) CheckRequirements(ctx context.Context) error {
+func (b noopBackend) CheckRequirements(context.Context, *backend.CheckCtx) error {
 	return nil
 }
 

--- a/pkg/lightning/backend/tidb/tidb.go
+++ b/pkg/lightning/backend/tidb/tidb.go
@@ -322,7 +322,7 @@ func (be *tidbBackend) ShouldPostProcess() bool {
 	return true
 }
 
-func (be *tidbBackend) CheckRequirements(ctx context.Context) error {
+func (be *tidbBackend) CheckRequirements(ctx context.Context, _ *backend.CheckCtx) error {
 	log.L().Info("skipping check requirements for tidb backend")
 	return nil
 }

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -83,8 +83,8 @@ const (
 )
 
 var (
-	tiflashMinImcompatibleVersion = semver.New("3.1.0")
-	tiflashMaxImcompatibleVersion = semver.New("4.0.4")
+	// the min version of tiflash that is compatible with local backend
+	tiflashminCompatibleVersion = semver.New("4.0.5")
 )
 
 // DeliverPauser is a shared pauser to pause progress to (*chunkRestore).encodeLoop
@@ -1915,7 +1915,7 @@ func (rc *RestoreController) checkRequirements(ctx context.Context) error {
 		if err != nil {
 			return errors.Annotatef(err, "fetch tidb version failed")
 		}
-		if v.Compare(*tiflashMaxImcompatibleVersion) <= 0 && v.Compare(*tiflashMinImcompatibleVersion) >= 0 {
+		if v.Compare(*tiflashminCompatibleVersion) < 0 {
 			res, err := rc.tidbGlue.GetSQLExecutor().QueryStringsWithLog(ctx, tiFlashReplicaQuery, "fetch tiflash replica info", log.L())
 			if err != nil {
 				return errors.Annotate(err, "fetch tiflash replica info failed")

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -20,11 +20,13 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -58,6 +60,7 @@ import (
 	"github.com/pingcap/br/pkg/pdutil"
 	"github.com/pingcap/br/pkg/storage"
 	"github.com/pingcap/br/pkg/utils"
+	"github.com/pingcap/br/pkg/version"
 	"github.com/pingcap/br/pkg/version/build"
 )
 
@@ -77,6 +80,11 @@ const (
 const (
 	compactStateIdle int32 = iota
 	compactStateDoing
+)
+
+var (
+	tiflashMinImcompatibleVersion = semver.New("3.1.0")
+	tiflashMaxImcompatibleVersion = semver.New("4.0.4")
 )
 
 // DeliverPauser is a shared pauser to pause progress to (*chunkRestore).encodeLoop
@@ -1879,12 +1887,68 @@ func (rc *RestoreController) enforceDiskQuota(ctx context.Context) {
 	}()
 }
 
+var (
+	tidbVersionQuery    = "SELECT version();"
+	tiFlashReplicaQuery = "SELECT TABLE_SCHEMA, TABLE_NAME, REPLICA_COUNT FROM information_schema.TIFLASH_REPLICA;"
+)
+
 func (rc *RestoreController) checkRequirements(ctx context.Context) error {
 	// skip requirement check if explicitly turned off
 	if !rc.cfg.App.CheckRequirements {
 		return nil
 	}
-	return rc.backend.CheckRequirements(ctx)
+	if err := rc.backend.CheckRequirements(ctx); err != nil {
+		return errors.Trace(err)
+	}
+	// check TiFlash replicas.
+	// local backend doesn't support TiFlash before tidb v4.0.5
+	if rc.cfg.TikvImporter.Backend == config.BackendLocal {
+		versionStr, err := rc.tidbGlue.GetSQLExecutor().ObtainStringWithLog(
+			ctx,
+			tidbVersionQuery,
+			"check TiDB version",
+			log.L())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		v, err := version.ExtractTiDBVersion(versionStr)
+		if err != nil {
+			return errors.Annotatef(err, "fetch tidb version failed")
+		}
+		if v.Compare(*tiflashMaxImcompatibleVersion) <= 0 && v.Compare(*tiflashMinImcompatibleVersion) >= 0 {
+			res, err := rc.tidbGlue.GetSQLExecutor().QueryStringsWithLog(ctx, tiFlashReplicaQuery, "fetch tiflash replica info", log.L())
+			if err != nil {
+				return errors.Annotate(err, "fetch tiflash replica info failed")
+			}
+
+			tiflashTables := make(map[string]int64, len(res))
+			for _, tblInfo := range res {
+				count, err := strconv.ParseInt(tblInfo[2], 10, 64)
+				if err != nil {
+					return errors.Annotatef(err, "parse tiflash replica for `%s`.`%s` count '%s' failed",
+						tblInfo[0], tblInfo[1], tblInfo[2])
+				}
+				if count > 0 {
+					name := common.UniqueTable(tblInfo[0], tblInfo[1])
+					tiflashTables[name] = count
+				}
+			}
+
+			for _, dbMeta := range rc.dbMetas {
+				for _, tblMeta := range dbMeta.Tables {
+					if len(tblMeta.DataFiles) == 0 {
+						continue
+					}
+					name := common.UniqueTable(dbMeta.Name, tblMeta.Name)
+					if _, ok := tiflashTables[name]; ok {
+						helpInfo := "Please either upgrade TiDB to version >= 4.0.5 or add TiFlash replica after load data."
+						return errors.Errorf("lightning local backend doesn't support TiFlash in this TiDB version. conflict table: %s. "+helpInfo, name)
+					}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (rc *RestoreController) setGlobalVariables(ctx context.Context) error {

--- a/pkg/lightning/restore/restore_test.go
+++ b/pkg/lightning/restore/restore_test.go
@@ -806,6 +806,68 @@ func (s *tableRestoreSuite) TestCheckRequirements(c *C) {
 	c.Assert(err, ErrorMatches, "fake check requirement error.*")
 }
 
+func (s *tableRestoreSuite) TestCheckRequirementsTiFlash(c *C) {
+	controller := gomock.NewController(c)
+	defer controller.Finish()
+	mockBackend := mock.NewMockBackend(controller)
+	backend := backend.MakeBackend(mockBackend)
+	glue := mock.NewMockGlue(controller)
+	exec := mock.NewMockSQLExecutor(controller)
+	ctx := context.Background()
+	rc := &RestoreController{
+		cfg: &config.Config{
+			App:          config.Lightning{CheckRequirements: true},
+			TikvImporter: config.TikvImporter{Backend: config.BackendLocal},
+		},
+		backend:  backend,
+		tidbGlue: glue,
+		dbMetas: []*mydump.MDDatabaseMeta{
+			{
+				Name: "test",
+				Tables: []*mydump.MDTableMeta{
+					{
+						DB:        "test",
+						Name:      "t1",
+						DataFiles: []mydump.FileInfo{{}},
+					},
+					{
+						DB:        "test",
+						Name:      "tbl",
+						DataFiles: []mydump.FileInfo{{}},
+					},
+				},
+			},
+			{
+				Name: "test1",
+				Tables: []*mydump.MDTableMeta{
+					{
+						DB:        "test1",
+						Name:      "t",
+						DataFiles: []mydump.FileInfo{{}},
+					},
+					{
+						DB:        "test",
+						Name:      "tbl",
+						DataFiles: []mydump.FileInfo{{}},
+					},
+				},
+			},
+		},
+	}
+
+	mockBackend.EXPECT().
+		CheckRequirements(ctx).
+		Return(nil)
+	glue.EXPECT().GetSQLExecutor().Return(exec).Times(2)
+	exec.EXPECT().ObtainStringWithLog(ctx, tidbVersionQuery, gomock.Any(), gomock.Any()).
+		Return("5.7.25-TiDB-v4.0.0", nil)
+	exec.EXPECT().QueryStringsWithLog(ctx, tiFlashReplicaQuery, gomock.Any(), gomock.Any()).
+		Return([][]string{{"db", "tbl", "1"}, {"test", "t1", "0"}, {"test", "t2", "3"}, {"test1", "tbl", "1"}}, nil)
+
+	err := rc.checkRequirements(ctx)
+	c.Assert(err, ErrorMatches, "lightning local backend doesn't support TiFlash in this TiDB version. conflict table: `test1`.`tbl`.*")
+}
+
 func (s *tableRestoreSuite) TestTableRestoreMetrics(c *C) {
 	controller := gomock.NewController(c)
 	defer controller.Finish()

--- a/pkg/mock/backend.go
+++ b/pkg/mock/backend.go
@@ -8,54 +8,55 @@ package mock
 
 import (
 	context "context"
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
 	backend "github.com/pingcap/br/pkg/lightning/backend"
 	kv "github.com/pingcap/br/pkg/lightning/backend/kv"
 	model "github.com/pingcap/parser/model"
 	table "github.com/pingcap/tidb/table"
-	reflect "reflect"
-	time "time"
 )
 
-// MockBackend is a mock of AbstractBackend interface
+// MockBackend is a mock of AbstractBackend interface.
 type MockBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackendMockRecorder
 }
 
-// MockBackendMockRecorder is the mock recorder for MockBackend
+// MockBackendMockRecorder is the mock recorder for MockBackend.
 type MockBackendMockRecorder struct {
 	mock *MockBackend
 }
 
-// NewMockBackend creates a new mock instance
+// NewMockBackend creates a new mock instance.
 func NewMockBackend(ctrl *gomock.Controller) *MockBackend {
 	mock := &MockBackend{ctrl: ctrl}
 	mock.recorder = &MockBackendMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 	return m.recorder
 }
 
-// CheckRequirements mocks base method
-func (m *MockBackend) CheckRequirements(arg0 context.Context) error {
+// CheckRequirements mocks base method.
+func (m *MockBackend) CheckRequirements(arg0 context.Context, arg1 *backend.CheckCtx) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckRequirements", arg0)
+	ret := m.ctrl.Call(m, "CheckRequirements", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CheckRequirements indicates an expected call of CheckRequirements
-func (mr *MockBackendMockRecorder) CheckRequirements(arg0 interface{}) *gomock.Call {
+// CheckRequirements indicates an expected call of CheckRequirements.
+func (mr *MockBackendMockRecorder) CheckRequirements(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRequirements", reflect.TypeOf((*MockBackend)(nil).CheckRequirements), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRequirements", reflect.TypeOf((*MockBackend)(nil).CheckRequirements), arg0, arg1)
 }
 
-// CleanupEngine mocks base method
+// CleanupEngine mocks base method.
 func (m *MockBackend) CleanupEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupEngine", arg0, arg1)
@@ -63,25 +64,25 @@ func (m *MockBackend) CleanupEngine(arg0 context.Context, arg1 uuid.UUID) error 
 	return ret0
 }
 
-// CleanupEngine indicates an expected call of CleanupEngine
+// CleanupEngine indicates an expected call of CleanupEngine.
 func (mr *MockBackendMockRecorder) CleanupEngine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupEngine", reflect.TypeOf((*MockBackend)(nil).CleanupEngine), arg0, arg1)
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockBackend) Close() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Close")
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockBackendMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockBackend)(nil).Close))
 }
 
-// CloseEngine mocks base method
+// CloseEngine mocks base method.
 func (m *MockBackend) CloseEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloseEngine", arg0, arg1)
@@ -89,13 +90,13 @@ func (m *MockBackend) CloseEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	return ret0
 }
 
-// CloseEngine indicates an expected call of CloseEngine
+// CloseEngine indicates an expected call of CloseEngine.
 func (mr *MockBackendMockRecorder) CloseEngine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseEngine", reflect.TypeOf((*MockBackend)(nil).CloseEngine), arg0, arg1)
 }
 
-// EngineFileSizes mocks base method
+// EngineFileSizes mocks base method.
 func (m *MockBackend) EngineFileSizes() []backend.EngineFileSize {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EngineFileSizes")
@@ -103,13 +104,13 @@ func (m *MockBackend) EngineFileSizes() []backend.EngineFileSize {
 	return ret0
 }
 
-// EngineFileSizes indicates an expected call of EngineFileSizes
+// EngineFileSizes indicates an expected call of EngineFileSizes.
 func (mr *MockBackendMockRecorder) EngineFileSizes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EngineFileSizes", reflect.TypeOf((*MockBackend)(nil).EngineFileSizes))
 }
 
-// FetchRemoteTableModels mocks base method
+// FetchRemoteTableModels mocks base method.
 func (m *MockBackend) FetchRemoteTableModels(arg0 context.Context, arg1 string) ([]*model.TableInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchRemoteTableModels", arg0, arg1)
@@ -118,13 +119,13 @@ func (m *MockBackend) FetchRemoteTableModels(arg0 context.Context, arg1 string) 
 	return ret0, ret1
 }
 
-// FetchRemoteTableModels indicates an expected call of FetchRemoteTableModels
+// FetchRemoteTableModels indicates an expected call of FetchRemoteTableModels.
 func (mr *MockBackendMockRecorder) FetchRemoteTableModels(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchRemoteTableModels", reflect.TypeOf((*MockBackend)(nil).FetchRemoteTableModels), arg0, arg1)
 }
 
-// FlushAllEngines mocks base method
+// FlushAllEngines mocks base method.
 func (m *MockBackend) FlushAllEngines(arg0 context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FlushAllEngines", arg0)
@@ -132,13 +133,13 @@ func (m *MockBackend) FlushAllEngines(arg0 context.Context) error {
 	return ret0
 }
 
-// FlushAllEngines indicates an expected call of FlushAllEngines
+// FlushAllEngines indicates an expected call of FlushAllEngines.
 func (mr *MockBackendMockRecorder) FlushAllEngines(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushAllEngines", reflect.TypeOf((*MockBackend)(nil).FlushAllEngines), arg0)
 }
 
-// FlushEngine mocks base method
+// FlushEngine mocks base method.
 func (m *MockBackend) FlushEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FlushEngine", arg0, arg1)
@@ -146,13 +147,13 @@ func (m *MockBackend) FlushEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	return ret0
 }
 
-// FlushEngine indicates an expected call of FlushEngine
+// FlushEngine indicates an expected call of FlushEngine.
 func (mr *MockBackendMockRecorder) FlushEngine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushEngine", reflect.TypeOf((*MockBackend)(nil).FlushEngine), arg0, arg1)
 }
 
-// ImportEngine mocks base method
+// ImportEngine mocks base method.
 func (m *MockBackend) ImportEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportEngine", arg0, arg1)
@@ -160,13 +161,13 @@ func (m *MockBackend) ImportEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	return ret0
 }
 
-// ImportEngine indicates an expected call of ImportEngine
+// ImportEngine indicates an expected call of ImportEngine.
 func (mr *MockBackendMockRecorder) ImportEngine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportEngine", reflect.TypeOf((*MockBackend)(nil).ImportEngine), arg0, arg1)
 }
 
-// LocalWriter mocks base method
+// LocalWriter mocks base method.
 func (m *MockBackend) LocalWriter(arg0 context.Context, arg1 uuid.UUID) (backend.EngineWriter, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LocalWriter", arg0, arg1)
@@ -175,13 +176,13 @@ func (m *MockBackend) LocalWriter(arg0 context.Context, arg1 uuid.UUID) (backend
 	return ret0, ret1
 }
 
-// LocalWriter indicates an expected call of LocalWriter
+// LocalWriter indicates an expected call of LocalWriter.
 func (mr *MockBackendMockRecorder) LocalWriter(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalWriter", reflect.TypeOf((*MockBackend)(nil).LocalWriter), arg0, arg1)
 }
 
-// MakeEmptyRows mocks base method
+// MakeEmptyRows mocks base method.
 func (m *MockBackend) MakeEmptyRows() kv.Rows {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeEmptyRows")
@@ -189,13 +190,13 @@ func (m *MockBackend) MakeEmptyRows() kv.Rows {
 	return ret0
 }
 
-// MakeEmptyRows indicates an expected call of MakeEmptyRows
+// MakeEmptyRows indicates an expected call of MakeEmptyRows.
 func (mr *MockBackendMockRecorder) MakeEmptyRows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeEmptyRows", reflect.TypeOf((*MockBackend)(nil).MakeEmptyRows))
 }
 
-// NewEncoder mocks base method
+// NewEncoder mocks base method.
 func (m *MockBackend) NewEncoder(arg0 table.Table, arg1 *kv.SessionOptions) (kv.Encoder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewEncoder", arg0, arg1)
@@ -204,13 +205,13 @@ func (m *MockBackend) NewEncoder(arg0 table.Table, arg1 *kv.SessionOptions) (kv.
 	return ret0, ret1
 }
 
-// NewEncoder indicates an expected call of NewEncoder
+// NewEncoder indicates an expected call of NewEncoder.
 func (mr *MockBackendMockRecorder) NewEncoder(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewEncoder", reflect.TypeOf((*MockBackend)(nil).NewEncoder), arg0, arg1)
 }
 
-// OpenEngine mocks base method
+// OpenEngine mocks base method.
 func (m *MockBackend) OpenEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenEngine", arg0, arg1)
@@ -218,13 +219,13 @@ func (m *MockBackend) OpenEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	return ret0
 }
 
-// OpenEngine indicates an expected call of OpenEngine
+// OpenEngine indicates an expected call of OpenEngine.
 func (mr *MockBackendMockRecorder) OpenEngine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenEngine", reflect.TypeOf((*MockBackend)(nil).OpenEngine), arg0, arg1)
 }
 
-// ResetEngine mocks base method
+// ResetEngine mocks base method.
 func (m *MockBackend) ResetEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetEngine", arg0, arg1)
@@ -232,13 +233,13 @@ func (m *MockBackend) ResetEngine(arg0 context.Context, arg1 uuid.UUID) error {
 	return ret0
 }
 
-// ResetEngine indicates an expected call of ResetEngine
+// ResetEngine indicates an expected call of ResetEngine.
 func (mr *MockBackendMockRecorder) ResetEngine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetEngine", reflect.TypeOf((*MockBackend)(nil).ResetEngine), arg0, arg1)
 }
 
-// RetryImportDelay mocks base method
+// RetryImportDelay mocks base method.
 func (m *MockBackend) RetryImportDelay() time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetryImportDelay")
@@ -246,13 +247,13 @@ func (m *MockBackend) RetryImportDelay() time.Duration {
 	return ret0
 }
 
-// RetryImportDelay indicates an expected call of RetryImportDelay
+// RetryImportDelay indicates an expected call of RetryImportDelay.
 func (mr *MockBackendMockRecorder) RetryImportDelay() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryImportDelay", reflect.TypeOf((*MockBackend)(nil).RetryImportDelay))
 }
 
-// ShouldPostProcess mocks base method
+// ShouldPostProcess mocks base method.
 func (m *MockBackend) ShouldPostProcess() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldPostProcess")
@@ -260,36 +261,36 @@ func (m *MockBackend) ShouldPostProcess() bool {
 	return ret0
 }
 
-// ShouldPostProcess indicates an expected call of ShouldPostProcess
+// ShouldPostProcess indicates an expected call of ShouldPostProcess.
 func (mr *MockBackendMockRecorder) ShouldPostProcess() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldPostProcess", reflect.TypeOf((*MockBackend)(nil).ShouldPostProcess))
 }
 
-// MockEngineWriter is a mock of EngineWriter interface
+// MockEngineWriter is a mock of EngineWriter interface.
 type MockEngineWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockEngineWriterMockRecorder
 }
 
-// MockEngineWriterMockRecorder is the mock recorder for MockEngineWriter
+// MockEngineWriterMockRecorder is the mock recorder for MockEngineWriter.
 type MockEngineWriterMockRecorder struct {
 	mock *MockEngineWriter
 }
 
-// NewMockEngineWriter creates a new mock instance
+// NewMockEngineWriter creates a new mock instance.
 func NewMockEngineWriter(ctrl *gomock.Controller) *MockEngineWriter {
 	mock := &MockEngineWriter{ctrl: ctrl}
 	mock.recorder = &MockEngineWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEngineWriter) EXPECT() *MockEngineWriterMockRecorder {
 	return m.recorder
 }
 
-// AppendRows mocks base method
+// AppendRows mocks base method.
 func (m *MockEngineWriter) AppendRows(arg0 context.Context, arg1 string, arg2 []string, arg3 uint64, arg4 kv.Rows) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppendRows", arg0, arg1, arg2, arg3, arg4)
@@ -297,13 +298,13 @@ func (m *MockEngineWriter) AppendRows(arg0 context.Context, arg1 string, arg2 []
 	return ret0
 }
 
-// AppendRows indicates an expected call of AppendRows
+// AppendRows indicates an expected call of AppendRows.
 func (mr *MockEngineWriterMockRecorder) AppendRows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendRows", reflect.TypeOf((*MockEngineWriter)(nil).AppendRows), arg0, arg1, arg2, arg3, arg4)
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockEngineWriter) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -311,7 +312,7 @@ func (m *MockEngineWriter) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockEngineWriterMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockEngineWriter)(nil).Close))


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Return error at check-requirement if tidb cluster <= "v4.0.4" and some table contains tiflash replicas.

close #965

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Make return error more user-friendly when lightning load data into tables with TiFlash replica but cluster version is too old.

<!-- fill in the release note, or just write "No release note" -->
