### PR TITLE
lightning: fix split larget csv EOF error

### DIFF
--- a/pkg/lightning/mydump/region.go
+++ b/pkg/lightning/mydump/region.go
@@ -15,6 +15,7 @@ package mydump
 
 import (
 	"context"
+	"io"
 	"math"
 	"sync"
 	"time"
@@ -365,7 +366,11 @@ func SplitLargeFile(
 			}
 			pos, err := parser.ReadUntilTokNewLine()
 			if err != nil {
-				return 0, nil, nil, err
+				if !errors.ErrorEqual(err, io.EOF) {
+					return 0, nil, nil, err
+				}
+				log.L().Warn("file contains no '\r\n' at end", zap.String("path", dataFile.FileMeta.Path))
+				pos = dataFile.FileMeta.FileSize
 			}
 			endOffset = pos
 			parser.Close()

--- a/pkg/lightning/mydump/region_test.go
+++ b/pkg/lightning/mydump/region_test.go
@@ -15,8 +15,10 @@ package mydump_test
 
 import (
 	"context"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/pingcap/br/pkg/storage"
 
@@ -229,5 +231,64 @@ func (s *testMydumpRegionSuite) TestSplitLargeFile(c *C) {
 			c.Assert(len(regions[i].Chunk.Columns), Equals, len(columns))
 			c.Assert(regions[i].Chunk.Columns, DeepEquals, columns)
 		}
+	}
+}
+
+func (s *testMydumpRegionSuite) TestSplitLargeFileNoNewLine(c *C) {
+	meta := &MDTableMeta{
+		DB:   "csv",
+		Name: "large_csv_file",
+	}
+	cfg := &config.Config{
+		Mydumper: config.MydumperRuntime{
+			ReadBlockSize: config.ReadBlockSize,
+			CSV: config.CSVConfig{
+				Separator:       ",",
+				Delimiter:       "",
+				Header:          true,
+				TrimLastSep:     false,
+				NotNull:         false,
+				Null:            "NULL",
+				BackslashEscape: true,
+			},
+			StrictFormat:  true,
+			Filter:        []string{"*.*"},
+			MaxRegionSize: 1,
+		},
+	}
+
+	dir := c.MkDir()
+
+	fileName := "test.csv"
+	filePath := filepath.Join(dir, fileName)
+
+	content := []byte("a,b\r\n123,456\r\n789,101")
+	err := ioutil.WriteFile(filePath, content, 0o644)
+	c.Assert(err, IsNil)
+
+	dataFileInfo, err := os.Stat(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fileSize := dataFileInfo.Size()
+	fileInfo := FileInfo{FileMeta: SourceFileMeta{Path: fileName, Type: SourceTypeCSV, FileSize: fileSize}}
+	colCnt := int64(2)
+	columns := []string{"a", "b"}
+	prevRowIdxMax := int64(0)
+	ioWorker := worker.NewPool(context.Background(), 4, "io")
+
+	store, err := storage.NewLocalStorage(dir)
+	c.Assert(err, IsNil)
+
+	offsets := [][]int64{{4, 13}, {13, 21}}
+
+	_, regions, _, err := SplitLargeFile(context.Background(), meta, cfg, fileInfo, colCnt, prevRowIdxMax, ioWorker, store)
+	c.Assert(err, IsNil)
+	c.Assert(len(regions), Equals, 2)
+	for i := range offsets {
+		c.Assert(regions[i].Chunk.Offset, Equals, offsets[i][0])
+		c.Assert(regions[i].Chunk.EndOffset, Equals, offsets[i][1])
+		c.Assert(len(regions[i].Chunk.Columns), Equals, len(columns))
+		c.Assert(regions[i].Chunk.Columns, DeepEquals, columns)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #1133 

### What is changed and how it works?
don't return io.EOF error if split large csv meets EOF error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

 - Fix the bug that lightning returns EOF error when CSV file without '\r\n' at the last line and `strict-format = true`.

<!-- fill in the release note, or just write "No release note" -->
