### PR TITLE
lightning: fix wrong error message of restoring table

### DIFF
--- a/pkg/lightning/mydump/loader.go
+++ b/pkg/lightning/mydump/loader.go
@@ -53,16 +53,16 @@ type SourceFileMeta struct {
 	FileSize    int64
 }
 
-func (m *MDTableMeta) GetSchema(ctx context.Context, store storage.ExternalStorage) string {
+func (m *MDTableMeta) GetSchema(ctx context.Context, store storage.ExternalStorage) (string, error) {
 	schema, err := ExportStatement(ctx, store, m.SchemaFile, m.charSet)
 	if err != nil {
 		log.L().Error("failed to extract table schema",
 			zap.String("Path", m.SchemaFile.FileMeta.Path),
 			log.ShortError(err),
 		)
-		return ""
+		return "", err
 	}
-	return string(schema)
+	return string(schema), nil
 }
 
 /*

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -15,7 +15,6 @@ package mydump_test
 
 import (
 	"context"
-	"github.com/pingcap/br/pkg/storage"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/pingcap/br/pkg/lightning/config"
 	md "github.com/pingcap/br/pkg/lightning/mydump"
+	"github.com/pingcap/br/pkg/storage"
 )
 
 var _ = Suite(&testMydumpLoaderSuite{})

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -15,6 +15,7 @@ package mydump_test
 
 import (
 	"context"
+	"github.com/pingcap/br/pkg/storage"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -162,6 +163,46 @@ func (s *testMydumpLoaderSuite) TestDuplicatedTable(c *C) {
 
 	_, err := md.NewMyDumpLoader(context.Background(), s.cfg)
 	c.Assert(err, ErrorMatches, `invalid table schema file, duplicated item - .*db\.tbl-schema\.sql`)
+}
+
+func (s *testMydumpLoaderSuite) TestTableInfoNotFound(c *C) {
+	s.cfg.Mydumper.CharacterSet = "auto"
+
+	s.touch(c, "db-schema-create.sql")
+	s.touch(c, "db.tbl-schema.sql")
+
+	ctx := context.Background()
+	store, err := storage.NewLocalStorage(s.sourceDir)
+	c.Assert(err, IsNil)
+
+	loader, err := md.NewMyDumpLoader(ctx, s.cfg)
+	c.Assert(err, IsNil)
+	for _, dbMeta := range loader.GetDatabases() {
+		for _, tblMeta := range dbMeta.Tables {
+			sql, err := tblMeta.GetSchema(ctx, store)
+			c.Assert(sql, Equals, "")
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
+func (s *testMydumpLoaderSuite) TestTableUnexpectedError(c *C) {
+	s.touch(c, "db-schema-create.sql")
+	s.touch(c, "db.tbl-schema.sql")
+
+	ctx := context.Background()
+	store, err := storage.NewLocalStorage(s.sourceDir)
+	c.Assert(err, IsNil)
+
+	loader, err := md.NewMyDumpLoader(ctx, s.cfg)
+	c.Assert(err, IsNil)
+	for _, dbMeta := range loader.GetDatabases() {
+		for _, tblMeta := range dbMeta.Tables {
+			sql, err := tblMeta.GetSchema(ctx, store)
+			c.Assert(sql, Equals, "")
+			c.Assert(err, ErrorMatches, "failed to decode db.tbl-schema.sql as : Unsupported encoding ")
+		}
+	}
 }
 
 func (s *testMydumpLoaderSuite) TestDataNoHostDB(c *C) {

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -414,7 +414,7 @@ func (worker *restoreSchemaWorker) makeJobs(dbMetas []*mydump.MDDatabaseMeta) er
 	// 2. restore tables, execute statements concurrency
 	for _, dbMeta := range dbMetas {
 		for _, tblMeta := range dbMeta.Tables {
-			sql := tblMeta.GetSchema(worker.ctx, worker.store)
+			sql, err := tblMeta.GetSchema(worker.ctx, worker.store)
 			if sql != "" {
 				stmts, err := createTableIfNotExistsStmt(worker.glue.GetParser(), sql, dbMeta.Name, tblMeta.Name)
 				if err != nil {
@@ -436,6 +436,9 @@ func (worker *restoreSchemaWorker) makeJobs(dbMetas []*mydump.MDDatabaseMeta) er
 					return err
 				}
 			}
+			if err != nil {
+				return err
+			}
 		}
 	}
 	err = worker.wait()
@@ -445,7 +448,7 @@ func (worker *restoreSchemaWorker) makeJobs(dbMetas []*mydump.MDDatabaseMeta) er
 	// 3. restore views. Since views can cross database we must restore views after all table schemas are restored.
 	for _, dbMeta := range dbMetas {
 		for _, viewMeta := range dbMeta.Views {
-			sql := viewMeta.GetSchema(worker.ctx, worker.store)
+			sql, err := viewMeta.GetSchema(worker.ctx, worker.store)
 			if sql != "" {
 				stmts, err := createTableIfNotExistsStmt(worker.glue.GetParser(), sql, dbMeta.Name, viewMeta.Name)
 				if err != nil {
@@ -471,6 +474,9 @@ func (worker *restoreSchemaWorker) makeJobs(dbMetas []*mydump.MDDatabaseMeta) er
 				if err != nil {
 					return err
 				}
+			}
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Restoring table schema raised wrong error messages.
https://github.com/pingcap/br/issues/969

### What is changed and how it works?

Propagating the error out.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects


Related changes


### Release Note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
