### PR TITLE
Makefile: fix version number on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,23 +9,23 @@ CHECKER := awk '{ print } END { if (NR > 0) { exit 1 } }'
 
 BR_PKG := github.com/pingcap/br
 
-VERSION =
-ifeq ($(VERSION),)
-	VERSION := v5.0.0-master
+RELEASE_VERSION =
+ifeq ($(RELEASE_VERSION),)
+	RELEASE_VERSION := v5.0.0-master
 	release_version_regex := ^v5\..*$$
 	release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/v[0-9]\.[0-9]\..*$$"
 	ifneq ($(shell git rev-parse --abbrev-ref HEAD | egrep $(release_branch_regex)),)
 		# If we are in release branch, try to use tag version.
 		ifneq ($(shell git describe --tags --dirty | egrep $(release_version_regex)),)
-			VERSION := $(shell git describe --tags --dirty)
+			RELEASE_VERSION := $(shell git describe --tags --dirty)
 		endif
 	else ifneq ($(shell git status --porcelain),)
 		# Add -dirty if the working tree is dirty for non release branch.
-		VERSION := $(VERSION)-dirty
+		RELEASE_VERSION := $(RELEASE_VERSION)-dirty
 	endif
 endif
 
-LDFLAGS += -X "$(BR_PKG)/pkg/version/build.ReleaseVersion=$(VERSION)"
+LDFLAGS += -X "$(BR_PKG)/pkg/version/build.ReleaseVersion=$(RELEASE_VERSION)"
 LDFLAGS += -X "$(BR_PKG)/pkg/version/build.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "$(BR_PKG)/pkg/version/build.GitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "$(BR_PKG)/pkg/version/build.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)"


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix make on macOS by correct regex.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```
git tag v5.0.2
git checkout -b refs/tags/v5.0.2
make build
```

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No release note.

<!-- fill in the release note, or just write "No release note" -->
