### PR TITLE
FreeBSD support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,17 @@ jobs:
 
       - name: Run build
         run: make build
+
+  compile-freebsd:
+    name: Compile for FreeBSD job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.1.0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Compile for FreeBSD
+        run: GOOS=freebsd make build

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ ifeq ("$(WITH_RACE)", "1")
 	GOBUILD  = CGO_ENABLED=1 GO111MODULE=on $(GO) build -ldflags '$(LDFLAGS)'
 endif
 
+# There is no FreeBSD environment for GitHub actions. So cross-compile on Linux
+# but that doesn't work with CGO_ENABLED=1, so disable cgo. The reason to have
+# cgo enabled on regular builds is performance.
+ifeq ("$(GOOS)", "freebsd")
+	GOBUILD  = CGO_ENABLED=0 GO111MODULE=on go build -trimpath -ldflags '$(LDFLAGS)'
+endif
+
 all: build check test
 
 prepare:

--- a/pkg/lightning/backend/local/local_freebsd.go
+++ b/pkg/lightning/backend/local/local_freebsd.go
@@ -11,23 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+// +build freebsd
 
 package local
 
 import (
-	"math"
-
-	"github.com/pingcap/errors"
+	"go.uber.org/zap"
 )
 
-type Rlim_t = uint64
+type Rlim_t = int64
 
-// return a big value as unlimited, since rlimit verify is skipped in windows.
-func GetSystemRLimit() (uint64, error) {
-	return math.MaxInt32, nil
-}
-
-func VerifyRLimit(estimateMaxFiles uint64) error {
-	return errors.New("Local-backend is not tested on Windows. Run with --check-requirements=false to disable this check, but you are on your own risk.")
+func zapRlim_t(key string, val Rlim_t) zap.Field {
+	return zap.Int64(key, val)
 }

--- a/pkg/lightning/backend/local/local_unix_generic.go
+++ b/pkg/lightning/backend/local/local_unix_generic.go
@@ -11,23 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+// +build !freebsd,!windows
 
 package local
 
-import (
-	"math"
-
-	"github.com/pingcap/errors"
-)
+import "go.uber.org/zap"
 
 type Rlim_t = uint64
 
-// return a big value as unlimited, since rlimit verify is skipped in windows.
-func GetSystemRLimit() (uint64, error) {
-	return math.MaxInt32, nil
-}
-
-func VerifyRLimit(estimateMaxFiles uint64) error {
-	return errors.New("Local-backend is not tested on Windows. Run with --check-requirements=false to disable this check, but you are on your own risk.")
+func zapRlim_t(key string, val Rlim_t) zap.Field {
+	return zap.Uint64(key, val)
 }

--- a/pkg/lightning/common/storage_unix.go
+++ b/pkg/lightning/common/storage_unix.go
@@ -50,7 +50,7 @@ func GetStorageSize(dir string) (size StorageSize, err error) {
 	}
 
 	// Available blocks * size per block = available space in bytes
-	size.Available = stat.Bavail * bSize
+	size.Available = uint64(stat.Bavail) * bSize
 	size.Capacity = stat.Blocks * bSize
 
 	return

--- a/pkg/lightning/lightning.go
+++ b/pkg/lightning/lightning.go
@@ -672,7 +672,7 @@ func checkSystemRequirement(cfg *config.Config, dbsMeta []*mydump.MDDatabaseMeta
 
 		// region-concurrency: number of LocalWriters writing SST files.
 		// 2*totalSize/memCacheSize: number of Pebble MemCache files.
-		estimateMaxFiles := uint64(cfg.App.RegionConcurrency) + uint64(topNTotalSize)/uint64(cfg.TikvImporter.EngineMemCacheSize)*2
+		estimateMaxFiles := local.Rlim_t(cfg.App.RegionConcurrency) + local.Rlim_t(topNTotalSize)/local.Rlim_t(cfg.TikvImporter.EngineMemCacheSize)*2
 		if err := local.VerifyRLimit(estimateMaxFiles); err != nil {
 			return err
 		}

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -233,12 +233,12 @@ func NewRestoreControllerWithPauser(
 		}
 		backend = tidb.NewTiDBBackend(db, cfg.TikvImporter.OnDuplicate)
 	case config.BackendLocal:
-		var rLimit uint64
+		var rLimit local.Rlim_t
 		rLimit, err = local.GetSystemRLimit()
 		if err != nil {
 			return nil, err
 		}
-		maxOpenFiles := int(rLimit / uint64(cfg.App.TableConcurrency))
+		maxOpenFiles := int(rLimit / local.Rlim_t(cfg.App.TableConcurrency))
 		// check overflow
 		if maxOpenFiles < 0 {
 			maxOpenFiles = math.MaxInt32


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The structs for `golang.org/x/sys/unix` on FreeBSD and Linux have different type for various members.

```
[dvaneeden@freebsd-tidb ~]$ for os in freebsd darwin linux; do echo $os; GOOS=$os go doc golang.org/x/sys/unix Statfs_t | grep Bsize; done
freebsd
	Bsize       uint64
darwin
	Bsize       uint32
linux
	Bsize   int64
```





### What is changed and how it works?

This adds a `pkg/lightning/backend/local/local_freebsd.go` file that is based on `pkg/lightning/backend/local/local_unix.go` but is using types that match FreeBSD for `rLimit.Cur` and `rLimit.Max`.

In `pkg/lightning/common/storage_unix.go` I fixed a minor incompatibility with `Bavail` of `Statfs_t`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Running `gmake build` on FreeBSD now works without errors and produces a binary.

```
[dvaneeden@freebsd-tidb ~/br]$ ./bin/br -V
Release Version: v5.0.0-master-dirty
Git Commit Hash: 87fd32e514d5f8575ad2602fd49f9c53e3326432
Git Branch: freebsd
Go Version: go1.13.15
UTC Build Time: 2021-04-28 12:42:18
Race Enabled: false
[dvaneeden@freebsd-tidb ~/br]$ file bin/br
bin/br: ELF 64-bit LSB executable, x86-64, version 1 (FreeBSD), dynamically linked, interpreter /libexec/ld-elf.so.1, Go BuildID=zjYhSI_xzlWzfWfLyR8w/GG2WUtGphVoP22gB81XT/pN6b1Ddbv8dc0tqwPwv3/q6C-ZkUy38dPoCVFGKFc, not stripped

```


Side effects

 - Increased code complexity


### Release Note

 -

<!-- fill in the release note, or just write "No release note" -->
