### PR TITLE
lightning: avoid ignore error when import data fails

### DIFF
--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1284,9 +1284,14 @@ func (local *local) WriteToTiKV(
 
 	var leaderPeerMetas []*sst.SSTMeta
 	for i, wStream := range clients {
-		if resp, closeErr := wStream.CloseAndRecv(); closeErr != nil {
+		resp, closeErr := wStream.CloseAndRecv()
+		if closeErr != nil {
 			return nil, Range{}, stats, errors.Trace(closeErr)
-		} else if leaderID == region.Region.Peers[i].GetId() {
+		}
+		if resp.Error != nil {
+			return nil, Range{}, stats, errors.New(resp.Error.Message)
+		}
+		if leaderID == region.Region.Peers[i].GetId() {
 			leaderPeerMetas = resp.Metas
 			log.L().Debug("get metas after write kv stream to tikv", zap.Reflect("metas", leaderPeerMetas))
 		}

--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1293,7 +1293,7 @@ func (local *local) WriteToTiKV(
 	}
 
 	// if there is not leader currently, we should directly return an error
-	if leaderPeerMetas == nil {
+	if len(leaderPeerMetas) == 0 {
 		log.L().Warn("write to tikv no leader", logutil.Region(region.Region), logutil.Leader(region.Leader),
 			zap.Uint64("leader_id", leaderID), logutil.SSTMeta(meta),
 			zap.Int64("kv_pairs", totalCount), zap.Int64("total_bytes", size))

--- a/pkg/lightning/backend/local/localhelper.go
+++ b/pkg/lightning/backend/local/localhelper.go
@@ -180,7 +180,7 @@ func (local *local) SplitAndScatterRegionByRanges(ctx context.Context, ranges []
 									}
 									return err1
 								} else if common.IsContextCanceledError(err1) {
-									// do not retry on conext.Canceled error
+									// do not retry on context.Canceled error
 									return err1
 								}
 								log.L().Warn("split regions", log.ShortError(err1), zap.Int("retry time", i),
@@ -189,9 +189,7 @@ func (local *local) SplitAndScatterRegionByRanges(ctx context.Context, ranges []
 								syncLock.Lock()
 								retryKeys = append(retryKeys, keys[startIdx:]...)
 								// set global error so if we exceed retry limit, the function will return this error
-								if !common.IsContextCanceledError(err1) {
-									err = multierr.Append(err, err1)
-								}
+								err = multierr.Append(err, err1)
 								syncLock.Unlock()
 								break
 							} else {
@@ -236,6 +234,8 @@ func (local *local) SplitAndScatterRegionByRanges(ctx context.Context, ranges []
 		}
 		close(ch)
 		if splitError := eg.Wait(); splitError != nil {
+			retryKeys = retryKeys[:0]
+			err = splitError
 			continue
 		}
 

--- a/pkg/lightning/backend/local/localhelper.go
+++ b/pkg/lightning/backend/local/localhelper.go
@@ -236,7 +236,7 @@ func (local *local) SplitAndScatterRegionByRanges(ctx context.Context, ranges []
 		}
 		close(ch)
 		if splitError := eg.Wait(); splitError != nil {
-			return splitError
+			continue
 		}
 
 		if len(retryKeys) == 0 {
@@ -305,6 +305,8 @@ func paginateScanRegion(
 	sort.Slice(regions, func(i, j int) bool {
 		return bytes.Compare(regions[i].Region.StartKey, regions[j].Region.StartKey) < 0
 	})
+	log.L().Info("paginate scan regions", zap.Int("count", len(regions)),
+		logutil.Key("start", startKey), logutil.Key("end", endKey))
 	return regions, nil
 }
 

--- a/pkg/lightning/backend/local/localhelper_test.go
+++ b/pkg/lightning/backend/local/localhelper_test.go
@@ -148,6 +148,10 @@ func (c *testClient) SplitRegion(
 func (c *testClient) BatchSplitRegionsWithOrigin(
 	ctx context.Context, regionInfo *restore.RegionInfo, keys [][]byte,
 ) (*restore.RegionInfo, []*restore.RegionInfo, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.splitCount++
+
 	if c.hook != nil {
 		regionInfo, keys = c.hook.BeforeSplitRegion(ctx, regionInfo, keys)
 	}
@@ -161,9 +165,6 @@ func (c *testClient) BatchSplitRegionsWithOrigin(
 	default:
 	}
 
-	c.splitCount++
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	newRegions := make([]*restore.RegionInfo, 0)
 	target, ok := c.regions[regionInfo.Region.Id]
 	if !ok {
@@ -542,7 +543,7 @@ type splitRegionNoValidKeyHook struct {
 	errorCnt       int32
 }
 
-func (h splitRegionNoValidKeyHook) BeforeSplitRegion(ctx context.Context, regionInfo *restore.RegionInfo, keys [][]byte) (*restore.RegionInfo, [][]byte) {
+func (h *splitRegionNoValidKeyHook) BeforeSplitRegion(ctx context.Context, regionInfo *restore.RegionInfo, keys [][]byte) (*restore.RegionInfo, [][]byte) {
 	regionInfo, keys = h.noopHook.BeforeSplitRegion(ctx, regionInfo, keys)
 	if atomic.AddInt32(&h.errorCnt, 1) <= h.returnErrTimes {
 		// clean keys to trigger "no valid keys" error
@@ -552,7 +553,7 @@ func (h splitRegionNoValidKeyHook) BeforeSplitRegion(ctx context.Context, region
 }
 
 func (s *localSuite) TestBatchSplitByRangesNoValidKeysOnce(c *C) {
-	s.doTestBatchSplitRegionByRanges(context.Background(), c, &splitRegionNoValidKeyHook{returnErrTimes: 1}, ".*no valid key.*", defaultHook{})
+	s.doTestBatchSplitRegionByRanges(context.Background(), c, &splitRegionNoValidKeyHook{returnErrTimes: 1}, "", defaultHook{})
 }
 
 func (s *localSuite) TestBatchSplitByRangesNoValidKeys(c *C) {

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -1593,8 +1593,8 @@ func (tr *TableRestore) restoreEngine(
 		}
 
 		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		case <-pCtx.Done():
+			return nil, pCtx.Err()
 		default:
 		}
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Let lightning return the actual error instead of return `context.Canceled`

### What is changed and how it works?
- Retry split regions instead of direct return an error in `BatchSplitRegions`
- check parent's context cancel event to avoid direct returning when chunk routine fails.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
