### PR TITLE
backup: fix ddl unmarshal error in meta v2

### DIFF
--- a/pkg/metautil/metafile.go
+++ b/pkg/metautil/metafile.go
@@ -42,12 +42,10 @@ const (
 	MetaFileSize = 128 * units.MiB
 )
 
-type metaVersion int32
-
 const (
 	// MetaV1 represents the old version of backupmeta.
 	// because the old version doesn't have version field, so set it to 0 for compatibility.
-	MetaV1 metaVersion = iota
+	MetaV1 = iota
 	// MetaV2 represents the new version of backupmeta.
 	MetaV2
 )

--- a/pkg/metautil/metafile.go
+++ b/pkg/metautil/metafile.go
@@ -106,7 +106,9 @@ func NewMetaReader(backpMeta *backuppb.BackupMeta, storage storage.ExternalStora
 
 func (reader *MetaReader) readDDLs(ctx context.Context, output func([]byte)) error {
 	// Read backupmeta v1 metafiles.
-	output(reader.backupMeta.Ddls)
+	if reader.backupMeta.DdlIndexes == nil {
+		output(reader.backupMeta.Ddls)
+	}
 	// Read backupmeta v2 metafiles.
 	outputFn := func(m *backuppb.MetaFile) {
 		for _, s := range m.Ddls {
@@ -148,7 +150,8 @@ func (reader *MetaReader) readDataFiles(ctx context.Context, output func(*backup
 // This function is compatible with the old backupmeta.
 func (reader *MetaReader) ReadDDLs(ctx context.Context) ([]byte, error) {
 	var err error
-	isV1Meta := len(reader.backupMeta.Ddls) != 0
+	// if we use v2 backupmeta, then ddlIndexes must not be nil.
+	isV1Meta := reader.backupMeta.DdlIndexes == nil
 
 	ch := make(chan interface{}, MaxBatchSize)
 	errCh := make(chan error)

--- a/pkg/metautil/metafile.go
+++ b/pkg/metautil/metafile.go
@@ -42,10 +42,12 @@ const (
 	MetaFileSize = 128 * units.MiB
 )
 
+type metaVersion int32
+
 const (
 	// MetaV1 represents the old version of backupmeta.
 	// because the old version doesn't have version field, so set it to 0 for compatibility.
-	MetaV1 = iota
+	MetaV1 metaVersion = iota
 	// MetaV2 represents the new version of backupmeta.
 	MetaV2
 )

--- a/pkg/restore/db_test.go
+++ b/pkg/restore/db_test.go
@@ -149,8 +149,8 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobs(c *C) {
 	mockMeta := &backuppb.BackupMeta{}
 	err = proto.Unmarshal(metaBytes, mockMeta)
 	c.Assert(err, IsNil)
-	// check the schema version, 0 means v1
-	c.Assert(mockMeta.Version, Equals, 0)
+	// check the schema version
+	c.Assert(mockMeta.Version, Equals, metautil.MetaV1)
 	metaReader := metautil.NewMetaReader(mockMeta, s.storage)
 	allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
 	c.Assert(err, IsNil)
@@ -206,7 +206,7 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobsV2(c *C) {
 	err = proto.Unmarshal(metaBytes, mockMeta)
 	c.Assert(err, IsNil)
 	// check the schema version
-	c.Assert(mockMeta.Version, Equals, 1)
+	c.Assert(mockMeta.Version, Equals, metautil.MetaV2)
 	metaReader := metautil.NewMetaReader(mockMeta, s.storage)
 	allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
 	c.Assert(err, IsNil)

--- a/pkg/restore/db_test.go
+++ b/pkg/restore/db_test.go
@@ -149,6 +149,8 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobs(c *C) {
 	mockMeta := &backuppb.BackupMeta{}
 	err = proto.Unmarshal(metaBytes, mockMeta)
 	c.Assert(err, IsNil)
+	// check the schema version
+	c.Assert(mockMeta.Version, Equals, 1)
 	metaReader := metautil.NewMetaReader(mockMeta, s.storage)
 	allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
 	c.Assert(err, IsNil)
@@ -203,6 +205,8 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobsV2(c *C) {
 	mockMeta := &backuppb.BackupMeta{}
 	err = proto.Unmarshal(metaBytes, mockMeta)
 	c.Assert(err, IsNil)
+	// check the schema version
+	c.Assert(mockMeta.Version, Equals, 2)
 	metaReader := metautil.NewMetaReader(mockMeta, s.storage)
 	allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
 	c.Assert(err, IsNil)

--- a/pkg/restore/db_test.go
+++ b/pkg/restore/db_test.go
@@ -150,7 +150,7 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobs(c *C) {
 	err = proto.Unmarshal(metaBytes, mockMeta)
 	c.Assert(err, IsNil)
 	// check the schema version
-	c.Assert(mockMeta.Version, Equals, metautil.MetaV1)
+	c.Assert(mockMeta.Version, Equals, int32(metautil.MetaV1))
 	metaReader := metautil.NewMetaReader(mockMeta, s.storage)
 	allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
 	c.Assert(err, IsNil)
@@ -206,7 +206,7 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobsV2(c *C) {
 	err = proto.Unmarshal(metaBytes, mockMeta)
 	c.Assert(err, IsNil)
 	// check the schema version
-	c.Assert(mockMeta.Version, Equals, metautil.MetaV2)
+	c.Assert(mockMeta.Version, Equals, int32(metautil.MetaV2))
 	metaReader := metautil.NewMetaReader(mockMeta, s.storage)
 	allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
 	c.Assert(err, IsNil)

--- a/pkg/restore/db_test.go
+++ b/pkg/restore/db_test.go
@@ -149,8 +149,8 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobs(c *C) {
 	mockMeta := &backuppb.BackupMeta{}
 	err = proto.Unmarshal(metaBytes, mockMeta)
 	c.Assert(err, IsNil)
-	// check the schema version
-	c.Assert(mockMeta.Version, Equals, 1)
+	// check the schema version, 0 means v1
+	c.Assert(mockMeta.Version, Equals, 0)
 	metaReader := metautil.NewMetaReader(mockMeta, s.storage)
 	allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
 	c.Assert(err, IsNil)
@@ -206,7 +206,7 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobsV2(c *C) {
 	err = proto.Unmarshal(metaBytes, mockMeta)
 	c.Assert(err, IsNil)
 	// check the schema version
-	c.Assert(mockMeta.Version, Equals, 2)
+	c.Assert(mockMeta.Version, Equals, 1)
 	metaReader := metautil.NewMetaReader(mockMeta, s.storage)
 	allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
solve https://github.com/pingcap/br/issues/1222
json unmarshal ddl bytes array failed, because we got an `[]` in reader.backupMeta.Ddls in v2 meta.

### What is changed and how it works?
use reader.backupMeta.DdlIndexes to determine whether we are use v1 or v2 meta.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

 - Fix the issue that incremental restore DDL failed when use meta v2 backups.

<!-- fill in the release note, or just write "No release note" -->
