### PR TITLE
lightning: fix deliver kvs too few at a time

### DIFF
--- a/pkg/lightning/restore/restore_test.go
+++ b/pkg/lightning/restore/restore_test.go
@@ -1171,7 +1171,7 @@ func (s *chunkRestoreSuite) TestEncodeLoopDeliverLimit(c *C) {
 
 	rc := &Controller{pauser: DeliverPauser, cfg: cfg}
 	c.Assert(failpoint.Enable(
-		"github.com/pingcap/br/pkg/lightning/restore/mock-kv-size", "return(110000000)"), IsNil)
+		"github.com/pingcap/br/pkg/lightning/restore/mock-kv-size", "return(4089446400)"), IsNil)
 	_, _, err = s.cr.encodeLoop(ctx, kvsCh, s.tr, s.tr.logger, kvEncoder, deliverCompleteCh, rc)
 
 	// we have 3 kvs total. after the failpoint injected.


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In `chunkRestore.encodeLoop`, when `kvSize >= minDeliverBytes`, it will trigger a deliver. But `minDeliverBytes` (`96KB`) is too small, which probably impact performance. I think a larger limit should be more reasonable.
https://github.com/pingcap/br/blob/221bed67d5517873ce412e93150397b7ea20d1ef/pkg/lightning/restore/restore.go#L3028-L3034


### What is changed and how it works?
Introduce a new `maxDeliverBytes` which value is `3840MB`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release note

 - lightning: fix deliver kvs too few at a time
