### PR TITLE
test: fix the unstable unit test 

### DIFF
--- a/pkg/lightning/lightning_test.go
+++ b/pkg/lightning/lightning_test.go
@@ -143,7 +143,7 @@ func (s *lightningServerSuite) TestRunServer(c *C) {
 	resp.Body.Close()
 
 	go func() {
-		s.lightning.RunServer()
+		_ = s.lightning.RunServer()
 	}()
 	time.Sleep(100 * time.Millisecond)
 

--- a/pkg/lightning/lightning_test.go
+++ b/pkg/lightning/lightning_test.go
@@ -143,8 +143,7 @@ func (s *lightningServerSuite) TestRunServer(c *C) {
 	resp.Body.Close()
 
 	go func() {
-		err := s.lightning.RunServer()
-		c.Assert(err, IsNil)
+		s.lightning.RunServer()
 	}()
 	time.Sleep(100 * time.Millisecond)
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
TestLightning `Runserver` checks error is `nil` in another goroutine.and the result is unstable because Teardown(`ctx.cancel()`) may happen before `Runserver` exit.

just like https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/br_ghpr_unit_and_integration_test/detail/br_ghpr_unit_and_integration_test/9631/pipeline

### What is changed and how it works?
remove this check. because the error is either `nil` or `context.cancel`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note.

<!-- fill in the release note, or just write "No release note" -->
