### PR TITLE
pkg/conn/conn_test: remove github.com/tikv/pd/server/core

### DIFF
--- a/pkg/conn/conn_test.go
+++ b/pkg/conn/conn_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	pd "github.com/tikv/pd/client"
-	"github.com/tikv/pd/server/core"
 )
 
 func TestT(t *testing.T) {
@@ -24,14 +23,12 @@ type testClientSuite struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	mgr     *Mgr
-	regions *core.RegionsInfo
+	mgr *Mgr
 }
 
 func (s *testClientSuite) SetUpSuite(c *C) {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.mgr = &Mgr{PdController: &pdutil.PdController{}}
-	s.regions = core.NewRegionsInfo()
 }
 
 func (s *testClientSuite) TearDownSuite(c *C) {


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR removes the usage of `github.com/tikv/pd/server/core` since we do not need it. We want to use `github.com/tikv/pd/pd-client` only in the future, so we will try to remove the usage of 
`github.com/tikv/pd/XXX` except `pd-client` in br.

### Check List <!--REMOVE the items that are not applicable-->

 - Unit test



### Release Note

- No release note
