### PR TITLE
pkg/lightning: fix incorrect table counter

### DIFF
--- a/pkg/lightning/restore/restore_test.go
+++ b/pkg/lightning/restore/restore_test.go
@@ -1271,6 +1271,7 @@ type restoreSchemaSuite struct {
 	ctx        context.Context
 	rc         *Controller
 	controller *gomock.Controller
+	tableInfos []*model.TableInfo
 }
 
 func (s *restoreSchemaSuite) SetUpSuite(c *C) {
@@ -1286,14 +1287,28 @@ func (s *restoreSchemaSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	// restore table schema files
 	fakeTableFilesCount := 8
+
+	p := parser.New()
+	p.SetSQLMode(mysql.ModeANSIQuotes)
+	se := tmock.NewContext()
+
+	tableInfos := make([]*model.TableInfo, 0, fakeTableFilesCount)
 	for i := 1; i <= fakeTableFilesCount; i++ {
 		fakeTableName := fmt.Sprintf("tbl%d", i)
 		// please follow the `mydump.defaultFileRouteRules`, matches files like '{schema}.{table}-schema.sql'
 		fakeFileName := fmt.Sprintf("%s.%s-schema.sql", fakeDBName, fakeTableName)
-		fakeFileContent := []byte(fmt.Sprintf("CREATE TABLE %s(i TINYINT);", fakeTableName))
-		err = store.WriteFile(ctx, fakeFileName, fakeFileContent)
+		fakeFileContent := fmt.Sprintf("CREATE TABLE %s(i TINYINT);", fakeTableName)
+		err = store.WriteFile(ctx, fakeFileName, []byte(fakeFileContent))
 		c.Assert(err, IsNil)
+
+		node, err := p.ParseOneStmt(fakeFileContent, "", "")
+		c.Assert(err, IsNil)
+		core, err := ddl.MockTableInfo(se, node.(*ast.CreateTableStmt), 0xabcdef)
+		c.Assert(err, IsNil)
+		core.State = model.StatePublic
+		tableInfos = append(tableInfos, core)
 	}
+	s.tableInfos = tableInfos
 	// restore view schema files
 	fakeViewFilesCount := 8
 	for i := 1; i <= fakeViewFilesCount; i++ {
@@ -1323,11 +1338,11 @@ func (s *restoreSchemaSuite) SetUpSuite(c *C) {
 func (s *restoreSchemaSuite) SetUpTest(c *C) {
 	s.controller, s.ctx = gomock.WithContext(context.Background(), c)
 	mockBackend := mock.NewMockBackend(s.controller)
-	// We don't care the execute results of those
 	mockBackend.EXPECT().
 		FetchRemoteTableModels(gomock.Any(), gomock.Any()).
 		AnyTimes().
-		Return(make([]*model.TableInfo, 0), nil)
+		Return(s.tableInfos, nil)
+	mockBackend.EXPECT().Close()
 	s.rc.backend = backend.MakeBackend(mockBackend)
 	mockSQLExecutor := mock.NewMockSQLExecutor(s.controller)
 	mockSQLExecutor.EXPECT().
@@ -1361,6 +1376,7 @@ func (s *restoreSchemaSuite) SetUpTest(c *C) {
 		GetParser().
 		AnyTimes().
 		Return(parser)
+	mockSQLExecutor.EXPECT().Close()
 	s.rc.tidbGlue = mockTiDBGlue
 }
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the wrong table count in the `progress` log like following:
```
[2021/04/12 14:26:43.837 +08:00] [INFO] [restore.go:1026] [progress] [total=0.0%] [tables="0/2 (0.0%)"] [chunks="0/99 (0.0%)"] [engines="0/2 (0.0%)"] [speed(MiB/s)=145.03058180393646] [state=preparing] []
```
There is only one table data in the source files but the pending tables count is 2. 

### What is changed and how it works?
Calculate pending table count based on the tables in dbMetas instead of tables fetched from TiDB.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - Fix the bug that the table count in the progress log is wrong

<!-- fill in the release note, or just write "No release note" -->
