### PR TITLE
tests: fix shell stuck while br is exited with failure status

### DIFF
--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -5,9 +5,12 @@ set -eux
 . run_services
 
 wait_file_exist() {
-    isexit=0
-    until [ -e "$1" -o $isexit -eq 1 ]; do
-        kill -0 $2 || isexit=$?
+    timeout=0
+    until [ -e "$1" ]; do
+        timeout=$(( $timeout + 1 ))
+        if [[ $timeout -gt 100 ]]; then
+            echo "timeout! maybe BR process is exited!"; exit 1;
+        fi
         sleep 1
     done
 }

--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -5,7 +5,9 @@ set -eux
 . run_services
 
 wait_file_exist() {
-    until [ -e "$1" ]; do
+    isexit=0
+    until [ -e "$1" -o $isexit -eq 1 ]; do
+        kill -0 $2 || isexit=$?
         sleep 1
     done
 }
@@ -16,19 +18,19 @@ single_point_fault() {
     echo "Will make failure($type) to store#$victim."
     case $type in
         outage)
-            wait_file_exist "$hint_backup_start"
+            wait_file_exist "$hint_backup_start" $2
             kv_outage -d 30 -i $victim;;
         outage-after-request)
-            wait_file_exist "$hint_get_backup_client"
+            wait_file_exist "$hint_get_backup_client" $2
             kv_outage -d 30 -i $victim;;
         outage-at-finegrained)
-            wait_file_exist "$hint_finegrained"
+            wait_file_exist "$hint_finegrained" $2
             kv_outage --kill -i $victim;;
         shutdown)
-            wait_file_exist "$hint_backup_start"
+            wait_file_exist "$hint_backup_start" $2
             kv_outage --kill -i $victim;;
         scale-out)
-            wait_file_exist "$hint_backup_start"
+            wait_file_exist "$hint_backup_start" $2
             kv_outage --kill -i $victim
             kv_outage --scale-out -i 4;;
     esac
@@ -69,7 +71,7 @@ github.com/pingcap/br/pkg/conn/hint-get-backup-client=1*return(\"$hint_get_backu
     rm -rf "${backup_dir:?}"
     run_br backup full -s local://"$backup_dir" &
     backup_pid=$!
-    single_point_fault $failure
+    single_point_fault $failure $backup_pid
     wait $backup_pid
     case $failure in
     scale-out | shutdown | outage-at-finegrained ) stop_services

--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -21,19 +21,19 @@ single_point_fault() {
     echo "Will make failure($type) to store#$victim."
     case $type in
         outage)
-            wait_file_exist "$hint_backup_start" $2
+            wait_file_exist "$hint_backup_start"
             kv_outage -d 30 -i $victim;;
         outage-after-request)
-            wait_file_exist "$hint_get_backup_client" $2
+            wait_file_exist "$hint_get_backup_client"
             kv_outage -d 30 -i $victim;;
         outage-at-finegrained)
-            wait_file_exist "$hint_finegrained" $2
+            wait_file_exist "$hint_finegrained"
             kv_outage --kill -i $victim;;
         shutdown)
-            wait_file_exist "$hint_backup_start" $2
+            wait_file_exist "$hint_backup_start"
             kv_outage --kill -i $victim;;
         scale-out)
-            wait_file_exist "$hint_backup_start" $2
+            wait_file_exist "$hint_backup_start"
             kv_outage --kill -i $victim
             kv_outage --scale-out -i 4;;
     esac
@@ -74,7 +74,7 @@ github.com/pingcap/br/pkg/conn/hint-get-backup-client=1*return(\"$hint_get_backu
     rm -rf "${backup_dir:?}"
     run_br backup full -s local://"$backup_dir" &
     backup_pid=$!
-    single_point_fault $failure $backup_pid
+    single_point_fault $failure
     wait $backup_pid
     case $failure in
     scale-out | shutdown | outage-at-finegrained ) stop_services


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

shell stuck to wait file created by BR while BR is exited with failure status.

### What is changed and how it works?

add a condition : when BR process is not alive, shell will jump out loop.


Related changes

 - Need to cherry-pick to the release branch

### Release note

 -No release note

<!-- fill in the release note, or just write "No release note" -->
