### PR TITLE
tests: add row count check for br clustered index tests

### DIFF
--- a/tests/br_clustered_index/run.sh
+++ b/tests/br_clustered_index/run.sh
@@ -19,7 +19,7 @@ TABLE="usertable"
 
 run_sql "CREATE DATABASE $DB;"
 
-table_names=${cases:-'t0 t1 t2 t_bit t_bool t_tinyint t_smallint t_mediumint t_int t_date t_time t_datetime t_timestamp t_year t_char t_varchar t_text t_binary t_blob t_enum t_set t8 t9 t10 t11 t12'}
+table_names=${cases:-'t0 t1 t2 t_bit t_bool t_tinyint t_smallint t_mediumint t_int t_date t_time t_datetime t_timestamp t_year t_char t_varcher t_text t_binary t_blob t_enum t_set t8 t9 t10 t11 t12'}
 
 run_sql "
 USE $DB;

--- a/tests/br_clustered_index/run.sh
+++ b/tests/br_clustered_index/run.sh
@@ -19,6 +19,8 @@ TABLE="usertable"
 
 run_sql "CREATE DATABASE $DB;"
 
+table_names=${cases:-'t0 t1 t2 t_bit t_bool t_tinyint t_smallint t_mediumint t_int t_date t_time t_datetime t_timestamp t_year t_char t_varchar t_text t_binary t_blob t_enum t_set t8 t9 t10 t11 t12'}
+
 run_sql "
 USE $DB;
 
@@ -165,11 +167,30 @@ clustered_table_count=$(run_sql "\
 echo "backup start..."
 run_br --pd $PD_ADDR backup db -s "local://$TEST_DIR/$DB" --db $DB --ratelimit 5 --concurrency 4
 
+# count
+echo "count rows..."
+row_counts=()
+for table_name in $table_names; do
+    row_counts+=($(run_sql "SELECT COUNT(*) FROM $DB.$table_name;" | awk '/COUNT/{print $2}'))
+done
+
 run_sql "DROP DATABASE $DB;"
 run_sql "CREATE DATABASE $DB;"
 
 # restore table
 echo "restore start..."
 run_br restore db --db $DB -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+
+# check count
+echo "check count..."
+idx=0
+for table_name in $table_names; do
+    row_count=$(run_sql "SELECT COUNT(*) FROM $DB.$table_name;" | awk '/COUNT/{print $2}')
+    if [[ $row_count -ne ${row_counts[$idx]} ]]; then
+        echo "Lost some rows in table $table_name. Expect ${row_counts[$idx]}; Get $row_count."
+        exit 1
+    fi
+    idx=$(( $idx + 1 ))
+done
 
 run_sql "DROP DATABASE $DB;"

--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -54,7 +54,8 @@ hint_backup_start=$TEST_DIR/hint_backup_start
 hint_get_backup_client=$TEST_DIR/hint_get_backup_client
 
 
-cases=${cases:-'outage outage-after-request outage-at-finegrained shutdown scale-out'}
+# cases=${cases:-'outage outage-after-request outage-at-finegrained shutdown scale-out'}
+cases=${cases:-'outage outage-after-request shutdown scale-out'}
 
 for failure in $cases; do
     rm -f "$hint_finegrained" "$hint_backup_start" "$hint_get_backup_client"

--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -54,8 +54,7 @@ hint_backup_start=$TEST_DIR/hint_backup_start
 hint_get_backup_client=$TEST_DIR/hint_get_backup_client
 
 
-# cases=${cases:-'outage outage-after-request outage-at-finegrained shutdown scale-out'}
-cases=${cases:-'outage outage-after-request shutdown scale-out'}
+cases=${cases:-'outage outage-after-request outage-at-finegrained shutdown scale-out'}
 
 for failure in $cases; do
     rm -f "$hint_finegrained" "$hint_backup_start" "$hint_get_backup_client"


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Key range in backup and checksum might be wrong at the same time(They are still the same) when the table use clustered index, which means checksum cannot find this error.

### What is changed and how it works?

add row_count check for the test.

### Check List <!--REMOVE the items that are not applicable-->

 - Need to cherry-pick to the release branch

### Release note

 -No release note

<!-- fill in the release note, or just write "No release note" -->
