### PR TITLE
lightning: fix id allocator base for double auto_increment field

### DIFF
--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -16,6 +16,7 @@ package kv
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/pingcap/errors"
@@ -352,7 +353,7 @@ func (kvcodec *tableKVEncoder) AddRecord(
 		}
 		if isAutoIncCol {
 			// TODO use auto incremental type
-			_ = kvcodec.tbl.RebaseAutoID(kvcodec.se, value.GetInt64(), false, autoid.RowIDAllocType)
+			_ = kvcodec.tbl.RebaseAutoID(kvcodec.se, getAutoRecordID(value, &col.FieldType), false, autoid.RowIDAllocType)
 		}
 	}
 
@@ -382,6 +383,21 @@ func (kvcodec *tableKVEncoder) AddRecord(
 	pairs, size := kvcodec.se.takeKvPairs()
 	kvcodec.recordCache = record[:0]
 	return Pairs(pairs), size, nil
+}
+
+// get record value for auto-increment field
+//
+// See: https://github.com/pingcap/tidb/blob/47f0f15b14ed54fc2222f3e304e29df7b05e6805/executor/insert_common.go#L781-L852
+// TODO: merge this with pkg/lightning/backend/kv/sql2kv.go
+func getAutoRecordID(d types.Datum, target *types.FieldType) int64 {
+	switch target.Tp {
+	case mysql.TypeFloat, mysql.TypeDouble:
+		return int64(math.Round(d.GetFloat64()))
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
+		return d.GetInt64()
+	default:
+		panic(fmt.Sprintf("unsupported auto-increment field type '%d'", target.Tp))
+	}
 }
 
 // RemoveRecord encode a row of data into KV pairs.

--- a/pkg/lightning/backend/kv/sql2kv.go
+++ b/pkg/lightning/backend/kv/sql2kv.go
@@ -16,6 +16,8 @@
 package kv
 
 import (
+	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 
@@ -355,7 +357,7 @@ func (kvcodec *tableKVEncoder) Encode(
 			}
 		}
 		if isAutoIncCol {
-			if err := kvcodec.tbl.RebaseAutoID(kvcodec.se, value.GetInt64(), false, autoid.AutoIncrementType); err != nil {
+			if err := kvcodec.tbl.RebaseAutoID(kvcodec.se, getAutoRecordID(value, &col.FieldType), false, autoid.AutoIncrementType); err != nil {
 				return nil, errors.Trace(err)
 			}
 		}
@@ -406,6 +408,20 @@ func (kvcodec *tableKVEncoder) Encode(
 	pairs := kvcodec.se.takeKvPairs()
 	kvcodec.recordCache = record[:0]
 	return kvPairs(pairs), nil
+}
+
+// get record value for auto-increment field
+//
+// See: https://github.com/pingcap/tidb/blob/47f0f15b14ed54fc2222f3e304e29df7b05e6805/executor/insert_common.go#L781-L852
+func getAutoRecordID(d types.Datum, target *types.FieldType) int64 {
+	switch target.Tp {
+	case mysql.TypeFloat, mysql.TypeDouble:
+		return int64(math.Round(d.GetFloat64()))
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
+		return d.GetInt64()
+	default:
+		panic(fmt.Sprintf("unsupported auto-increment field type '%d'", target.Tp))
+	}
 }
 
 func (kvs kvPairs) Size() uint64 {

--- a/pkg/lightning/backend/kv/sql2kv_test.go
+++ b/pkg/lightning/backend/kv/sql2kv_test.go
@@ -215,6 +215,37 @@ func (s *kvSuite) TestEncodeTimestamp(c *C) {
 	}))
 }
 
+func (s *kvSuite) TestEncodeDoubleAutoIncrement(c *C) {
+	tblInfo := mockTableInfo(c, "create table t (id double not null auto_increment, unique key `u_id` (`id`));")
+	tbl, err := tables.TableFromMeta(NewPanickingAllocators(0), tblInfo)
+	c.Assert(err, IsNil)
+
+	logger := log.Logger{Logger: zap.NewNop()}
+
+	encoder, err := NewTableKVEncoder(tbl, &SessionOptions{
+		SQLMode: mysql.ModeStrictAllTables,
+		SysVars: map[string]string{
+			"tidb_row_format_version": "2",
+		},
+	})
+	c.Assert(err, IsNil)
+	pairs, err := encoder.Encode(logger, []types.Datum{
+		types.NewStringDatum("1"),
+	}, 70, []int{0, -1})
+	c.Assert(err, IsNil)
+	c.Assert(pairs, DeepEquals, kvPairs([]common.KvPair{
+		{
+			Key: []uint8{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x46},
+			Val: []uint8{0x80, 0x0, 0x1, 0x0, 0x0, 0x0, 0x1, 0x8, 0x0, 0xbf, 0xf0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		},
+		{
+			Key: []uint8{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x5, 0xbf, 0xf0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+			Val: []uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x46},
+		},
+	}))
+	c.Assert(tbl.Allocators(encoder.(*tableKVEncoder).se).Get(autoid.AutoIncrementType).Base(), Equals, int64(70))
+}
+
 func mockTableInfo(c *C, createSQL string) *model.TableInfo {
 	parser := parser.New()
 	node, err := parser.ParseOneStmt(createSQL, "", "")


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the bug that lightning will got invalid auto_increment base if the corresponding auto_increment field is double/float.
```
[2021/06/05 13:37:03.227 +08:00] [INFO] [tidb.go:355] ["alter table auto_increment start"] [table=`db`.`table`] [auto_increment=4753151844738400257]
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

### Release note

 - Fix the bug that lightning rebase wrong auto_increment base when the auto_increment field type is float or double.

<!-- fill in the release note, or just write "No release note" -->
