### PR TITLE
test: reduce the time spent on test disk quota

### DIFF
--- a/tests/lightning_disk_quota/config.toml
+++ b/tests/lightning_disk_quota/config.toml
@@ -5,4 +5,4 @@ max-kv-pairs = 50
 local-writer-mem-cache-size = '75MB'
 
 [cron]
-check-disk-quota = '1s'
+check-disk-quota = '100ms'

--- a/tests/lightning_disk_quota/run.sh
+++ b/tests/lightning_disk_quota/run.sh
@@ -59,7 +59,7 @@ while [ ! -e "$FINISHED_FILE" ] && [ -e "$DISK_QUOTA_DIR" ]; do
     fi
 done &
 
-export GO_FAILPOINTS="github.com/pingcap/br/pkg/lightning/restore/SlowDownWriteRows=sleep(500)"
+export GO_FAILPOINTS="github.com/pingcap/br/pkg/lightning/restore/SlowDownWriteRows=sleep(50)"
 run_lightning --sorted-kv-dir "$DISK_QUOTA_DIR/sorted" --log-file "$TEST_DIR/lightning-disk-quota.log"
 touch "$FINISHED_FILE"
 # if $FINISHED_FILE has content, it is only because the hard disk quota is exceeded.


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Reduce the time spent on test disk quota, which is reduced from about 20 minutes to 3 minutes.

### What is changed and how it works?

Decrease sleep time in `SlowDownWriteRows` to 50 ms and  `check-disk-quota` in config file to 100ms.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test
 

Code changes

Side effects

Related changes

### Release note

No release note

<!-- fill in the release note, or just write "No release note" -->
