### PR TITLE
test: fix integration test unbound variable error

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -61,6 +61,6 @@ for casename in $SELECTED_TEST_NAME; do
     TIDB_ADDR="$TIDB_ADDR" \
     TIDB_STATUS_ADDR="$TIDB_STATUS_ADDR" \
     TIKV_ADDR="$TIKV_ADDR" \
-    BR_LOG_TO_TERM=1 \
+    BR_LOG_TO_TERM=1 
     bash "$script" && echo "TEST: [$TEST_NAME] success!"
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -47,11 +47,11 @@ run_sql 'set @@global.tidb_enable_clustered_index = 0' || echo "tidb does not su
 sleep 2
 
 for casename in $SELECTED_TEST_NAME; do
-    script=tests/$casename/run.sh
+    TEST_NAME="$casename" 
+    script=tests/$TEST_NAME/run.sh
     echo "*===== Running test $script... =====*"
     INTEGRATION_TEST=1 \
     TEST_DIR="$TEST_DIR" \
-    TEST_NAME="$casename" \
     CLUSTER_VERSION_MAJOR="${CLUSTER_VERSION_MAJOR#v}" \
     CLUSTER_VERSION_MINOR="$CLUSTER_VERSION_MINOR" \
     CLUSTER_VERSION_REVISION="$CLUSTER_VERSION_REVISION" \
@@ -61,6 +61,6 @@ for casename in $SELECTED_TEST_NAME; do
     TIDB_ADDR="$TIDB_ADDR" \
     TIDB_STATUS_ADDR="$TIDB_STATUS_ADDR" \
     TIKV_ADDR="$TIKV_ADDR" \
-    BR_LOG_TO_TERM=1 
+    BR_LOG_TO_TERM=1 \
     bash "$script" && echo "TEST: [$TEST_NAME] success!"
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -47,11 +47,11 @@ run_sql 'set @@global.tidb_enable_clustered_index = 0' || echo "tidb does not su
 sleep 2
 
 for casename in $SELECTED_TEST_NAME; do
-    TEST_NAME="$casename" 
     script=tests/$TEST_NAME/run.sh
     echo "*===== Running test $script... =====*"
     INTEGRATION_TEST=1 \
     TEST_DIR="$TEST_DIR" \
+    TEST_NAME="$casename" \
     CLUSTER_VERSION_MAJOR="${CLUSTER_VERSION_MAJOR#v}" \
     CLUSTER_VERSION_MINOR="$CLUSTER_VERSION_MINOR" \
     CLUSTER_VERSION_REVISION="$CLUSTER_VERSION_REVISION" \
@@ -62,5 +62,5 @@ for casename in $SELECTED_TEST_NAME; do
     TIDB_STATUS_ADDR="$TIDB_STATUS_ADDR" \
     TIKV_ADDR="$TIKV_ADDR" \
     BR_LOG_TO_TERM=1 \
-    bash "$script" && echo "TEST: [$TEST_NAME] success!"
+    bash "$script" && echo "TEST: [$casename] success!"
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -47,7 +47,7 @@ run_sql 'set @@global.tidb_enable_clustered_index = 0' || echo "tidb does not su
 sleep 2
 
 for casename in $SELECTED_TEST_NAME; do
-    script=tests/$TEST_NAME/run.sh
+    script=tests/$casename/run.sh
     echo "*===== Running test $script... =====*"
     INTEGRATION_TEST=1 \
     TEST_DIR="$TEST_DIR" \


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When we make integration test, an unbound variable error will raise.

### What is changed and how it works?

Change `tests/run.sh`

In original version
```sh
for casename in $SELECTED_TEST_NAME; do
    script=tests/$casename/run.sh
    echo "*===== Running test $script... =====*"
    INTEGRATION_TEST=1 \
    TEST_DIR="$TEST_DIR" \
    TEST_NAME="$casename" \
    CLUSTER_VERSION_MAJOR="${CLUSTER_VERSION_MAJOR#v}" \
    CLUSTER_VERSION_MINOR="$CLUSTER_VERSION_MINOR" \
    CLUSTER_VERSION_REVISION="$CLUSTER_VERSION_REVISION" \
    PD_ADDR="$PD_ADDR" \
    TIDB_IP="$TIDB_IP" \
    TIDB_PORT="$TIDB_PORT" \
    TIDB_ADDR="$TIDB_ADDR" \
    TIDB_STATUS_ADDR="$TIDB_STATUS_ADDR" \
    TIKV_ADDR="$TIKV_ADDR" \
    BR_LOG_TO_TERM=1 \
    bash "$script" && echo "TEST: [$TEST_NAME] success!"
done
```

the previous assignment `TEST_NAME="$casename"` will not work for `echo "TEST:[$TEST_NAME] success!"` in line 65, the variable `$TEST_NAME`  should be replaced by `$casename`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release Note

 - No Release Note

<!-- fill in the release note, or just write "No release note" -->
