### PR TITLE
makefile: fix the issue that build the wrong version when not in release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BR_PKG := github.com/pingcap/br
 
 VERSION := v5.0.0-dev
 release_version_regex := ^v5\..*$$
-release_branch_regex := ^release-[0-9]\.[0-9].*$$
+release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$"
 ifneq ($(shell git rev-parse --abbrev-ref HEAD | egrep $(release_branch_regex)),)
 	# If we are in release branch, try to use tag version.
 	ifneq ($(shell git describe --tags --dirty | egrep $(release_version_regex)),)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the issue that makes would build the wrong version tag when execute it not in the `release` branch.

### What is changed and how it works?
update the branch check conditions in MakeFile

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)



### Release Note

 - Fix the issue that makes would build the wrong version tag when execute it not in the `release` branch.


<!-- fill in the release note, or just write "No release note" -->
