### PR TITLE
pd: Add pd request retry logic

### DIFF
--- a/pkg/pdutil/pd.go
+++ b/pkg/pdutil/pd.go
@@ -146,11 +146,15 @@ func pdRequest(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	var resp *http.Response
+	var (
+		resp   *http.Response
+		reqErr error
+	)
+
 	for i := 0; i < pdRequestRetryTime; i++ {
-		resp, err = cli.Do(req)
+		resp, reqErr = cli.Do(req)
 		if err != nil {
-			log.Warn("pd request fail, retry", zap.Int("retry time", i), zap.Error(err))
+			log.Warn("pd request fail, retry", zap.Int("retry time", i), zap.Error(reqErr))
 			time.Sleep(time.Duration(i) * time.Second)
 			continue
 		}
@@ -166,7 +170,7 @@ func pdRequest(
 		}
 		return r, nil
 	}
-	return nil, errors.Trace(err)
+	return nil, errors.Trace(reqErr)
 }
 
 // PdController manage get/update config from pd.


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When client send a request to pd failed due to some recoverable network issues, it is better to retry than to return error.

### What is changed and how it works?

Add pd request retry logic on  `pdRequest` function in `pkg/pdutil/pd.go` file.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

### Release Note

 -

<!-- fill in the release note, or just write "No release note" -->
