### PR TITLE
err_msg: clarify some ambiguous error message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build
+on:
+  push:
+    branches:
+      - master
+      - 'release-[0-9].[0-9]*'
+  pull_request:
+    branches:
+      - master
+      - 'release-[0-9].[0-9]*'
+
+jobs:
+  compile:
+    name: ${{ matrix.os }} / ${{ matrix.target}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v2.1.0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Run build
+        run: make build

--- a/.github/workflows/compatible_test.yml
+++ b/.github/workflows/compatible_test.yml
@@ -57,10 +57,10 @@ jobs:
     - name: Collect component log
       if: ${{ failure() }}
       run: |
-        tar czvf /tmp/br/logs.tar.gz /tmp/br/docker/backup_logs/*
+        tar czvf ${{ github.workspace }}/logs.tar.gz /tmp/br/docker/backup_logs/*
 
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
         name: logs
-        path: /tmp/br/logs.tar.gz
+        path: ${{ github.workspace }}/logs.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -9,20 +9,23 @@ CHECKER := awk '{ print } END { if (NR > 0) { exit 1 } }'
 
 BR_PKG := github.com/pingcap/br
 
-VERSION := v5.0.0-master
-release_version_regex := ^v5\..*$$
-release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$|*/tags/v[0-9]\.[0-9]\."
-ifneq ($(shell git rev-parse --abbrev-ref HEAD | egrep $(release_branch_regex)),)
-	# If we are in release branch, try to use tag version.
-	ifneq ($(shell git describe --tags --dirty | egrep $(release_version_regex)),)
-		VERSION := $(shell git describe --tags --dirty)
+RELEASE_VERSION =
+ifeq ($(RELEASE_VERSION),)
+	RELEASE_VERSION := v5.0.0-master
+	release_version_regex := ^v5\..*$$
+	release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/v[0-9]\.[0-9]\..*$$"
+	ifneq ($(shell git rev-parse --abbrev-ref HEAD | egrep $(release_branch_regex)),)
+		# If we are in release branch, try to use tag version.
+		ifneq ($(shell git describe --tags --dirty | egrep $(release_version_regex)),)
+			RELEASE_VERSION := $(shell git describe --tags --dirty)
+		endif
+	else ifneq ($(shell git status --porcelain),)
+		# Add -dirty if the working tree is dirty for non release branch.
+		RELEASE_VERSION := $(RELEASE_VERSION)-dirty
 	endif
-else ifneq ($(shell git status --porcelain),)
-	# Add -dirty if the working tree is dirty for non release branch.
-	VERSION := $(VERSION)-dirty
 endif
 
-LDFLAGS += -X "$(BR_PKG)/pkg/version/build.ReleaseVersion=$(VERSION)"
+LDFLAGS += -X "$(BR_PKG)/pkg/version/build.ReleaseVersion=$(RELEASE_VERSION)"
 LDFLAGS += -X "$(BR_PKG)/pkg/version/build.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "$(BR_PKG)/pkg/version/build.GitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "$(BR_PKG)/pkg/version/build.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Notice BR supports building with Go version `Go >= 1.13`
 
 When BR is built successfully, you can find binary in the `bin` directory.
 
-## Quick start
+## Quick start(docker-compose)
 
 ```sh
 # Start TiDB cluster
@@ -85,6 +85,42 @@ bin/br backup full --pd pd0:2379 --storage "s3://mybucket/full" \
 mysql -uroot -htidb -P4000 -E -e "DROP DATABASE test; SHOW DATABASES;" && \
 bin/br restore full --pd pd0:2379 --storage "s3://mybucket/full" \
     --s3.endpoint="$S3_ENDPOINT"
+```
+
+## Quick Start(tiup)
+
+```sh
+# Using tiup to start a TiDB cluster
+tiup playground --db 2 --pd 3 --kv 3 --monitor
+
+# Using tiup bench to generater test data.
+tiup bench tpcc --warehouses 1 prepare
+
+# How many row do we get? 300242 rows.
+mysql --host 127.0.0.1 --port 4000 -E -e "SELECT COUNT(*) FROM test.order_line" -u root -p
+
+# Build br.
+make build
+
+# Backup TPC-C test data.
+bin/br backup table --db test \
+	--table order_line \
+	-s local:///tmp/backup_test/ \
+	--pd ${PD_ADDR}:2379 \
+	--log-file backup_test.log \
+					
+# Let's drop the table.
+mysql -uroot --host 127.0.0.1 -P4000 -E -e "USE test; DROP TABLE order_line; show tables" -u root -p
+
+# Restore from the backup.
+bin/br restore table --db test \
+	--table order_line \ 
+	-s local:///tmp/backup_test/ \ 
+	--pd ${PD_ADDR}:2379 \ 
+	--log-file restore_test.log
+
+# How many rows do we get after restore? Expected to be 300242 rows.
+mysql --host 127.0.0.1 -P4000 -E -e "SELECT COUNT(*) FROM test.order_line" -uroot -p
 ```
 
 ## Compatible test

--- a/errors.toml
+++ b/errors.toml
@@ -98,7 +98,7 @@ rewrite rule not found
 
 ["BR:KV:ErrKVUnknown"]
 error = '''
-unknown tikv error
+unknown error occur on tikv, please ensure tikv is permitted to read from & write to the storage.
 '''
 
 ["BR:KV:ErrNotTiKVStorage"]

--- a/pkg/backup/client.go
+++ b/pkg/backup/client.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/pingcap/br/pkg/conn"
 	berrors "github.com/pingcap/br/pkg/errors"
-	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/logutil"
 	"github.com/pingcap/br/pkg/redact"
 	"github.com/pingcap/br/pkg/rtree"
@@ -64,10 +63,17 @@ type Checksum struct {
 	TotalBytes uint64
 }
 
+// ProgressUnit represents the unit of progress.
+type ProgressUnit string
+
 // Maximum total sleep time(in ms) for kv/cop commands.
 const (
 	backupFineGrainedMaxBackoff = 80000
 	backupRetryTimes            = 5
+	// RangeUnit represents the progress updated counter when a range finished.
+	RangeUnit ProgressUnit = "range"
+	// RegionUnit represents the progress updated counter when a region finished.
+	RegionUnit ProgressUnit = "region"
 )
 
 // Client is a client instructs TiKV how to do a backup.
@@ -348,10 +354,10 @@ func BuildBackupRangeAndSchema(
 					return nil, nil, errors.Trace(err)
 				}
 				tableInfo.AutoRandID = globalAutoRandID
-				logger.Info("change table AutoRandID",
+				logger.Debug("change table AutoRandID",
 					zap.Int64("AutoRandID", globalAutoRandID))
 			}
-			logger.Info("change table AutoIncID",
+			logger.Debug("change table AutoIncID",
 				zap.Int64("AutoIncID", globalAutoID))
 
 			// remove all non-public indices
@@ -433,7 +439,7 @@ func (bc *Client) BackupRanges(
 	ranges []rtree.Range,
 	req backuppb.BackupRequest,
 	concurrency uint,
-	updateCh glue.Progress,
+	progressCallBack func(ProgressUnit),
 ) ([]*backuppb.File, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("Client.BackupRanges", opentracing.ChildOf(span.Context()))
@@ -467,7 +473,7 @@ func (bc *Client) BackupRanges(
 		for _, r := range ranges {
 			sk, ek := r.StartKey, r.EndKey
 			workerPool.ApplyOnErrorGroup(eg, func() error {
-				files, err := bc.BackupRange(ectx, sk, ek, req, updateCh)
+				files, err := bc.BackupRange(ectx, sk, ek, req, progressCallBack)
 				if err == nil {
 					filesCh <- files
 				}
@@ -501,7 +507,7 @@ func (bc *Client) BackupRange(
 	ctx context.Context,
 	startKey, endKey []byte,
 	req backuppb.BackupRequest,
-	updateCh glue.Progress,
+	progressCallBack func(ProgressUnit),
 ) (files []*backuppb.File, err error) {
 	start := time.Now()
 	defer func() {
@@ -531,7 +537,7 @@ func (bc *Client) BackupRange(
 	push := newPushDown(bc.mgr, len(allStores))
 
 	var results rtree.RangeTree
-	results, err = push.pushBackup(ctx, req, allStores, updateCh)
+	results, err = push.pushBackup(ctx, req, allStores, progressCallBack)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -541,10 +547,13 @@ func (bc *Client) BackupRange(
 	// TODO: test fine grained backup.
 	err = bc.fineGrainedBackup(
 		ctx, startKey, endKey, req.StartVersion, req.EndVersion, req.CompressionType, req.CompressionLevel,
-		req.RateLimit, req.Concurrency, results, updateCh)
+		req.RateLimit, req.Concurrency, results, progressCallBack)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	// update progress of range unit
+	progressCallBack(RangeUnit)
 
 	if req.IsRawKv {
 		log.Info("backup raw ranges",
@@ -605,7 +614,7 @@ func (bc *Client) fineGrainedBackup(
 	rateLimit uint64,
 	concurrency uint32,
 	rangeTree rtree.RangeTree,
-	updateCh glue.Progress,
+	progressCallBack func(ProgressUnit),
 ) error {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("Client.fineGrainedBackup", opentracing.ChildOf(span.Context()))
@@ -702,7 +711,7 @@ func (bc *Client) fineGrainedBackup(
 				rangeTree.Put(resp.StartKey, resp.EndKey, resp.Files)
 
 				// Update progress
-				updateCh.Inc()
+				progressCallBack(RegionUnit)
 			}
 		}
 

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/zap"
 
 	berrors "github.com/pingcap/br/pkg/errors"
-	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/logutil"
 	"github.com/pingcap/br/pkg/redact"
 	"github.com/pingcap/br/pkg/rtree"
@@ -43,7 +42,7 @@ func (push *pushDown) pushBackup(
 	ctx context.Context,
 	req backuppb.BackupRequest,
 	stores []*metapb.Store,
-	updateCh glue.Progress,
+	progressCallBack func(ProgressUnit),
 ) (rtree.RangeTree, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("pushDown.pushBackup", opentracing.ChildOf(span.Context()))
@@ -120,7 +119,7 @@ func (push *pushDown) pushBackup(
 					resp.GetStartKey(), resp.GetEndKey(), resp.GetFiles())
 
 				// Update progress
-				updateCh.Inc()
+				progressCallBack(RegionUnit)
 			} else {
 				errPb := resp.GetError()
 				switch v := errPb.Detail.(type) {

--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -113,6 +113,13 @@ func (push *pushDown) pushBackup(
 					Msg: msg,
 				}
 			})
+			failpoint.Inject("tikv-rw-error", func(val failpoint.Value) {
+				msg := val.(string)
+				log.Debug("failpoint tikv-rw-error injected.", zap.String("msg", msg))
+				resp.Error = &backuppb.Error{
+					Msg: msg,
+				}
+			})
 			if resp.GetError() == nil {
 				// None error means range has been backuped successfully.
 				res.Put(

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -53,7 +53,7 @@ var (
 	ErrStorageInvalidConfig = errors.Normalize("invalid external storage config", errors.RFCCodeText("BR:ExternalStorage:ErrStorageInvalidConfig"))
 
 	// Errors reported from TiKV.
-	ErrKVUnknown           = errors.Normalize("unknown tikv error", errors.RFCCodeText("BR:KV:ErrKVUnknown"))
+	ErrKVUnknown           = errors.Normalize("unknown error occur on tikv, please ensure tikv is permitted to read from & write to the storage.", errors.RFCCodeText("BR:KV:ErrKVUnknown"))
 	ErrKVClusterIDMismatch = errors.Normalize("tikv cluster ID mismatch", errors.RFCCodeText("BR:KV:ErrKVClusterIDMismatch"))
 	ErrKVNotHealth         = errors.Normalize("tikv cluster not health", errors.RFCCodeText("BR:KV:ErrKVNotHealth"))
 	ErrKVNotLeader         = errors.Normalize("not leader", errors.RFCCodeText("BR:KV:ErrKVNotLeader"))

--- a/pkg/lightning/mydump/loader.go
+++ b/pkg/lightning/mydump/loader.go
@@ -53,16 +53,16 @@ type SourceFileMeta struct {
 	FileSize    int64
 }
 
-func (m *MDTableMeta) GetSchema(ctx context.Context, store storage.ExternalStorage) string {
+func (m *MDTableMeta) GetSchema(ctx context.Context, store storage.ExternalStorage) (string, error) {
 	schema, err := ExportStatement(ctx, store, m.SchemaFile, m.charSet)
 	if err != nil {
 		log.L().Error("failed to extract table schema",
 			zap.String("Path", m.SchemaFile.FileMeta.Path),
 			log.ShortError(err),
 		)
-		return ""
+		return "", err
 	}
-	return string(schema)
+	return string(schema), nil
 }
 
 /*

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -414,7 +414,7 @@ func (worker *restoreSchemaWorker) makeJobs(dbMetas []*mydump.MDDatabaseMeta) er
 	// 2. restore tables, execute statements concurrency
 	for _, dbMeta := range dbMetas {
 		for _, tblMeta := range dbMeta.Tables {
-			sql := tblMeta.GetSchema(worker.ctx, worker.store)
+			sql, err := tblMeta.GetSchema(worker.ctx, worker.store)
 			if sql != "" {
 				stmts, err := createTableIfNotExistsStmt(worker.glue.GetParser(), sql, dbMeta.Name, tblMeta.Name)
 				if err != nil {
@@ -436,6 +436,9 @@ func (worker *restoreSchemaWorker) makeJobs(dbMetas []*mydump.MDDatabaseMeta) er
 					return err
 				}
 			}
+			if err != nil {
+				return err
+			}
 		}
 	}
 	err = worker.wait()
@@ -445,7 +448,7 @@ func (worker *restoreSchemaWorker) makeJobs(dbMetas []*mydump.MDDatabaseMeta) er
 	// 3. restore views. Since views can cross database we must restore views after all table schemas are restored.
 	for _, dbMeta := range dbMetas {
 		for _, viewMeta := range dbMeta.Views {
-			sql := viewMeta.GetSchema(worker.ctx, worker.store)
+			sql, err := viewMeta.GetSchema(worker.ctx, worker.store)
 			if sql != "" {
 				stmts, err := createTableIfNotExistsStmt(worker.glue.GetParser(), sql, dbMeta.Name, viewMeta.Name)
 				if err != nil {
@@ -471,6 +474,9 @@ func (worker *restoreSchemaWorker) makeJobs(dbMetas []*mydump.MDDatabaseMeta) er
 				if err != nil {
 					return err
 				}
+			}
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -4,6 +4,8 @@ package task
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -11,6 +13,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	backuppb "github.com/pingcap/kvproto/pkg/backup"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/model"
@@ -336,25 +339,56 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		}
 	}
 
-	// The number of regions need to backup
-	approximateRegions := 0
-	for _, r := range ranges {
-		var regionCount int
-		regionCount, err = mgr.GetRegionCount(ctx, r.StartKey, r.EndKey)
-		if err != nil {
-			return errors.Trace(err)
+	summary.CollectInt("backup total ranges", len(ranges))
+
+	var updateCh glue.Progress
+	var unit backup.ProgressUnit
+	if len(ranges) < 100 {
+		unit = backup.RegionUnit
+		// The number of regions need to backup
+		approximateRegions := 0
+		for _, r := range ranges {
+			var regionCount int
+			regionCount, err = mgr.GetRegionCount(ctx, r.StartKey, r.EndKey)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			approximateRegions += regionCount
 		}
-		approximateRegions += regionCount
+		// Redirect to log if there is no log file to avoid unreadable output.
+		updateCh = g.StartProgress(
+			ctx, cmdName, int64(approximateRegions), !cfg.LogProgress)
+		summary.CollectInt("backup total regions", approximateRegions)
+	} else {
+		unit = backup.RangeUnit
+		// To reduce the costs, we can use the range as unit of progress.
+		updateCh = g.StartProgress(
+			ctx, cmdName, int64(len(ranges)), !cfg.LogProgress)
 	}
 
-	summary.CollectInt("backup total regions", approximateRegions)
+	progressCount := 0
+	progressCallBack := func(callBackUnit backup.ProgressUnit) {
+		if unit == callBackUnit {
+			updateCh.Inc()
+			progressCount++
+			failpoint.Inject("progress-call-back", func(v failpoint.Value) {
+				log.Info("failpoint progress-call-back injected")
+				if fileName, ok := v.(string); ok {
+					f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+					if err != nil {
+						log.Warn("failed to create file", zap.Error(err))
+					}
+					msg := []byte(fmt.Sprintf("%s:%d\n", unit, progressCount))
+					_, err = f.Write(msg)
+					if err != nil {
+						log.Warn("failed to write data to file", zap.Error(err))
+					}
+				}
+			})
+		}
+	}
 
-	// Backup
-	// Redirect to log if there is no log file to avoid unreadable output.
-	updateCh := g.StartProgress(
-		ctx, cmdName, int64(approximateRegions), !cfg.LogProgress)
-
-	files, err := client.BackupRanges(ctx, ranges, req, uint(cfg.Concurrency), updateCh)
+	files, err := client.BackupRanges(ctx, ranges, req, uint(cfg.Concurrency), progressCallBack)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -193,6 +193,13 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	updateCh := g.StartProgress(
 		ctx, cmdName, int64(approximateRegions), !cfg.LogProgress)
 
+	progressCallBack := func(unit backup.ProgressUnit) {
+		if unit == backup.RangeUnit {
+			return
+		}
+		updateCh.Inc()
+	}
+
 	req := backuppb.BackupRequest{
 		ClusterId:        client.GetClusterID(),
 		StartVersion:     0,
@@ -204,7 +211,7 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 		CompressionType:  cfg.CompressionType,
 		CompressionLevel: cfg.CompressionLevel,
 	}
-	files, err := client.BackupRange(ctx, backupRange.StartKey, backupRange.EndKey, req, updateCh)
+	files, err := client.BackupRange(ctx, backupRange.StartKey, backupRange.EndKey, req, progressCallBack)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/utils/dyn_pprof_other.go
+++ b/pkg/utils/dyn_pprof_other.go
@@ -3,7 +3,9 @@
 
 package utils
 
+import tidbutils "github.com/pingcap/tidb-tools/pkg/utils"
+
 // StartDynamicPProfListener starts the listener that will enable pprof when received `startPProfSignal`
-func StartDynamicPProfListener() {
+func StartDynamicPProfListener(tls *tidbutils.TLS) {
 	// nothing to do on no posix signal supporting systems.
 }

--- a/tests/br_db/run.sh
+++ b/tests/br_db/run.sh
@@ -16,6 +16,9 @@
 set -eu
 DB="$TEST_NAME"
 
+PROGRESS_FILE="$TEST_DIR/progress_unit_file"
+rm -rf $PROGRESS_FILE
+
 run_sql "CREATE DATABASE $DB;"
 
 run_sql "CREATE TABLE $DB.usertable1 ( \
@@ -36,7 +39,20 @@ run_sql "CREATE TABLE $DB.usertable2 ( \
 run_sql "INSERT INTO $DB.usertable2 VALUES (\"c\", \"d\");"
 # backup db
 echo "backup start..."
+export GO_FAILPOINTS="github.com/pingcap/br/pkg/task/progress-call-back=return(\"$PROGRESS_FILE\")"
 run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$TEST_DIR/$DB" --ratelimit 5 --concurrency 4
+export GO_FAILPOINTS=""
+
+# check if we use the region unit
+if [[ "$(wc -l <$PROGRESS_FILE)" == "1" ]] && [[ $(grep -c "region" $PROGRESS_FILE) == "1" ]];
+then
+  echo "use the correct progress unit"
+else
+  echo "use the wrong progress unit, expect region"
+  cat $PROGRESS_FILE
+  exit 1
+fi
+rm -rf $PROGRESS_FILE
 
 run_sql "DROP DATABASE $DB;"
 

--- a/tests/br_full/run.sh
+++ b/tests/br_full/run.sh
@@ -53,6 +53,25 @@ run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-lz4" --concurrency 4 
 export GO_FAILPOINTS=""
 size_lz4=$(du -d 0 $TEST_DIR/$DB-lz4 | awk '{print $1}')
 
+echo "backup with tikv error start..." 
+export GO_FAILPOINTS="github.com/pingcap/br/pkg/backup/tikv-rw-error=return(\"tikv read or write error\")"
+error_msg=$(run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-tikverr" --concurrency 4 |  awk '{match($0,/.+(\[BR:KV:ErrKVUnknown\]unknown error occur on tikv, please ensure tikv is permitted to read from & write to the storage.)/,a);if (a[1] != "") print a[1]}')
+if [ "$error_msg" = "" ]
+then 
+    echo "error_msg is not set, tikv error message test fail"
+    exit 1
+else 
+    echo "error_msg is set, and error_msg is $error_msg"
+fi
+
+pid=$!
+export GO_FAILPOINTS=""
+sleep 15
+if ps -q $pid ; then 
+    echo "After failed 15 seconds, BR doesn't gracefully shutdown..."
+    exit 1
+fi
+
 echo "backup with zstd start..."
 run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-zstd" --concurrency 4 --compression zstd --compression-level 6
 size_zstd=$(du -d 0 $TEST_DIR/$DB-zstd | awk '{print $1}')


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some error message in BR is ambiguous and misleading. i.e. if tikv has no right to read from & write to backup storage, error message cannot clarify whether error occur on br side or tikv side. Users may think why I got "permission denied"? I'm running BR as root.

### What is changed and how it works?
Some error messages are changes, and will clarify what is going on when error occur.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported variable/fields change

### Release Note

 - No realease note

<!-- fill in the release note, or just write "No release note" -->
