### PR TITLE
*: upgrade go version from 1.13/1.15 to 1.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Run build
         run: make build
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Compile for FreeBSD
         run: GOOS=freebsd make build

--- a/.github/workflows/compatible_test.yml
+++ b/.github/workflows/compatible_test.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
       if: ${{ github.event_name == 'pull_request' || steps.check.outputs.triggered == 'true' }}
 
     - name: Generate compatibility test backup data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ your contribution accepted.
 
 Developing BR requires:
 
-* [Go 1.13+](http://golang.org/doc/code.html)
+* [Go 1.16+](http://golang.org/doc/code.html)
 * An internet connection to download the dependencies
 
 Simply run `make` to build the program.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ make
 $ make test
 ```
 
-Notice BR supports building with Go version `Go >= 1.13`
+Notice BR supports building with Go version `Go >= 1.16`
 
 When BR is built successfully, you can find binary in the `bin` directory.
 
@@ -108,15 +108,15 @@ bin/br backup table --db test \
 	-s local:///tmp/backup_test/ \
 	--pd ${PD_ADDR}:2379 \
 	--log-file backup_test.log \
-					
+
 # Let's drop the table.
 mysql -uroot --host 127.0.0.1 -P4000 -E -e "USE test; DROP TABLE order_line; show tables" -u root -p
 
 # Restore from the backup.
 bin/br restore table --db test \
-	--table order_line \ 
-	-s local:///tmp/backup_test/ \ 
-	--pd ${PD_ADDR}:2379 \ 
+	--table order_line \
+	-s local:///tmp/backup_test/ \
+	--pd ${PD_ADDR}:2379 \
 	--log-file restore_test.log
 
 # How many rows do we get after restore? Expected to be 300242 rows.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # For loading data to TiDB
-FROM golang:1.13.8-buster as go-ycsb-builder
+FROM golang:1.16.4-buster as go-ycsb-builder
 WORKDIR /go/src/github.com/pingcap/
 RUN git clone https://github.com/pingcap/go-ycsb.git && \
     cd go-ycsb && \
@@ -8,7 +8,7 @@ RUN git clone https://github.com/pingcap/go-ycsb.git && \
 # For operating minio S3 compatible storage
 FROM minio/mc as mc-builder
 
-FROM golang:1.13.8-buster
+FROM golang:1.16.4-buster
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \

--- a/go.mod1
+++ b/go.mod1
@@ -1,6 +1,6 @@
 module github.com/pingcap/br
 
-go 1.13
+go 1.16
 
 require (
 	cloud.google.com/go/storage v1.6.0

--- a/go.sum1
+++ b/go.sum1
@@ -97,7 +97,6 @@ github.com/cockroachdb/pebble v0.0.0-20201023120638-f1224da22976/go.mod h1:BbtTi
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codahale/hdrhistogram v0.9.0 h1:9GjrtRI+mLEFPtTfR/AZhcxp+Ii8NZYWq5104FbZQY0=
 github.com/codahale/hdrhistogram v0.9.0/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/colinmarc/hdfs/v2 v2.1.1/go.mod h1:M3x+k8UKKmxtFu++uAZ0OtDU8jR3jnaZIAc6yK4Ue0c=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
@@ -162,7 +161,6 @@ github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/fsouza/fake-gcs-server v1.19.0 h1:XyaGOlqo+R5sjT03x2ymk0xepaQlgwhRLTT2IopW0zA=

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -111,7 +111,9 @@ func (s *gcsStorage) ReadFile(ctx context.Context, name string) ([]byte, error) 
 	object := s.objectName(name)
 	rc, err := s.bucket.Object(object).NewReader(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err,
+			"failed to read gcs file, file info: input.bucket='%s', input.key='%s'",
+			s.gcs.Bucket, object)
 	}
 	defer rc.Close()
 

--- a/tests/up.sh
+++ b/tests/up.sh
@@ -117,14 +117,14 @@ FROM minio/minio                                    AS minio-builder
 FROM minio/mc                                       AS mc-builder
 FROM fsouza/fake-gcs-server                         AS gcs-builder
 
-FROM golang:1.13.8-buster as ycsb-builder
+FROM golang:1.16.4-buster as ycsb-builder
 WORKDIR /go/src/github.com/pingcap/
 RUN git clone https://github.com/pingcap/go-ycsb.git && \
     cd go-ycsb && \
     make && \
     cp bin/go-ycsb /go-ycsb
 
-FROM golang:1.13.8-buster
+FROM golang:1.16.4-buster
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/br/_tools
 
-go 1.13
+go 1.16
 
 require (
 	github.com/dnephin/govet v0.0.0-20171012192244-4a96d43e39d3

--- a/web/go.mod
+++ b/web/go.mod
@@ -2,4 +2,4 @@
 
 module github.com/pingcap/br/pkg/lightning/web
 
-go 1.13
+go 1.16


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

The CI recently upgraded the Go compiler version to 1.16, but the test scripts and go.mod still assume 1.13. This PR changes them all to 1.16 to keep in sync with the CI.

### What is changed and how it works?

Upgrade all references to Go 1.13 and 1.15 to 1.16.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

### Release note

 - No release note

