### PR TITLE
lightning: make `tikv-importer.backend` required

### DIFF
--- a/pkg/lightning/checkpoints/checkpoints_file_test.go
+++ b/pkg/lightning/checkpoints/checkpoints_file_test.go
@@ -31,6 +31,7 @@ func newTestConfig() *config.Config {
 	cfg.TaskID = 123
 	cfg.TiDB.Port = 4000
 	cfg.TiDB.PdAddr = "127.0.0.1:2379"
+	cfg.TikvImporter.Backend = config.BackendLocal
 	cfg.TikvImporter.Addr = "127.0.0.1:8287"
 	cfg.TikvImporter.SortedKVDir = "/tmp/sorted-kv"
 	return cfg

--- a/pkg/lightning/checkpoints/checkpoints_sql_test.go
+++ b/pkg/lightning/checkpoints/checkpoints_sql_test.go
@@ -69,7 +69,7 @@ func (s *cpSQLSuite) TestNormalOperations(c *C) {
 	initializeStmt := s.mock.ExpectPrepare(
 		"REPLACE INTO `mock-schema`\\.task_v\\d+")
 	initializeStmt.ExpectExec().
-		WithArgs(123, "/data", "importer", "127.0.0.1:8287", "127.0.0.1", 4000, "127.0.0.1:2379", "/tmp/sorted-kv", build.ReleaseVersion).
+		WithArgs(123, "/data", "local", "127.0.0.1:8287", "127.0.0.1", 4000, "127.0.0.1:2379", "/tmp/sorted-kv", build.ReleaseVersion).
 		WillReturnResult(sqlmock.NewResult(6, 1))
 	initializeStmt = s.mock.
 		ExpectPrepare("INSERT INTO `mock-schema`\\.table_v\\d+")

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -421,7 +421,7 @@ func NewConfig() *Config {
 			Filter:        DefaultFilter,
 		},
 		TikvImporter: TikvImporter{
-			Backend:         BackendImporter,
+			Backend:         "",
 			OnDuplicate:     ReplaceOnDup,
 			MaxKVPairs:      4096,
 			SendKVPairs:     32768,
@@ -563,6 +563,9 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 		cfg.Mydumper.DefaultFileRules = true
 	}
 
+	if cfg.TikvImporter.Backend == "" {
+		return errors.New("tikv-importer.backend must not be empty!")
+	}
 	cfg.TikvImporter.Backend = strings.ToLower(cfg.TikvImporter.Backend)
 	mustHaveInternalConnections := true
 	switch cfg.TikvImporter.Backend {

--- a/pkg/lightning/config/global.go
+++ b/pkg/lightning/config/global.go
@@ -104,7 +104,7 @@ func NewGlobalConfig() *GlobalConfig {
 			Filter: DefaultFilter,
 		},
 		TikvImporter: GlobalImporter{
-			Backend: "importer",
+			Backend: "",
 		},
 		PostRestore: GlobalPostRestore{
 			Checksum: OpLevelRequired,
@@ -154,7 +154,7 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	pdAddr := fs.String("pd-urls", "", "PD endpoint address")
 	dataSrcPath := fs.String("d", "", "Directory of the dump to import")
 	importerAddr := fs.String("importer", "", "address (host:port) to connect to tikv-importer")
-	backend := flagext.ChoiceVar(fs, "backend", "", `delivery backend: importer, tidb, local (default importer)`, "", "importer", "tidb", "local")
+	backend := flagext.ChoiceVar(fs, "backend", "", `delivery backend: local, importer, tidb`, "", "local", "importer", "tidb")
 	sortedKVDir := fs.String("sorted-kv-dir", "", "path for KV pairs when local backend enabled")
 	enableCheckpoint := fs.Bool("enable-checkpoint", true, "whether to enable checkpoints")
 	noSchema := fs.Bool("no-schema", false, "ignore schema files, get schema directly from TiDB instead")

--- a/pkg/lightning/lightning_test.go
+++ b/pkg/lightning/lightning_test.go
@@ -63,6 +63,8 @@ func (s *lightningSuite) TestRun(c *C) {
 	globalConfig.TiDB.Port = 4000
 	globalConfig.TiDB.PdAddr = "test.invalid:2379"
 	globalConfig.Mydumper.SourceDir = "not-exists"
+	globalConfig.TikvImporter.Backend = config.BackendLocal
+	globalConfig.TikvImporter.SortedKVDir = c.MkDir()
 	lightning := New(globalConfig)
 	cfg := config.NewConfig()
 	err := cfg.LoadFromGlobal(globalConfig)
@@ -115,6 +117,8 @@ func (s *lightningServerSuite) SetUpTest(c *C) {
 	cfg.App.ServerMode = true
 	cfg.App.StatusAddr = "127.0.0.1:0"
 	cfg.Mydumper.SourceDir = "file://."
+	cfg.TikvImporter.Backend = config.BackendLocal
+	cfg.TikvImporter.SortedKVDir = c.MkDir()
 
 	s.lightning = New(cfg)
 	s.taskCfgCh = make(chan *config.Config)

--- a/pkg/lightning/restore/restore_test.go
+++ b/pkg/lightning/restore/restore_test.go
@@ -155,6 +155,7 @@ func (s *restoreSuite) TestVerifyCheckpoint(c *C) {
 		cfg.TaskID = 123
 		cfg.TiDB.Port = 4000
 		cfg.TiDB.PdAddr = "127.0.0.1:2379"
+		cfg.TikvImporter.Backend = config.BackendImporter
 		cfg.TikvImporter.Addr = "127.0.0.1:8287"
 		cfg.TikvImporter.SortedKVDir = "/tmp/sorted-kv"
 
@@ -166,7 +167,7 @@ func (s *restoreSuite) TestVerifyCheckpoint(c *C) {
 
 	adjustFuncs := map[string]func(cfg *config.Config){
 		"tikv-importer.backend": func(cfg *config.Config) {
-			cfg.TikvImporter.Backend = "local"
+			cfg.TikvImporter.Backend = config.BackendLocal
 		},
 		"tikv-importer.addr": func(cfg *config.Config) {
 			cfg.TikvImporter.Addr = "128.0.0.1:8287"
@@ -923,6 +924,7 @@ func (s *tableRestoreSuite) TestTableRestoreMetrics(c *C) {
 
 	cfg.Mydumper.SourceDir = "."
 	cfg.Mydumper.CSV.Header = false
+	cfg.TikvImporter.Backend = config.BackendImporter
 	tls, err := cfg.ToTLS()
 	c.Assert(err, IsNil)
 

--- a/tests/_utils/run_lightning
+++ b/tests/_utils/run_lightning
@@ -25,6 +25,7 @@ bin/tidb-lightning.test -test.coverprofile="$TEST_DIR/cov.$TEST_NAME.$$.out" DEV
     --pd-urls '127.0.0.1:2379' \
     --config "tests/$TEST_NAME/config.toml" \
     -d "tests/$TEST_NAME/data" \
+    --backend 'local' \
     --importer '127.0.0.1:8808' \
     --sorted-kv-dir "$TEST_DIR/$TEST_NAME.sorted" \
     --enable-checkpoint=0 \

--- a/tests/_utils/run_lightning
+++ b/tests/_utils/run_lightning
@@ -25,7 +25,7 @@ bin/tidb-lightning.test -test.coverprofile="$TEST_DIR/cov.$TEST_NAME.$$.out" DEV
     --pd-urls '127.0.0.1:2379' \
     --config "tests/$TEST_NAME/config.toml" \
     -d "tests/$TEST_NAME/data" \
-    --backend 'local' \
+    --backend 'importer' \
     --importer '127.0.0.1:8808' \
     --sorted-kv-dir "$TEST_DIR/$TEST_NAME.sorted" \
     --enable-checkpoint=0 \

--- a/tests/_utils/run_lightning
+++ b/tests/_utils/run_lightning
@@ -25,7 +25,6 @@ bin/tidb-lightning.test -test.coverprofile="$TEST_DIR/cov.$TEST_NAME.$$.out" DEV
     --pd-urls '127.0.0.1:2379' \
     --config "tests/$TEST_NAME/config.toml" \
     -d "tests/$TEST_NAME/data" \
-    --backend 'importer' \
     --importer '127.0.0.1:8808' \
     --sorted-kv-dir "$TEST_DIR/$TEST_NAME.sorted" \
     --enable-checkpoint=0 \

--- a/tests/_utils/run_lightning_ctl
+++ b/tests/_utils/run_lightning_ctl
@@ -23,6 +23,7 @@ bin/tidb-lightning-ctl.test -test.coverprofile="$TEST_DIR/cov.ctl.$TEST_NAME.$$.
     --tidb-port 4000 \
     --pd-urls '127.0.0.1:2379' \
     -d "tests/$TEST_NAME/data" \
+    --backend 'local' \
     --importer '127.0.0.1:8808' \
     --sorted-kv-dir "$TEST_DIR/sorted" \
     --enable-checkpoint=0 \

--- a/tests/_utils/run_lightning_ctl
+++ b/tests/_utils/run_lightning_ctl
@@ -23,7 +23,7 @@ bin/tidb-lightning-ctl.test -test.coverprofile="$TEST_DIR/cov.ctl.$TEST_NAME.$$.
     --tidb-port 4000 \
     --pd-urls '127.0.0.1:2379' \
     -d "tests/$TEST_NAME/data" \
-    --backend 'local' \
+    --backend 'importer' \
     --importer '127.0.0.1:8808' \
     --sorted-kv-dir "$TEST_DIR/sorted" \
     --enable-checkpoint=0 \

--- a/tests/_utils/run_lightning_ctl
+++ b/tests/_utils/run_lightning_ctl
@@ -23,7 +23,6 @@ bin/tidb-lightning-ctl.test -test.coverprofile="$TEST_DIR/cov.ctl.$TEST_NAME.$$.
     --tidb-port 4000 \
     --pd-urls '127.0.0.1:2379' \
     -d "tests/$TEST_NAME/data" \
-    --backend 'importer' \
     --importer '127.0.0.1:8808' \
     --sorted-kv-dir "$TEST_DIR/sorted" \
     --enable-checkpoint=0 \

--- a/tests/lightning_black-white-list/config.toml
+++ b/tests/lightning_black-white-list/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+backend = "local"

--- a/tests/lightning_black-white-list/even-table-only.toml
+++ b/tests/lightning_black-white-list/even-table-only.toml
@@ -1,3 +1,6 @@
+[tikv-importer]
+backend = "local"
+
 [[black-white-list.ignore-tables]]
 db-name = "firstdb"
 tbl-name = "~."

--- a/tests/lightning_black-white-list/firstdb-only.toml
+++ b/tests/lightning_black-white-list/firstdb-only.toml
@@ -1,2 +1,5 @@
+[tikv-importer]
+backend = "local"
+
 [black-white-list]
 do-dbs = ["~^f"]

--- a/tests/lightning_character_sets/auto.toml
+++ b/tests/lightning_character_sets/auto.toml
@@ -1,5 +1,8 @@
 [lightning]
 table-concurrency = 1
 
+[tikv-importer]
+backend = "local"
+
 [mydumper]
 character-set = "auto"

--- a/tests/lightning_character_sets/binary.toml
+++ b/tests/lightning_character_sets/binary.toml
@@ -1,5 +1,8 @@
 [lightning]
 table-concurrency = 1
 
+[tikv-importer]
+backend = "local"
+
 [mydumper]
 character-set = "binary"

--- a/tests/lightning_character_sets/gb18030.toml
+++ b/tests/lightning_character_sets/gb18030.toml
@@ -1,5 +1,8 @@
 [lightning]
 table-concurrency = 1
 
+[tikv-importer]
+backend = "local"
+
 [mydumper]
 character-set = "gb18030"

--- a/tests/lightning_character_sets/utf8mb4.toml
+++ b/tests/lightning_character_sets/utf8mb4.toml
@@ -1,5 +1,8 @@
 [lightning]
 table-concurrency = 1
 
+[tikv-importer]
+backend = "local"
+
 [mydumper]
 character-set = "utf8mb4"

--- a/tests/lightning_checkpoint_chunks/config.toml
+++ b/tests/lightning_checkpoint_chunks/config.toml
@@ -2,7 +2,7 @@
 region-concurrency = 1
 
 [tikv-importer]
-backend = "local"
+backend = "importer"
 
 [checkpoint]
 enable = true

--- a/tests/lightning_checkpoint_chunks/config.toml
+++ b/tests/lightning_checkpoint_chunks/config.toml
@@ -1,6 +1,9 @@
 [lightning]
 region-concurrency = 1
 
+[tikv-importer]
+backend = "local"
+
 [checkpoint]
 enable = true
 schema = "tidb_lightning_checkpoint_test_cpch"

--- a/tests/lightning_checkpoint_chunks/file.toml
+++ b/tests/lightning_checkpoint_chunks/file.toml
@@ -2,7 +2,7 @@
 region-concurrency = 1
 
 [tikv-importer]
-backend = "local"
+backend = "importer"
 
 [checkpoint]
 enable = true

--- a/tests/lightning_checkpoint_chunks/file.toml
+++ b/tests/lightning_checkpoint_chunks/file.toml
@@ -1,6 +1,9 @@
 [lightning]
 region-concurrency = 1
 
+[tikv-importer]
+backend = "local"
+
 [checkpoint]
 enable = true
 schema = "tidb_lightning_checkpoint_test_cpch"

--- a/tests/lightning_checkpoint_dirty_tableid/file.toml
+++ b/tests/lightning_checkpoint_dirty_tableid/file.toml
@@ -1,3 +1,6 @@
+[tikv-importer]
+backend = "local"
+
 [checkpoint]
 enable = true
 driver = "file"

--- a/tests/lightning_checkpoint_dirty_tableid/mysql.toml
+++ b/tests/lightning_checkpoint_dirty_tableid/mysql.toml
@@ -1,3 +1,6 @@
+[tikv-importer]
+backend = "local"
+
 [checkpoint]
 enable = true
 driver = "mysql"

--- a/tests/lightning_checkpoint_error_destroy/file.toml
+++ b/tests/lightning_checkpoint_error_destroy/file.toml
@@ -3,5 +3,8 @@ enable = true
 driver = "file"
 dsn = "/tmp/cp_error_destroy.pb"
 
+[tikv-importer]
+backend = "local"
+
 [tidb]
 sql-mode = 'STRICT_ALL_TABLES'

--- a/tests/lightning_checkpoint_error_destroy/mysql.toml
+++ b/tests/lightning_checkpoint_error_destroy/mysql.toml
@@ -2,5 +2,8 @@
 enable = true
 driver = "mysql"
 
+[tikv-importer]
+backend = "local"
+
 [tidb]
 sql-mode = 'STRICT_ALL_TABLES'

--- a/tests/lightning_checkpoint_timestamp/config.toml
+++ b/tests/lightning_checkpoint_timestamp/config.toml
@@ -7,5 +7,8 @@ schema = "tidb_lightning_checkpoint_timestamp"
 driver = "file"
 dsn = "/tmp/backup_restore_test/cpts.pb"
 
+[tikv-importer]
+backend = "local"
+
 [mydumper]
 read-block-size = 1

--- a/tests/lightning_checkpoint_timestamp/config.toml
+++ b/tests/lightning_checkpoint_timestamp/config.toml
@@ -8,7 +8,7 @@ driver = "file"
 dsn = "/tmp/backup_restore_test/cpts.pb"
 
 [tikv-importer]
-backend = "local"
+backend = "importer"
 
 [mydumper]
 read-block-size = 1

--- a/tests/lightning_checkpoint_timestamp/mysql.toml
+++ b/tests/lightning_checkpoint_timestamp/mysql.toml
@@ -8,7 +8,7 @@ driver = "mysql"
 keep-after-success = true
 
 [tikv-importer]
-backend = "local"
+backend = "importer"
 
 [mydumper]
 read-block-size = 1

--- a/tests/lightning_checkpoint_timestamp/mysql.toml
+++ b/tests/lightning_checkpoint_timestamp/mysql.toml
@@ -7,5 +7,8 @@ schema = "tidb_lightning_checkpoint_timestamp"
 driver = "mysql"
 keep-after-success = true
 
+[tikv-importer]
+backend = "local"
+
 [mydumper]
 read-block-size = 1

--- a/tests/lightning_cmdline_override/run.sh
+++ b/tests/lightning_cmdline_override/run.sh
@@ -11,6 +11,7 @@ run_lightning \
     --tidb-status 10080 \
     --pd-urls 127.0.0.1:2379 \
     -d "tests/$TEST_NAME/data" \
+    --backend 'importer' \
     --importer 127.0.0.1:8808
 
 run_sql 'SELECT * FROM cmdline_override.t'

--- a/tests/lightning_concurrent-restore/config.toml
+++ b/tests/lightning_concurrent-restore/config.toml
@@ -1,3 +1,6 @@
 [lightning]
 table-concurrency = 4
 index-concurrency = 4
+
+[tikv-importer]
+backend = "local"

--- a/tests/lightning_default-columns/config.toml
+++ b/tests/lightning_default-columns/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+backend = "local"

--- a/tests/lightning_error_summary/config.toml
+++ b/tests/lightning_error_summary/config.toml
@@ -2,3 +2,6 @@
 enable = true
 schema = "tidb_lightning_checkpoint_error_summary"
 driver = "mysql"
+
+[tikv-importer]
+backend = 'local'

--- a/tests/lightning_examples/1.toml
+++ b/tests/lightning_examples/1.toml
@@ -2,5 +2,8 @@
 table-concurrency = 1
 level = "warning"
 
+[tikv-importer]
+backend = 'local'
+
 [mydumper]
 read-block-size = 1

--- a/tests/lightning_examples/131072.toml
+++ b/tests/lightning_examples/131072.toml
@@ -2,5 +2,8 @@
 table-concurrency = 1
 level = "warning"
 
+[tikv-importer]
+backend = 'local'
+
 [mydumper]
 read-block-size = 131072

--- a/tests/lightning_examples/512.toml
+++ b/tests/lightning_examples/512.toml
@@ -2,5 +2,8 @@
 table-concurrency = 1
 level = "warning"
 
+[tikv-importer]
+backend = 'local'
+
 [mydumper]
 read-block-size = 512

--- a/tests/lightning_exotic_filenames/config.toml
+++ b/tests/lightning_exotic_filenames/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+backend = 'local'

--- a/tests/lightning_no_schema/config.toml
+++ b/tests/lightning_no_schema/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+backend = 'local'

--- a/tests/lightning_restore/config.toml
+++ b/tests/lightning_restore/config.toml
@@ -1,2 +1,5 @@
 [lightning]
 table-concurrency = 4
+
+[tikv-importer]
+backend = 'local'

--- a/tests/lightning_routes/config.toml
+++ b/tests/lightning_routes/config.toml
@@ -1,3 +1,6 @@
+[tikv-importer]
+backend = 'local'
+
 # the complicated routing rules should be tested in tidb-tools repo already
 # here we're just verifying the basic things do work.
 [[routes]]

--- a/tests/lightning_row-format-v2/config.toml
+++ b/tests/lightning_row-format-v2/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+backend = 'local'

--- a/tests/lightning_sqlmode/off.toml
+++ b/tests/lightning_sqlmode/off.toml
@@ -1,2 +1,5 @@
+[tikv-importer]
+backend = 'local'
+
 [tidb]
 sql-mode = 'ALLOW_INVALID_DATES'

--- a/tests/lightning_sqlmode/on.toml
+++ b/tests/lightning_sqlmode/on.toml
@@ -1,2 +1,5 @@
+[tikv-importer]
+backend = 'local'
+
 [tidb]
 sql-mode = 'STRICT_TRANS_TABLES'

--- a/tests/lightning_tool_135/config.toml
+++ b/tests/lightning_tool_135/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+backend = 'local'

--- a/tests/lightning_tool_1420/config.toml
+++ b/tests/lightning_tool_1420/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+backend = 'local'

--- a/tests/lightning_tool_1472/config.toml
+++ b/tests/lightning_tool_1472/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+backend = 'local'

--- a/tests/lightning_tool_241/config.toml
+++ b/tests/lightning_tool_241/config.toml
@@ -1,5 +1,8 @@
 [lightning]
 table-concurrency = 3
 
+[tikv-importer]
+backend = 'local'
+
 [tidb]
 sql-mode = ''


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Make lightning's `tikv-importer.backend` required.

### What is changed and how it works?

Remove the default backend setting from the configuration and make `tikv-importer.backend` required.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

 - lightning: make tikv-importer.backend required

<!-- fill in the release note, or just write "No release note" -->
