### PR TITLE
pkg: use the GoTimeToTS() from oracle pkg

### DIFF
--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -19,8 +19,8 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics/handle"
+	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/types"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
@@ -476,7 +476,7 @@ func parseTSString(ts string) (uint64, error) {
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	return variable.GoTimeToTS(t1), nil
+	return oracle.GoTimeToTS(t1), nil
 }
 
 func parseCompressionType(s string) (backuppb.CompressionType, error) {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

`GoTimeToTS()` from [varsutil.go#L469](https://github.com/pingcap/tidb/blob/c8bc701170165e82cc7893ab68523f9a2059a7e6/sessionctx/variable/varsutil.go#L469) is exactly the same as `GoTimeToTS()` in `oracle` pkg which is the original version and the right place it should belong to.

### What is changed and how it works?

Use `oracle.GoTimeToTS()` instead of `variable.GoTimeToTS()`, and the latter will be removed in pingcap/tidb#24813.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - pingcap/tidb#24766

### Release note

 - No release note.
