### PR TITLE
tests: fix br_tikv_outage learner bug

### DIFF
--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -58,7 +58,7 @@ hint_finegrained=$TEST_DIR/hint_finegrained
 hint_backup_start=$TEST_DIR/hint_backup_start
 hint_get_backup_client=$TEST_DIR/hint_get_backup_client
 
-# NOTE : cases `outage-at-finegrained shutdown scale-out` should be former to avoid issue
+# NOTE : cases `outage-at-finegrained shutdown scale-out` should be first to avoid issue
 #       https://github.com/pingcap/br/issues/1050
 cases=${cases:-'outage-at-finegrained shutdown scale-out outage outage-after-request'}
 

--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -58,7 +58,8 @@ hint_finegrained=$TEST_DIR/hint_finegrained
 hint_backup_start=$TEST_DIR/hint_backup_start
 hint_get_backup_client=$TEST_DIR/hint_get_backup_client
 
-
+# NOTE : cases `outage-at-finegrained shutdown` should be former to avoid issue
+#       https://github.com/pingcap/br/issues/1050
 cases=${cases:-'outage-at-finegrained shutdown scale-out outage outage-after-request'}
 
 for failure in $cases; do

--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -59,7 +59,7 @@ hint_backup_start=$TEST_DIR/hint_backup_start
 hint_get_backup_client=$TEST_DIR/hint_get_backup_client
 
 
-cases=${cases:-'outage outage-after-request outage-at-finegrained shutdown scale-out'}
+cases=${cases:-'outage-at-finegrained shutdown scale-out outage outage-after-request'}
 
 for failure in $cases; do
     rm -f "$hint_finegrained" "$hint_backup_start" "$hint_get_backup_client"

--- a/tests/br_tikv_outage/run.sh
+++ b/tests/br_tikv_outage/run.sh
@@ -58,7 +58,7 @@ hint_finegrained=$TEST_DIR/hint_finegrained
 hint_backup_start=$TEST_DIR/hint_backup_start
 hint_get_backup_client=$TEST_DIR/hint_get_backup_client
 
-# NOTE : cases `outage-at-finegrained shutdown` should be former to avoid issue
+# NOTE : cases `outage-at-finegrained shutdown scale-out` should be former to avoid issue
 #       https://github.com/pingcap/br/issues/1050
 cases=${cases:-'outage-at-finegrained shutdown scale-out outage outage-after-request'}
 


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix issue #1050 
In the case `outage-after-request`, there is a voter peer on tikv1 removed, and then a learner peer on tikv1 added.
But then quickly in the next case `outage-at-finegrained` (don't restart tikv while doing backup), tikv3 is killed.
So there is only 1 peer and 1 learner for region 257, lead to test got stuck.

### What is changed and how it works?

It seems the case `outage-after-request` have a bad influence on the next case, so this PR try to exchange the sequence of these cases.

### Check List <!--REMOVE the items that are not applicable-->
Related changes

 - Need to cherry-pick to the release branch

### Release note

 -No release note

<!-- fill in the release note, or just write "No release note" -->
