### PR TITLE
storage: fix noop writer to help dumpling to do some tests

### DIFF
--- a/pkg/storage/noop.go
+++ b/pkg/storage/noop.go
@@ -39,7 +39,7 @@ func (s *noopStorage) URI() string {
 
 // Create implements ExternalStorage interface.
 func (*noopStorage) Create(ctx context.Context, name string) (ExternalFileWriter, error) {
-	panic("noop storage not support multi-upload")
+	return &noopWriter{}, nil
 }
 
 func newNoopStorage() *noopStorage {
@@ -49,7 +49,7 @@ func newNoopStorage() *noopStorage {
 type noopReader struct{}
 
 func (noopReader) Read(p []byte) (n int, err error) {
-	return 0, nil
+	return len(p), nil
 }
 
 func (noopReader) Close() error {
@@ -57,5 +57,15 @@ func (noopReader) Close() error {
 }
 
 func (noopReader) Seek(offset int64, whence int) (int64, error) {
-	return 0, nil
+	return offset, nil
+}
+
+type noopWriter struct{}
+
+func (noopWriter) Write(ctx context.Context, p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (noopWriter) Close(ctx context.Context) error {
+	return nil
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When dumpling specify a noop uri, dumpling will panic.

### What is changed and how it works?
Fix noop storage structures.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

### Release note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
