### PR TITLE
restore: remove table field from rewrite rules

### DIFF
--- a/cmd/br/debug.go
+++ b/cmd/br/debug.go
@@ -209,8 +209,7 @@ func newBackupMetaValidateCommand() *cobra.Command {
 				_, _ = tableIDAllocator.Alloc() // Ignore error
 			}
 			rewriteRules := &restore.RewriteRules{
-				Table: make([]*import_sstpb.RewriteRule, 0),
-				Data:  make([]*import_sstpb.RewriteRule, 0),
+				Data: make([]*import_sstpb.RewriteRule, 0),
 			}
 			tableIDMap := make(map[int64]int64)
 			// Simulate to create table
@@ -229,7 +228,6 @@ func newBackupMetaValidateCommand() *cobra.Command {
 					}
 				}
 				rules := restore.GetRewriteRules(newTable, table.Info, 0)
-				rewriteRules.Table = append(rewriteRules.Table, rules.Table...)
 				rewriteRules.Data = append(rewriteRules.Data, rules.Data...)
 				tableIDMap[table.Info.ID] = int64(tableID)
 			}

--- a/pkg/restore/batcher_test.go
+++ b/pkg/restore/batcher_test.go
@@ -134,7 +134,7 @@ func (manager *recordCurrentTableManager) Has(tables ...restore.TableWithRange) 
 }
 
 func (sender *drySender) HasRewriteRuleOfKey(prefix string) bool {
-	for _, rule := range sender.rewriteRules.Table {
+	for _, rule := range sender.rewriteRules.Data {
 		if bytes.Equal([]byte(prefix), rule.OldKeyPrefix) {
 			return true
 		}
@@ -172,7 +172,7 @@ func fakeTableWithRange(id int64, rngs []rtree.Range) restore.TableWithRange {
 
 func fakeRewriteRules(oldPrefix string, newPrefix string) *restore.RewriteRules {
 	return &restore.RewriteRules{
-		Table: []*import_sstpb.RewriteRule{
+		Data: []*import_sstpb.RewriteRule{
 			{
 				OldKeyPrefix: []byte(oldPrefix),
 				NewKeyPrefix: []byte(newPrefix),

--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -354,8 +354,7 @@ func (rc *Client) CreateTables(
 	newTS uint64,
 ) (*RewriteRules, []*model.TableInfo, error) {
 	rewriteRules := &RewriteRules{
-		Table: make([]*import_sstpb.RewriteRule, 0),
-		Data:  make([]*import_sstpb.RewriteRule, 0),
+		Data: make([]*import_sstpb.RewriteRule, 0),
 	}
 	newTables := make([]*model.TableInfo, 0, len(tables))
 	errCh := make(chan error, 1)
@@ -366,7 +365,6 @@ func (rc *Client) CreateTables(
 	dataCh := rc.GoCreateTables(context.TODO(), dom, tables, newTS, nil, errCh)
 	for et := range dataCh {
 		rules := et.RewriteRule
-		rewriteRules.Table = append(rewriteRules.Table, rules.Table...)
 		rewriteRules.Data = append(rewriteRules.Data, rules.Data...)
 		newTables = append(newTables, et.Table)
 	}

--- a/pkg/restore/client_test.go
+++ b/pkg/restore/client_test.go
@@ -87,7 +87,7 @@ func (s *testRestoreClientSuite) TestCreateTables(c *C) {
 	}
 	oldTableIDExist := make(map[int64]bool)
 	newTableIDExist := make(map[int64]bool)
-	for _, tr := range rules.Table {
+	for _, tr := range rules.Data {
 		oldTableID := tablecodec.DecodeTableID(tr.GetOldKeyPrefix())
 		c.Assert(oldTableIDExist[oldTableID], IsFalse, Commentf("table rule duplicate old table id"))
 		oldTableIDExist[oldTableID] = true

--- a/pkg/restore/range.go
+++ b/pkg/restore/range.go
@@ -120,20 +120,17 @@ func (region *RegionInfo) ContainsInterior(key []byte) bool {
 
 // RewriteRules contains rules for rewriting keys of tables.
 type RewriteRules struct {
-	Table []*import_sstpb.RewriteRule
-	Data  []*import_sstpb.RewriteRule
+	Data []*import_sstpb.RewriteRule
 }
 
 // Append append its argument to this rewrite rules.
 func (r *RewriteRules) Append(other RewriteRules) {
 	r.Data = append(r.Data, other.Data...)
-	r.Table = append(r.Table, other.Table...)
 }
 
 // EmptyRewriteRule make a new, empty rewrite rule.
 func EmptyRewriteRule() *RewriteRules {
 	return &RewriteRules{
-		Table: []*import_sstpb.RewriteRule{},
-		Data:  []*import_sstpb.RewriteRule{},
+		Data: []*import_sstpb.RewriteRule{},
 	}
 }

--- a/pkg/restore/range_test.go
+++ b/pkg/restore/range_test.go
@@ -46,8 +46,7 @@ func (s *testRangeSuite) TestSortRange(c *C) {
 		{OldKeyPrefix: tablecodec.GenTableRecordPrefix(2), NewKeyPrefix: tablecodec.GenTableRecordPrefix(5)},
 	}
 	rewriteRules := &restore.RewriteRules{
-		Table: make([]*import_sstpb.RewriteRule, 0),
-		Data:  dataRules,
+		Data: dataRules,
 	}
 	ranges1 := []rtree.Range{
 		{

--- a/pkg/restore/split.go
+++ b/pkg/restore/split.go
@@ -90,7 +90,7 @@ func (rs *RegionSplitter) Split(
 	}
 	minKey := codec.EncodeBytes(sortedRanges[0].StartKey)
 	maxKey := codec.EncodeBytes(sortedRanges[len(sortedRanges)-1].EndKey)
-	for _, rule := range rewriteRules.Table {
+	for _, rule := range rewriteRules.Data {
 		if bytes.Compare(minKey, rule.GetNewKeyPrefix()) > 0 {
 			minKey = rule.GetNewKeyPrefix()
 		}
@@ -319,9 +319,6 @@ func PaginateScanRegion(
 func getSplitKeys(rewriteRules *RewriteRules, ranges []rtree.Range, regions []*RegionInfo) map[uint64][][]byte {
 	splitKeyMap := make(map[uint64][][]byte)
 	checkKeys := make([][]byte, 0)
-	for _, rule := range rewriteRules.Table {
-		checkKeys = append(checkKeys, rule.GetNewKeyPrefix())
-	}
 	for _, rule := range rewriteRules.Data {
 		checkKeys = append(checkKeys, rule.GetNewKeyPrefix())
 	}
@@ -367,11 +364,6 @@ func NeedSplit(splitKey []byte, regions []*RegionInfo) *RegionInfo {
 func replacePrefix(s []byte, rewriteRules *RewriteRules) ([]byte, *sst.RewriteRule) {
 	// We should search the dataRules firstly.
 	for _, rule := range rewriteRules.Data {
-		if bytes.HasPrefix(s, rule.GetOldKeyPrefix()) {
-			return append(append([]byte{}, rule.GetNewKeyPrefix()...), s[len(rule.GetOldKeyPrefix()):]...), rule
-		}
-	}
-	for _, rule := range rewriteRules.Table {
 		if bytes.HasPrefix(s, rule.GetOldKeyPrefix()) {
 			return append(append([]byte{}, rule.GetNewKeyPrefix()...), s[len(rule.GetOldKeyPrefix()):]...), rule
 		}

--- a/pkg/restore/split_test.go
+++ b/pkg/restore/split_test.go
@@ -291,8 +291,7 @@ func initRewriteRules() *restore.RewriteRules {
 		NewKeyPrefix: []byte("bb"),
 	}
 	return &restore.RewriteRules{
-		Table: rules[:],
-		Data:  rules[:],
+		Data: rules[:],
 	}
 }
 

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -82,8 +82,7 @@ func GetRewriteRules(
 	}
 
 	return &RewriteRules{
-		Table: tableRules,
-		Data:  dataRules,
+		Data: dataRules,
 	}
 }
 
@@ -341,21 +340,11 @@ func matchOldPrefix(key []byte, rewriteRules *RewriteRules) *import_sstpb.Rewrit
 			return rule
 		}
 	}
-	for _, rule := range rewriteRules.Table {
-		if bytes.HasPrefix(key, rule.GetOldKeyPrefix()) {
-			return rule
-		}
-	}
 	return nil
 }
 
 func matchNewPrefix(key []byte, rewriteRules *RewriteRules) *import_sstpb.RewriteRule {
 	for _, rule := range rewriteRules.Data {
-		if bytes.HasPrefix(key, rule.GetNewKeyPrefix()) {
-			return rule
-		}
-	}
-	for _, rule := range rewriteRules.Table {
 		if bytes.HasPrefix(key, rule.GetNewKeyPrefix()) {
 			return rule
 		}
@@ -403,7 +392,6 @@ func rewriteFileKeys(file *backuppb.File, rewriteRules *RewriteRules) (startKey,
 		if rewriteRules != nil && rule == nil {
 			log.Error("cannot find rewrite rule",
 				logutil.Key("startKey", file.GetStartKey()),
-				zap.Reflect("rewrite table", rewriteRules.Table),
 				zap.Reflect("rewrite data", rewriteRules.Data))
 			err = errors.Annotate(berrors.ErrRestoreInvalidRewrite, "cannot find rewrite rule for start key")
 			return

--- a/pkg/restore/util.go
+++ b/pkg/restore/util.go
@@ -59,14 +59,8 @@ func GetRewriteRules(
 		}
 	}
 
-	tableRules := make([]*import_sstpb.RewriteRule, 0)
 	dataRules := make([]*import_sstpb.RewriteRule, 0)
 	for oldTableID, newTableID := range tableIDs {
-		tableRules = append(tableRules, &import_sstpb.RewriteRule{
-			OldKeyPrefix: tablecodec.EncodeTablePrefix(oldTableID),
-			NewKeyPrefix: tablecodec.EncodeTablePrefix(newTableID),
-			NewTimestamp: newTimeStamp,
-		})
 		dataRules = append(dataRules, &import_sstpb.RewriteRule{
 			OldKeyPrefix: append(tablecodec.EncodeTablePrefix(oldTableID), recordPrefixSep...),
 			NewKeyPrefix: append(tablecodec.EncodeTablePrefix(newTableID), recordPrefixSep...),

--- a/pkg/restore/util_test.go
+++ b/pkg/restore/util_test.go
@@ -97,7 +97,7 @@ func (s *testRestoreUtilSuite) TestMapTableToFiles(c *C) {
 
 func (s *testRestoreUtilSuite) TestValidateFileRewriteRule(c *C) {
 	rules := &restore.RewriteRules{
-		Table: []*import_sstpb.RewriteRule{{
+		Data: []*import_sstpb.RewriteRule{{
 			OldKeyPrefix: []byte(tablecodec.EncodeTablePrefix(1)),
 			NewKeyPrefix: []byte(tablecodec.EncodeTablePrefix(2)),
 		}},
@@ -137,7 +137,7 @@ func (s *testRestoreUtilSuite) TestValidateFileRewriteRule(c *C) {
 	c.Assert(err, ErrorMatches, ".*cannot find rewrite rule.*")
 
 	// Add a rule for end key.
-	rules.Table = append(rules.Table, &import_sstpb.RewriteRule{
+	rules.Data = append(rules.Data, &import_sstpb.RewriteRule{
 		OldKeyPrefix: tablecodec.EncodeTablePrefix(2),
 		NewKeyPrefix: tablecodec.EncodeTablePrefix(3),
 	})
@@ -152,7 +152,7 @@ func (s *testRestoreUtilSuite) TestValidateFileRewriteRule(c *C) {
 	c.Assert(err, ErrorMatches, ".*restore table ID mismatch")
 
 	// Add a bad rule for end key, after rewrite start key > end key.
-	rules.Table = append(rules.Table[:1], &import_sstpb.RewriteRule{
+	rules.Data = append(rules.Data[:1], &import_sstpb.RewriteRule{
 		OldKeyPrefix: tablecodec.EncodeTablePrefix(2),
 		NewKeyPrefix: tablecodec.EncodeTablePrefix(1),
 	})


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
struct RewriteRules now has two field
```go
type RewriteRules struct {
	Table []*import_sstb.RewriteRule
	Data  []*import_sstpb.RewriteRule
}
```
field `Table` is unnecessary, this pull request remove that field and provide compatible test.

### What is changed and how it works?
This modified `RewriteRules` struct in `pkg/restore/range.go` file and changed all code related with `Table` field

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
 Using tiup bench to generate 100 warehourse tpcc data, and run modified BR on various tikv version including v4.0.9, v4.0.12, v5.0.0

**TiKV 4.0.9 + BR fix-rewrite-rules version**
```
[collector.go:62] ["Database restore success summary"] [total-ranges=253] [ranges-succeed=253] [ranges-failed=0] [split-region=55.671636681s] [restore-checksum=2m3.436042676s] [restore-ranges=179] [Size=4806591284] [total-take=1m47.475833605s] [total-kv=108904178] [data-size=12.37GB] [average-speed=68.15MB/s]
```
**TiKV 4.0.12 + BR fix-rewrite-rules version**
```
[collector.go:62] ["Database restore success summary"] [total-ranges=253] [ranges-succeed=253] [ranges-failed=0] [split-region=52.530581048s] [restore-checksum=2m56.746218609s] [restore-ranges=179] [Size=4806591284] [total-take=2m5.797748427s] [total-kv=108904178] [data-size=12.37GB] [average-speed=53.95MB/s]
```
**TiKV 5.0.0 + BR fix-rewrite-rules version**
```
[collector.go:62] ["Database restore success summary"] [total-ranges=253] [ranges-succeed=253] [ranges-failed=0] [split-region=42.622399681s] [restore-checksum=2m10.806211667s] [restore-ranges=179] [Size=4806591638] [total-take=1m56.536507342s] [total-kv=108904178] [data-size=12.37GB] [average-speed=69.18MB/s]
```
Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has persistent data change

### Release Note

 - No Release Note

<!-- fill in the release note, or just write "No release note" -->

