### PR TITLE
backup: optimize progress update logic

### DIFF
--- a/.github/workflows/compatible_test.yml
+++ b/.github/workflows/compatible_test.yml
@@ -57,10 +57,10 @@ jobs:
     - name: Collect component log
       if: ${{ failure() }}
       run: |
-        tar czvf /tmp/br/docker/logs.tar.gz /tmp/br/docker/backup_logs/*
+        tar czvf ${{ github.workspace }}/logs.tar.gz /tmp/br/docker/backup_logs/*
 
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
         name: logs
-        path: /tmp/br/docker/logs.tar.gz
+        path: ${{ github.workspace }}/logs.tar.gz

--- a/.github/workflows/compatible_test.yml
+++ b/.github/workflows/compatible_test.yml
@@ -57,10 +57,10 @@ jobs:
     - name: Collect component log
       if: ${{ failure() }}
       run: |
-        tar czvf /tmp/br/logs.tar.gz /tmp/br/docker/backup_logs/*
+        tar czvf /tmp/br/docker/logs.tar.gz /tmp/br/docker/backup_logs/*
 
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
         name: logs
-        path: /tmp/br/logs.tar.gz
+        path: /tmp/br/docker/logs.tar.gz

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -71,9 +71,9 @@ const (
 	backupFineGrainedMaxBackoff = 80000
 	backupRetryTimes            = 5
 	// RangeUnit represents the progress updated counter when a range finished.
-	RangeUint ProgressUnit = "range"
+	RangeUnit ProgressUnit = "range"
 	// RegionUnit represents the progress updated counter when a region finished.
-	RegionUint ProgressUnit = "region"
+	RegionUnit ProgressUnit = "region"
 )
 
 // Client is a client instructs TiKV how to do a backup.

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -354,10 +354,10 @@ func BuildBackupRangeAndSchema(
 					return nil, nil, errors.Trace(err)
 				}
 				tableInfo.AutoRandID = globalAutoRandID
-				logger.Info("change table AutoRandID",
+				logger.Debug("change table AutoRandID",
 					zap.Int64("AutoRandID", globalAutoRandID))
 			}
-			logger.Info("change table AutoIncID",
+			logger.Debug("change table AutoIncID",
 				zap.Int64("AutoIncID", globalAutoID))
 
 			// remove all non-public indices

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -553,7 +553,7 @@ func (bc *Client) BackupRange(
 	}
 
 	// update progress of range unit
-	progressCallBack(RangeUint)
+	progressCallBack(RangeUnit)
 
 	if req.IsRawKv {
 		log.Info("backup raw ranges",
@@ -711,7 +711,7 @@ func (bc *Client) fineGrainedBackup(
 				rangeTree.Put(resp.StartKey, resp.EndKey, resp.Files)
 
 				// Update progress
-				progressCallBack(RegionUint)
+				progressCallBack(RegionUnit)
 			}
 		}
 

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -63,16 +63,13 @@ type Checksum struct {
 	TotalBytes uint64
 }
 
+// ProgressUnit represents the unit of progress.
+type ProgressUnit string
+
 // Maximum total sleep time(in ms) for kv/cop commands.
 const (
 	backupFineGrainedMaxBackoff = 80000
 	backupRetryTimes            = 5
-)
-
-// ProgressUnit represents the unit of progress.
-type ProgressUnit string
-
-const (
 	// RangeUnit represents the progress updated counter when a range finished.
 	RangeUint ProgressUnit = "range"
 	// RegionUnit represents the progress updated counter when a region finished.

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -42,7 +42,7 @@ func (push *pushDown) pushBackup(
 	ctx context.Context,
 	req backuppb.BackupRequest,
 	stores []*metapb.Store,
-	progressCallBack func(bool),
+	progressCallBack func(ProgressUnit),
 ) (rtree.RangeTree, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("pushDown.pushBackup", opentracing.ChildOf(span.Context()))
@@ -119,7 +119,7 @@ func (push *pushDown) pushBackup(
 					resp.GetStartKey(), resp.GetEndKey(), resp.GetFiles())
 
 				// Update progress
-				progressCallBack(false)
+				progressCallBack(RegionUint)
 			} else {
 				errPb := resp.GetError()
 				switch v := errPb.Detail.(type) {

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/zap"
 
 	berrors "github.com/pingcap/br/pkg/errors"
-	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/logutil"
 	"github.com/pingcap/br/pkg/redact"
 	"github.com/pingcap/br/pkg/rtree"
@@ -43,7 +42,7 @@ func (push *pushDown) pushBackup(
 	ctx context.Context,
 	req backuppb.BackupRequest,
 	stores []*metapb.Store,
-	updateCh glue.Progress,
+	progressCallBack func(bool),
 ) (rtree.RangeTree, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("pushDown.pushBackup", opentracing.ChildOf(span.Context()))
@@ -120,7 +119,7 @@ func (push *pushDown) pushBackup(
 					resp.GetStartKey(), resp.GetEndKey(), resp.GetFiles())
 
 				// Update progress
-				updateCh.Inc()
+				progressCallBack(false)
 			} else {
 				errPb := resp.GetError()
 				switch v := errPb.Detail.(type) {

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -119,7 +119,7 @@ func (push *pushDown) pushBackup(
 					resp.GetStartKey(), resp.GetEndKey(), resp.GetFiles())
 
 				// Update progress
-				progressCallBack(RegionUint)
+				progressCallBack(RegionUnit)
 			} else {
 				errPb := resp.GetError()
 				switch v := errPb.Detail.(type) {

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -367,7 +367,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	progressCount := 0
 	failpointInjectFn := func(unit backup.ProgressUnit) {
 		failpoint.Inject("progress-call-back", func(v failpoint.Value) {
-			progressCount ++
+			progressCount++
 			log.Info("failpoint progress-call-back injected")
 			if fileName, ok := v.(string); ok {
 				f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY, os.ModePerm)

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -370,7 +370,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 			progressCount ++
 			log.Info("failpoint progress-call-back injected")
 			if fileName, ok := v.(string); ok {
-				f, err := os.OpenFile(fileName, os.O_CREATE|os.O_APPEND, 0666)
+				f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY, os.ModePerm)
 				if err != nil {
 					log.Warn("failed to create file", zap.Error(err))
 				}

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -193,6 +193,13 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	updateCh := g.StartProgress(
 		ctx, cmdName, int64(approximateRegions), !cfg.LogProgress)
 
+	progressCallBack := func(isRangeUnit bool) {
+		if isRangeUnit {
+			return
+		}
+		updateCh.Inc()
+	}
+
 	req := backuppb.BackupRequest{
 		ClusterId:        client.GetClusterID(),
 		StartVersion:     0,
@@ -204,7 +211,7 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 		CompressionType:  cfg.CompressionType,
 		CompressionLevel: cfg.CompressionLevel,
 	}
-	files, err := client.BackupRange(ctx, backupRange.StartKey, backupRange.EndKey, req, updateCh)
+	files, err := client.BackupRange(ctx, backupRange.StartKey, backupRange.EndKey, req, progressCallBack)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -194,7 +194,7 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 		ctx, cmdName, int64(approximateRegions), !cfg.LogProgress)
 
 	progressCallBack := func(unit backup.ProgressUnit) {
-		if unit == backup.RangeUint {
+		if unit == backup.RangeUnit {
 			return
 		}
 		updateCh.Inc()

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -193,8 +193,8 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	updateCh := g.StartProgress(
 		ctx, cmdName, int64(approximateRegions), !cfg.LogProgress)
 
-	progressCallBack := func(isRangeUnit bool) {
-		if isRangeUnit {
+	progressCallBack := func(unit backup.ProgressUnit) {
+		if unit == backup.RangeUint {
 			return
 		}
 		updateCh.Inc()

--- a/tests/br_300_small_tables/run.sh
+++ b/tests/br_300_small_tables/run.sh
@@ -37,7 +37,7 @@ export GO_FAILPOINTS="github.com/pingcap/br/pkg/task/progress-call-back=return(\
 run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 export GO_FAILPOINTS=""
 
-if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ !$(grep -q "range" $PROGRESS_FILE) ]];
+if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -c "range" $PROGRESS_FILE) == "1" ]];
 then
   echo "use the correct progress unit"
 else

--- a/tests/br_300_small_tables/run.sh
+++ b/tests/br_300_small_tables/run.sh
@@ -37,7 +37,7 @@ export GO_FAILPOINTS="github.com/pingcap/br/pkg/task/progress-call-back=return(\
 run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 export GO_FAILPOINTS=""
 
-if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -q "range" $PROGRESS_FILE) ]];
+if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ !$(grep -q "range" $PROGRESS_FILE) ]];
 then
   echo "use the correct progress unit"
 else

--- a/tests/br_300_small_tables/run.sh
+++ b/tests/br_300_small_tables/run.sh
@@ -33,17 +33,17 @@ done
 # backup db
 echo "backup start..."
 
-export GO_FAILPOINTS="github.com/pingcap/br/pkg/task/progress-call-back=1*return(\"$PROGRESS_FILE\")"
+export GO_FAILPOINTS="github.com/pingcap/br/pkg/task/progress-call-back=return(\"$PROGRESS_FILE\")"
 run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 export GO_FAILPOINTS=""
 
-if [ grep -q "range" $PROGRESS_FILE ]
+# check if we have 300 range, because we have 300 tables
+if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -q "range:300" $PROGRESS_FILE) ]];
 then
   echo "use the correct progress unit"
-  total=awk -F ":" '{sum+=$1;}END{print sum;}' $PROGRESS_FILE
-  echo total
 else
   echo "use the wrong progress unit, expect range"
+  cat $PROGRESS_FILE
   exit 1
 fi
 

--- a/tests/br_300_small_tables/run.sh
+++ b/tests/br_300_small_tables/run.sh
@@ -37,8 +37,7 @@ export GO_FAILPOINTS="github.com/pingcap/br/pkg/task/progress-call-back=return(\
 run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 export GO_FAILPOINTS=""
 
-# check if we have 300 range, because we have 300 tables
-if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -q "range:300" $PROGRESS_FILE) ]];
+if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -q "range" $PROGRESS_FILE) ]];
 then
   echo "use the correct progress unit"
 else

--- a/tests/br_db/run.sh
+++ b/tests/br_db/run.sh
@@ -44,7 +44,7 @@ run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit
 export GO_FAILPOINTS=""
 
 # check if we use the region unit
-if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -c "range" $PROGRESS_FILE) == "1" ]];
+if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -c "region" $PROGRESS_FILE) == "1" ]];
 then
   echo "use the correct progress unit"
 else

--- a/tests/br_db/run.sh
+++ b/tests/br_db/run.sh
@@ -44,7 +44,7 @@ run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit
 export GO_FAILPOINTS=""
 
 # check if we use the region unit
-if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ !$(grep -q "region" $PROGRESS_FILE) ]];
+if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -c "range" $PROGRESS_FILE) == "1" ]];
 then
   echo "use the correct progress unit"
 else

--- a/tests/br_db/run.sh
+++ b/tests/br_db/run.sh
@@ -16,6 +16,9 @@
 set -eu
 DB="$TEST_NAME"
 
+PROGRESS_FILE="$TEST_DIR/progress_unit_file"
+rm -rf $PROGRESS_FILE
+
 run_sql "CREATE DATABASE $DB;"
 
 run_sql "CREATE TABLE $DB.usertable1 ( \
@@ -41,7 +44,7 @@ run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit
 export GO_FAILPOINTS=""
 
 # check if we use the region unit
-if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -q "region" $PROGRESS_FILE) ]];
+if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ !$(grep -q "region" $PROGRESS_FILE) ]];
 then
   echo "use the correct progress unit"
 else
@@ -49,6 +52,7 @@ else
   cat $PROGRESS_FILE
   exit 1
 fi
+rm -rf $PROGRESS_FILE
 
 run_sql "DROP DATABASE $DB;"
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Solve https://github.com/pingcap/br/issues/1042

### What is changed and how it works?
if backup ranges is more than 100, we can use range as the unit of progress.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release Note

 - Fix the issue that backup costs too much time to count progress units when backup lots of ranges.

<!-- fill in the release note, or just write "No release note" -->
