### PR TITLE
Lightning: skip print check template and remove unnecessary check

### DIFF
--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -261,7 +261,7 @@ func (s *testMydumpLoaderSuite) TestViewNoHostTable(c *C) {
 	s.touch(c, "db.tbl-schema-view.sql")
 
 	_, err := md.NewMyDumpLoader(context.Background(), s.cfg)
-	c.Assert(err, ErrorMatches, `invalid view schema file, miss host table schema for view 'tbl'`)
+	c.Assert(err, IsNil)
 }
 
 func (s *testMydumpLoaderSuite) TestDataWithoutSchema(c *C) {

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -247,7 +247,7 @@ func (s *testMydumpLoaderSuite) TestViewNoHostDB(c *C) {
 	s.touch(c, "db.tbl-schema-view.sql")
 
 	_, err := md.NewMyDumpLoader(context.Background(), s.cfg)
-	c.Assert(err, IsNil)
+	c.Assert(err, ErrorMatches, `invalid view schema file, miss host table schema for view 'tbl'`)
 }
 
 func (s *testMydumpLoaderSuite) TestViewNoHostTable(c *C) {

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -261,7 +261,7 @@ func (s *testMydumpLoaderSuite) TestViewNoHostTable(c *C) {
 	s.touch(c, "db.tbl-schema-view.sql")
 
 	_, err := md.NewMyDumpLoader(context.Background(), s.cfg)
-	c.Assert(err, IsNil)
+	c.Assert(err, ErrorMatches, `invalid view schema file, miss host table schema for view 'tbl'`)
 }
 
 func (s *testMydumpLoaderSuite) TestDataWithoutSchema(c *C) {

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -144,7 +144,7 @@ func (s *testMydumpLoaderSuite) TestTableNoHostDB(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = md.NewMyDumpLoader(context.Background(), s.cfg)
-	c.Assert(err, ErrorMatches, `invalid table schema file, cannot find db 'db' - .*db\.tbl-schema\.sql`)
+	c.Assert(err, IsNil)
 }
 
 func (s *testMydumpLoaderSuite) TestDuplicatedTable(c *C) {
@@ -247,7 +247,7 @@ func (s *testMydumpLoaderSuite) TestViewNoHostDB(c *C) {
 	s.touch(c, "db.tbl-schema-view.sql")
 
 	_, err := md.NewMyDumpLoader(context.Background(), s.cfg)
-	c.Assert(err, ErrorMatches, `invalid table schema file, cannot find db 'db' - .*[/\\]?db\.tbl-schema-view\.sql`)
+	c.Assert(err, IsNil)
 }
 
 func (s *testMydumpLoaderSuite) TestViewNoHostTable(c *C) {

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -711,15 +711,13 @@ func (rc *Controller) restoreSchema(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 
-	if rc.tidbGlue.OwnsSQLExecutor() {
+	if rc.cfg.App.CheckRequirements && rc.tidbGlue.OwnsSQLExecutor() {
+		// print check template only if check requirements is true.
 		fmt.Println(rc.checkTemplate.Output())
-	} else {
-		// TODO use a new template to log
-		log.L().Info(rc.checkTemplate.Output())
-	}
-	if !rc.checkTemplate.Success() {
-		return errors.Errorf("lightning pre check failed." +
-			"please fix the check item and make check passed or set --check-requirement=false to avoid this check")
+		if !rc.checkTemplate.Success() {
+			return errors.Errorf("lightning pre check failed." +
+				"please fix the check item and make check passed or set --check-requirement=false to avoid this check")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
solve https://github.com/pingcap/br/issues/1221
lightning pre-check will print empty info when check skipped.
lightning may report a false-positive error when no-schema has deprecated.

### What is changed and how it works?
skip print check template when --check-requirements if false
remove unnecessary check in setup after no-schema is deprecated.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test



Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
