### PR TITLE
lightning: always enable `autocommit` in db connection

### DIFF
--- a/pkg/lightning/restore/tidb.go
+++ b/pkg/lightning/restore/tidb.go
@@ -98,6 +98,8 @@ func DBFromConfig(dsn config.DBStore) (*sql.DB, error) {
 			"allow_auto_random_explicit_insert": "1",
 			// allow use _tidb_rowid in sql statement
 			"tidb_opt_write_row_id": "1",
+			// always set auto-commit to ON
+			"autocommit": "1",
 		},
 	}
 	db, err := param.Connect()
@@ -255,7 +257,10 @@ func LoadSchemaInfo(
 		}
 
 		for _, tbl := range schema.Tables {
-			tblInfo := tableMap[strings.ToLower(tbl.Name)]
+			tblInfo, ok := tableMap[strings.ToLower(tbl.Name)]
+			if !ok {
+				return nil, errors.Errorf("table '%s' schema not found", tbl.Name)
+			}
 			tableName := tblInfo.Name.String()
 			if tblInfo.State != model.StatePublic {
 				err := errors.Errorf("table [%s.%s] state is not public", schema.Name, tableName)

--- a/tests/lightning_alter_random/run.sh
+++ b/tests/lightning_alter_random/run.sh
@@ -18,6 +18,9 @@ set -eu
 # FIXME: auto-random is only stable on master currently.
 check_cluster_version 4 0 0 AUTO_RANDOM || exit 0
 
+# test lightning with autocommit disabled
+run_sql "SET @@global.autocommit = '0';"
+
 for backend in tidb importer local; do
     if [ "$backend" = 'local' ]; then
         check_cluster_version 4 0 0 'local backend' || continue
@@ -43,3 +46,5 @@ for backend in tidb importer local; do
       check_contains 'inc: 4'
     fi
 done
+
+run_sql "SET @@global.autocommit = '1';"

--- a/tests/lightning_alter_random/run.sh
+++ b/tests/lightning_alter_random/run.sh
@@ -38,7 +38,7 @@ for backend in tidb importer local; do
     check_contains 'inc: 3'
 
     # auto random base is 4
-    run_sql "INSERT INTO alter_random.t VALUES ();"
+    run_sql "INSERT INTO alter_random.t VALUES ();commit;"
     run_sql "SELECT id & b'000001111111111111111111111111111111111111111111111111111111111' as inc FROM alter_random.t"
     if [ "$backend" = 'tidb' ]; then
       check_contains 'inc: 30002'


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1104 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release note

 - Fix the bug that lightning tidb backend cannot load any data when `autocommit` is disabled.

<!-- fill in the release note, or just write "No release note" -->
