### PR TITLE
test: fix unstable integration test lightning_checkpoint

### DIFF
--- a/pkg/lightning/lightning_test.go
+++ b/pkg/lightning/lightning_test.go
@@ -194,8 +194,8 @@ func (s *lightningServerSuite) TestRunServer(c *C) {
 			c.Assert(taskCfg.TiDB.Host, Equals, "test.invalid")
 			c.Assert(taskCfg.Mydumper.SourceDir, Equals, fmt.Sprintf("file://demo-path-%d", i))
 			c.Assert(taskCfg.Mydumper.CSV.Separator, Equals, "/")
-		case <-time.After(500 * time.Millisecond):
-			c.Fatalf("task is not queued after 500ms (i = %d)", i)
+		case <-time.After(1500 * time.Millisecond):
+			c.Fatalf("task is not queued after 1500ms (i = %d)", i)
 		}
 	}
 }

--- a/tests/lightning_checkpoint/run.sh
+++ b/tests/lightning_checkpoint/run.sh
@@ -57,7 +57,7 @@ for i in $(seq "$TABLE_COUNT"); do
 done
 PARTIAL_IMPORT_QUERY="SELECT *, $OUTER_QUERY AS s FROM (SELECT $INNER_QUERY) _"
 
-for BACKEND in importer tidb local; do
+for BACKEND in importer local; do
   if [ "$BACKEND" = 'local' ]; then
     check_cluster_version 4 0 0 'local backend' || continue
   fi


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #782 

### What is changed and how it works?
- Do not run `lightning_checkpoint` with tidb backend because tidb backend's checkpoint can't guarantee exact once semantics if target table has no primary/unique key.
- Wait more time (0.5s -> 1.5s) for unit test `TestRunServer` to make it less possible to timeout.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
