### PR TITLE
lightning: avoid do pre-checksum when checksum is disabled

### DIFF
--- a/pkg/lightning/restore/meta_manager_test.go
+++ b/pkg/lightning/restore/meta_manager_test.go
@@ -65,10 +65,11 @@ func (s *metaMgrSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.mgr = &dbTableMetaMgr{
-		session:   db,
-		taskID:    1,
-		tr:        s.tr,
-		tableName: common.UniqueTable("test", tableMetaTableName),
+		session:      db,
+		taskID:       1,
+		tr:           s.tr,
+		tableName:    common.UniqueTable("test", tableMetaTableName),
+		needChecksum: true,
 	}
 	s.mockDB = m
 	s.checksumMgr = &testChecksumMgr{}
@@ -129,6 +130,29 @@ func (s *metaMgrSuite) TestAllocTableRowIDsSingleTableContainsData(c *C) {
 	c.Assert(rowIDBase, Equals, int64(998))
 	c.Assert(ck, DeepEquals, &checksum)
 	c.Assert(s.checksumMgr.callCnt, Equals, 1)
+}
+
+func (s *metaMgrSuite) TestAllocTableRowIDsSingleTableSkipChecksum(c *C) {
+	s.mgr.needChecksum = false
+	defer func() {
+		s.mgr.needChecksum = true
+	}()
+	ctx := context.WithValue(context.Background(), &checksumManagerKey, s.checksumMgr)
+
+	rows := [][]driver.Value{
+		{int64(1), int64(0), int64(0), uint64(0), uint64(0), uint64(0), "initialized"},
+	}
+	nextID := int64(999)
+	//checksum := verification.MakeKVChecksum(1, 2, 3)
+	newStatus := "restore"
+	updateArgs := []driver.Value{int64(998), int64(1008), "allocated", int64(1), int64(1)}
+	s.prepareMock(rows, &nextID, updateArgs, nil, &newStatus)
+
+	ck, rowIDBase, err := s.mgr.AllocTableRowIDs(ctx, 10)
+	c.Assert(err, IsNil)
+	c.Assert(rowIDBase, Equals, int64(998))
+	c.Assert(ck, IsNil)
+	c.Assert(s.checksumMgr.callCnt, Equals, 0)
 }
 
 func (s *metaMgrSuite) TestAllocTableRowIDsAllocated(c *C) {

--- a/pkg/lightning/restore/meta_manager_test.go
+++ b/pkg/lightning/restore/meta_manager_test.go
@@ -143,7 +143,6 @@ func (s *metaMgrSuite) TestAllocTableRowIDsSingleTableSkipChecksum(c *C) {
 		{int64(1), int64(0), int64(0), uint64(0), uint64(0), uint64(0), "initialized"},
 	}
 	nextID := int64(999)
-	//checksum := verification.MakeKVChecksum(1, 2, 3)
 	newStatus := "restore"
 	updateArgs := []driver.Value{int64(998), int64(1008), "allocated", int64(1), int64(1)}
 	s.prepareMock(rows, &nextID, updateArgs, nil, &newStatus)

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -313,9 +313,10 @@ func NewRestoreControllerWithPauser(
 			return nil, errors.Trace(err)
 		}
 		metaBuilder = &dbMetaMgrBuilder{
-			db:     db,
-			taskID: cfg.TaskID,
-			schema: cfg.App.MetaSchemaName,
+			db:           db,
+			taskID:       cfg.TaskID,
+			schema:       cfg.App.MetaSchemaName,
+			needChecksum: cfg.PostRestore.Checksum != config.OpLevelOff,
 		}
 	default:
 		metaBuilder = noopMetaMgrBuilder{}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the bug that if `post-restore.checksum = off` and table auto_increment base is not 0, lightning will panic due to checksumManager is nil. 

### What is changed and how it works?
Avoid do pre-checksum if check is disabled.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects


Related changes

### Release note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
