### PR TITLE
cmd/br/debug.go: use br/pkg/mock/mockid instead of pd/pkg/mock/mockid

### DIFF
--- a/cmd/br/debug.go
+++ b/cmd/br/debug.go
@@ -20,11 +20,11 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/model"
 	"github.com/spf13/cobra"
-	"github.com/tikv/pd/pkg/mock/mockid"
 	"go.uber.org/zap"
 
 	berrors "github.com/pingcap/br/pkg/errors"
 	"github.com/pingcap/br/pkg/logutil"
+	"github.com/pingcap/br/pkg/mock/mockid"
 	"github.com/pingcap/br/pkg/restore"
 	"github.com/pingcap/br/pkg/rtree"
 	"github.com/pingcap/br/pkg/task"

--- a/pkg/mock/mockid/mockid.go
+++ b/pkg/mock/mockid/mockid.go
@@ -1,0 +1,36 @@
+// Copyright 2019 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockid
+
+import "sync/atomic"
+
+// IDAllocator mocks IDAllocator and it is only used for test.
+type IDAllocator struct {
+	base uint64
+}
+
+// NewIDAllocator creates a new IDAllocator.
+func NewIDAllocator() *IDAllocator {
+	return &IDAllocator{base: 0}
+}
+
+// Alloc returns a new id.
+func (alloc *IDAllocator) Alloc() (uint64, error) {
+	return atomic.AddUint64(&alloc.base, 1), nil
+}
+
+// Rebase implements the IDAllocator interface.
+func (alloc *IDAllocator) Rebase() error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR uses `github.com/pingcap/br/pkg/mock/mockid` instead of `github.com/tikv/pd/pkg/mock/mockid`. We want to use `github.com/tikv/pd/pd-client` only in the future, so we will try to remove the usage of 
`github.com/tikv/pd/XXX` except `pd-client` in br.

### Check List <!--REMOVE the items that are not applicable-->

 - Unit test



### Release Note

- No release note
