### PR TITLE
pd: Add pd request retry logic (#1088)

### DIFF
--- a/pkg/pdutil/pd.go
+++ b/pkg/pdutil/pd.go
@@ -131,6 +131,19 @@ func pdRequest(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	count := 0
+	for {
+		count++
+		if count > pdRequestRetryTime || resp.StatusCode < 500 {
+			break
+		}
+		resp.Body.Close()
+		time.Sleep(time.Second)
+		resp, err = cli.Do(req)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		res, _ := ioutil.ReadAll(resp.Body)

--- a/pkg/pdutil/pd.go
+++ b/pkg/pdutil/pd.go
@@ -38,6 +38,11 @@ const (
 	maxMsgSize           = int(128 * utils.MB) // pd.ScanRegion may return a large response
 	scheduleConfigPrefix = "pd/api/v1/config/schedule"
 	pauseTimeout         = 5 * time.Minute
+	// pd request retry time when connection fail
+	pdRequestRetryTime = 10
+
+	// set max-pending-peer-count to a large value to avoid scatter region failed.
+	maxPendingPeerUnlimited uint64 = math.MaxInt32
 )
 
 type pauseConfigExpectation uint8

--- a/pkg/pdutil/pd_test.go
+++ b/pkg/pdutil/pd_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -166,4 +167,35 @@ func (s *testPDControllerSuite) TestPDVersion(c *C) {
 	c.Assert(r.Major, Equals, expectV.Major)
 	c.Assert(r.Minor, Equals, expectV.Minor)
 	c.Assert(r.PreRelease, Equals, expectV.PreRelease)
+}
+
+func (s *testPDControllerSuite) TestPDRequestRetry(c *C) {
+	ctx := context.Background()
+	count := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		if count <= 5 {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	cli := http.DefaultClient
+	taddr := ts.URL
+	_, reqErr := pdRequest(ctx, taddr, "", cli, http.MethodGet, nil)
+	c.Assert(reqErr, IsNil)
+	ts.Close()
+	count = 0
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		if count <= 11 {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	taddr = ts.URL
+	_, reqErr = pdRequest(ctx, taddr, "", cli, http.MethodGet, nil)
+	c.Assert(reqErr, NotNil)
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This pr is cherry pick version of [#1088 ](https://github.com/pingcap/br/pull/1088) for release-4.0

When client send a request to pd failed due to some recoverable server faults or network issues, it is better to retry than to return error.

### What is changed and how it works?

Add pd request retry logic on  `pdRequest` function in `pkg/pdutil/pd.go` file.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

### Release Note

 - No Release Note 

<!-- fill in the release note, or just write "No release note" -->
