### PR TITLE
*: update tidb and enable integration tests

### DIFF
--- a/go.mod1
+++ b/go.mod1
@@ -26,10 +26,10 @@ require (
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
-	github.com/pingcap/kvproto v0.0.0-20210609044018-c9b3ba48af7e
+	github.com/pingcap/kvproto v0.0.0-20210611081648-a215b4e61d2f
 	github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4
 	github.com/pingcap/parser v0.0.0-20210610080504-cb77169bfed9
-	github.com/pingcap/tidb v1.1.0-beta.0.20210611092435-cc5e161ac068
+	github.com/pingcap/tidb v1.1.0-beta.0.20210611165635-07d16065d1bd
 	github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible
 	github.com/pingcap/tipb v0.0.0-20210603161937-cfb5a9225f95
 	github.com/prometheus/client_golang v1.5.1

--- a/go.sum1
+++ b/go.sum1
@@ -430,7 +430,7 @@ github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5e
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19 h1:IXpGy7y9HyoShAFmzW2OPF0xCA5EOoSTyZHwsgYk9Ro=
 github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19/go.mod h1:LyrqUOHZrUDf9oGi1yoz1+qw9ckSIhQb5eMa1acOLNQ=
-github.com/pingcap/br v5.1.0-alpha.0.20210604015827-db22c6d284a0+incompatible/go.mod h1:ymVmo50lQydxib0tmK5hHk4oteB7hZ0IMCArunwy3UQ=
+github.com/pingcap/br v5.2.0-alpha.0.20210611153635-74f18bcbe19d+incompatible/go.mod h1:ymVmo50lQydxib0tmK5hHk4oteB7hZ0IMCArunwy3UQ=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
@@ -457,9 +457,8 @@ github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO
 github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20210527074428-73468940541b/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20210531063847-f42e582bf0bb/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210602120243-804ac0a6ce21/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210609044018-c9b3ba48af7e h1:mb+R9srExSqVrAVHJf5fWW+Y0yd582pmi1pXTWBFljY=
-github.com/pingcap/kvproto v0.0.0-20210609044018-c9b3ba48af7e/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20210611081648-a215b4e61d2f h1:6K+5nbl1I3el9mYt/mlWorBR95qqmQdwrXYaNQrWWE8=
+github.com/pingcap/kvproto v0.0.0-20210611081648-a215b4e61d2f/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4 h1:ERrF0fTuIOnwfGbt71Ji3DKbOEaP189tjym50u8gpC8=
@@ -470,8 +469,8 @@ github.com/pingcap/parser v0.0.0-20210610080504-cb77169bfed9/go.mod h1:xZC8I7bug
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3 h1:A9KL9R+lWSVPH8IqUuH1QSTRJ5FGoY1bT2IcfPKsWD8=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
-github.com/pingcap/tidb v1.1.0-beta.0.20210611092435-cc5e161ac068 h1:aVOXL7TxwR5q868HdEx/OPAFq9pmtctq7Z49qx880Mw=
-github.com/pingcap/tidb v1.1.0-beta.0.20210611092435-cc5e161ac068/go.mod h1:bikh0ZRbzFfHs5pVVmCUiRkNUfaf627CN1fh0SeLU0M=
+github.com/pingcap/tidb v1.1.0-beta.0.20210611165635-07d16065d1bd h1:ei4DgV5BH1hUBen1w2hoSp0vPIQDbbJzFEV5vL16q4s=
+github.com/pingcap/tidb v1.1.0-beta.0.20210611165635-07d16065d1bd/go.mod h1:qC/By1WbjT3arKXJChHxBLgP+bJzGW8lUmPRjIevaKw=
 github.com/pingcap/tidb-dashboard v0.0.0-20210512074702-4ee3e3909d5e/go.mod h1:7HnQAeqKOuJwCBUeglCUel7SjW6fPNnoXawuv+6Q6Ek=
 github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible h1:ceznmu/lLseGHP/jKyOa/3u/5H3wtLLLqkH2V3ssSjg=
 github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=

--- a/tests/br_backup_empty/run.sh
+++ b/tests/br_backup_empty/run.sh
@@ -16,9 +16,6 @@
 set -eu
 DB="$TEST_NAME"
 
-# Skip test temporarily. Reopen after TiDB update.
-exit 0
-
 # backup empty.
 echo "backup start..."
 run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/empty_db" --ratelimit 5 --concurrency 4

--- a/tests/br_backup_version/run.sh
+++ b/tests/br_backup_version/run.sh
@@ -16,9 +16,6 @@
 set -eu
 DB="$TEST_NAME"
 
-# Skip test temporarily. Reopen after TiDB update.
-exit 0
-
 # example
 #    "cluster_id": 6931331682760961243
 expected_cluster_id=`run_curl "https://$PD_ADDR/pd/api/v1/members" | grep "cluster_id"`

--- a/tests/docker_compatible_gcs/prepare.sh
+++ b/tests/docker_compatible_gcs/prepare.sh
@@ -18,9 +18,6 @@ set -eux
 
 BUCKET="test"
 
-# Skip test temporarily. Reopen after TiDB update.
-exit 0
-
 # create gcs bucket
 curl -XPOST http://$GCS_HOST:$GCS_PORT/storage/v1/b -d '{"name":"test"}'
 

--- a/tests/docker_compatible_gcs/run.sh
+++ b/tests/docker_compatible_gcs/run.sh
@@ -18,9 +18,6 @@ set -eux
 
 BUCKET="test"
 
-# Skip test temporarily. Reopen after TiDB update.
-exit 0
-
 # we need start a oauth server or gcs client will failed to handle request.
 KEY=$(cat <<- EOF
 {

--- a/tests/docker_compatible_s3/prepare.sh
+++ b/tests/docker_compatible_s3/prepare.sh
@@ -16,9 +16,6 @@
 # This test is used to generate backup for later compatible test.
 set -eux
 
-# Skip test temporarily. Reopen after TiDB update.
-exit 0
-
 BUCKET="test"
 # start the s3 server
 MINIO_ACCESS_KEY='brs3accesskey'

--- a/tests/docker_compatible_s3/run.sh
+++ b/tests/docker_compatible_s3/run.sh
@@ -16,9 +16,6 @@
 # This test is used to test compatible for BR restore.
 set -eux
 
-# Skip test temporarily. Reopen after TiDB update.
-exit 0
-
 BUCKET="test"
 MINIO_ACCESS_KEY='brs3accesskey'
 MINIO_SECRET_KEY='brs3secretkey'


### PR DESCRIPTION
### What problem does this PR solve?
We have disabled some tests previously in order to update to client-go/v2.

### What is changed and how it works?
- update tidb to latest master
- enable integration tests

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

### Release note
- No release note
