### PR TITLE
storage: mkdirAll for local storage even when SkipCheckPath is true

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -137,9 +137,6 @@ func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalSt
 		if backend.Local == nil {
 			return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "local config not found")
 		}
-		if opts.SkipCheckPath {
-			return &LocalStorage{base: backend.Local.Path}, nil
-		}
 		return NewLocalStorage(backend.Local.Path)
 	case *backuppb.StorageBackend_S3:
 		if backend.S3 == nil {


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When we set `SkipCheckPath` to true, external local storage won't create a directory and will fail to create a new file.

### What is changed and how it works?
Try `mkdirAll` even when `SkipCheckPath` is true.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
