### PR TITLE
restore: fix [files lost] in log info

### DIFF
--- a/pkg/restore/client.go
+++ b/pkg/restore/client.go
@@ -611,7 +611,8 @@ func (rc *Client) RestoreFiles(
 	}
 
 	var rangeFiles []*backuppb.File
-	for rangeFiles, files = drainFilesByRange(files, rc.fileImporter.supportMultiIngest); len(rangeFiles) != 0; rangeFiles, files = drainFilesByRange(files, rc.fileImporter.supportMultiIngest) {
+	var leftFiles []*backuppb.File
+	for rangeFiles, leftFiles = drainFilesByRange(files, rc.fileImporter.supportMultiIngest); len(rangeFiles) != 0; rangeFiles, leftFiles = drainFilesByRange(leftFiles, rc.fileImporter.supportMultiIngest) {
 		filesReplica := rangeFiles
 		rc.workerPool.ApplyOnErrorGroup(eg,
 			func() error {

--- a/tests/lightning_checkpoint_engines_order/run.sh
+++ b/tests/lightning_checkpoint_engines_order/run.sh
@@ -22,6 +22,7 @@ for i in $(seq 5); do
     set -e
     # engine sorted kv dir name is 36 length (UUID4).
     [ $(ls -1q "$TEST_DIR/$TEST_NAME.sorted" | grep -E "^\S{36}$" |  wc -l) -eq 2 ]
+    ls -al "$TEST_DIR/$TEST_NAME.sorted"
 done
 
 # allow one file to be written at a time,
@@ -29,6 +30,7 @@ export GO_FAILPOINTS='github.com/pingcap/br/pkg/lightning/restore/FailAfterWrite
 
 # and now we should have 3 engines since one engine will be successfully imported.
 set +e
+ls -al "$TEST_DIR/$TEST_NAME.sorted"
 run_lightning --enable-checkpoint=1 2> /dev/null
 [ $? -ne 0 ] || exit 1
 set -e


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. files will be empty, which cause to log info print empty content.
https://github.com/pingcap/br/blob/f0c1eb5188549489440cb9ae2eb371883cc7dc87/pkg/restore/client.go#L594

2. `lightning_checkpoint_engine_order` : there is an engine cleaned up lead to count 2 other than 3 which failed.
https://ci.pingcap.net/blue/organizations/jenkins/br_ghpr_unit_and_integration_test/detail/br_ghpr_unit_and_integration_test/4877/pipeline/84/

### What is changed and how it works?

1. add temp variable

2. record all the existing engines into the file, and count the number of different engines

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note

 -No release note

<!-- fill in the release note, or just write "No release note" -->
