### PR TITLE
*: remove deprecated io/ioutil

### DIFF
--- a/pkg/lightning/checkpoints/checkpoints.go
+++ b/pkg/lightning/checkpoints/checkpoints.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"sort"
@@ -954,7 +953,7 @@ func NewFileCheckpointsDB(path string) *FileCheckpointsDB {
 		},
 	}
 	// ignore all errors -- file maybe not created yet (and it is fine).
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err == nil {
 		err2 := cpdb.checkpoints.Unmarshal(content)
 		if err2 != nil {
@@ -989,10 +988,10 @@ func (cpdb *FileCheckpointsDB) save() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// because `ioutil.WriteFile` is not atomic, directly write into it may reset the file
+	// because `os.WriteFile` is not atomic, directly write into it may reset the file
 	// to an empty file if write is not finished.
 	tmpPath := cpdb.path + ".tmp"
-	if err := ioutil.WriteFile(tmpPath, serialized, 0o644); err != nil {
+	if err := os.WriteFile(tmpPath, serialized, 0o644); err != nil {
 		return errors.Trace(err)
 	}
 	if err := os.Rename(tmpPath, cpdb.path); err != nil {

--- a/pkg/lightning/common/security.go
+++ b/pkg/lightning/common/security.go
@@ -17,10 +17,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 
 	"github.com/pingcap/errors"
 	pd "github.com/tikv/pd/client"
@@ -61,7 +61,7 @@ func ToTLSConfig(caPath, certPath, keyPath string) (*tls.Config, error) {
 
 	// Create a certificate pool from CA
 	certPool := x509.NewCertPool()
-	ca, err := ioutil.ReadFile(caPath)
+	ca, err := os.ReadFile(caPath)
 	if err != nil {
 		return nil, errors.Annotate(err, "could not read ca certificate")
 	}

--- a/pkg/lightning/common/security_test.go
+++ b/pkg/lightning/common/security_test.go
@@ -16,10 +16,10 @@ package common_test
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	. "github.com/pingcap/check"
@@ -80,7 +80,7 @@ func (s *securitySuite) TestInvalidTLS(c *C) {
 	_, err := common.NewTLS(caPath, "", "", "localhost")
 	c.Assert(err, ErrorMatches, "could not read ca certificate:.*")
 
-	err = ioutil.WriteFile(caPath, []byte("invalid ca content"), 0o644)
+	err = os.WriteFile(caPath, []byte("invalid ca content"), 0o644)
 	c.Assert(err, IsNil)
 	_, err = common.NewTLS(caPath, "", "", "localhost")
 	c.Assert(err, ErrorMatches, "failed to append ca certs")
@@ -90,9 +90,9 @@ func (s *securitySuite) TestInvalidTLS(c *C) {
 	_, err = common.NewTLS(caPath, certPath, keyPath, "localhost")
 	c.Assert(err, ErrorMatches, "could not load client key pair: open.*")
 
-	err = ioutil.WriteFile(certPath, []byte("invalid cert content"), 0o644)
+	err = os.WriteFile(certPath, []byte("invalid cert content"), 0o644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(keyPath, []byte("invalid key content"), 0o600)
+	err = os.WriteFile(keyPath, []byte("invalid key content"), 0o600)
 	c.Assert(err, IsNil)
 	_, err = common.NewTLS(caPath, certPath, keyPath, "localhost")
 	c.Assert(err, ErrorMatches, "could not load client key pair: tls.*")

--- a/pkg/lightning/common/util.go
+++ b/pkg/lightning/common/util.go
@@ -20,7 +20,6 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -92,7 +91,7 @@ func IsDirExists(name string) bool {
 
 // IsEmptyDir checks if dir is empty.
 func IsEmptyDir(name string) bool {
-	entries, err := ioutil.ReadDir(name)
+	entries, err := os.ReadDir(name)
 	if err != nil {
 		return false
 	}
@@ -345,7 +344,7 @@ func GetJSON(ctx context.Context, client *http.Client, url string, v interface{}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/lightning/config/global.go
+++ b/pkg/lightning/config/global.go
@@ -16,7 +16,6 @@ package config
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -185,7 +184,7 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	}
 
 	if len(configFilePath) > 0 {
-		data, err := ioutil.ReadFile(configFilePath)
+		data, err := os.ReadFile(configFilePath)
 		if err != nil {
 			return nil, errors.Annotatef(err, "Cannot read config file `%s`", configFilePath)
 		}

--- a/pkg/lightning/lightning.go
+++ b/pkg/lightning/lightning.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -122,7 +121,7 @@ func (l *Lightning) GoServe() error {
 	if len(statusAddr) == 0 {
 		return nil
 	}
-	return l.goServe(statusAddr, ioutil.Discard)
+	return l.goServe(statusAddr, io.Discard)
 }
 
 func (l *Lightning) goServe(statusAddr string, realAddrWriter io.Writer) error {
@@ -449,7 +448,7 @@ func (l *Lightning) handlePostTask(w http.ResponseWriter, req *http.Request) {
 		ID int64 `json:"id"`
 	}
 
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "cannot read request", err)
 		return

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -15,7 +15,6 @@ package mydump_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -64,7 +63,7 @@ func (s *testMydumpLoaderSuite) touch(c *C, filename ...string) {
 	components = append(components, s.sourceDir)
 	components = append(components, filename...)
 	path := filepath.Join(components...)
-	err := ioutil.WriteFile(path, nil, 0o644)
+	err := os.WriteFile(path, nil, 0o644)
 	c.Assert(err, IsNil)
 }
 
@@ -138,9 +137,9 @@ func (s *testMydumpLoaderSuite) TestTableNoHostDB(c *C) {
 	*/
 
 	dir := s.sourceDir
-	err := ioutil.WriteFile(filepath.Join(dir, "notdb-schema-create.sql"), nil, 0o644)
+	err := os.WriteFile(filepath.Join(dir, "notdb-schema-create.sql"), nil, 0o644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(dir, "db.tbl-schema.sql"), nil, 0o644)
+	err = os.WriteFile(filepath.Join(dir, "db.tbl-schema.sql"), nil, 0o644)
 	c.Assert(err, IsNil)
 
 	_, err = md.NewMyDumpLoader(context.Background(), s.cfg)
@@ -267,7 +266,7 @@ func (s *testMydumpLoaderSuite) TestViewNoHostTable(c *C) {
 func (s *testMydumpLoaderSuite) TestDataWithoutSchema(c *C) {
 	dir := s.sourceDir
 	p := filepath.Join(dir, "db.tbl.sql")
-	err := ioutil.WriteFile(p, nil, 0o644)
+	err := os.WriteFile(p, nil, 0o644)
 	c.Assert(err, IsNil)
 
 	mdl, err := md.NewMyDumpLoader(context.Background(), s.cfg)

--- a/pkg/lightning/mydump/reader_test.go
+++ b/pkg/lightning/mydump/reader_test.go
@@ -16,7 +16,6 @@ package mydump_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 
 	mockstorage "github.com/pingcap/br/pkg/mock/storage"
@@ -37,7 +36,7 @@ func (s *testMydumpReaderSuite) TearDownSuite(c *C) {}
 
 func (s *testMydumpReaderSuite) TestExportStatementNoTrailingNewLine(c *C) {
 	dir := c.MkDir()
-	file, err := ioutil.TempFile(dir, "tidb_lightning_test_reader")
+	file, err := os.CreateTemp(dir, "tidb_lightning_test_reader")
 	c.Assert(err, IsNil)
 	defer os.Remove(file.Name())
 
@@ -84,7 +83,7 @@ func (s *testMydumpReaderSuite) TestExportStatementWithCommentNoTrailingNewLine(
 
 func (s *testMydumpReaderSuite) exportStatmentShouldBe(c *C, stmt string, expected string) {
 	dir := c.MkDir()
-	file, err := ioutil.TempFile(dir, "tidb_lightning_test_reader")
+	file, err := os.CreateTemp(dir, "tidb_lightning_test_reader")
 	c.Assert(err, IsNil)
 	defer os.Remove(file.Name())
 
@@ -105,7 +104,7 @@ func (s *testMydumpReaderSuite) exportStatmentShouldBe(c *C, stmt string, expect
 
 func (s *testMydumpReaderSuite) TestExportStatementGBK(c *C) {
 	dir := c.MkDir()
-	file, err := ioutil.TempFile(dir, "tidb_lightning_test_reader")
+	file, err := os.CreateTemp(dir, "tidb_lightning_test_reader")
 	c.Assert(err, IsNil)
 	defer os.Remove(file.Name())
 
@@ -131,7 +130,7 @@ func (s *testMydumpReaderSuite) TestExportStatementGBK(c *C) {
 
 func (s *testMydumpReaderSuite) TestExportStatementGibberishError(c *C) {
 	dir := c.MkDir()
-	file, err := ioutil.TempFile(dir, "tidb_lightning_test_reader")
+	file, err := os.CreateTemp(dir, "tidb_lightning_test_reader")
 	c.Assert(err, IsNil)
 	defer os.Remove(file.Name())
 

--- a/pkg/lightning/mydump/reader_test.go
+++ b/pkg/lightning/mydump/reader_test.go
@@ -84,7 +84,7 @@ func (s *testMydumpReaderSuite) TestExportStatementWithCommentNoTrailingNewLine(
 
 func (s *testMydumpReaderSuite) exportStatmentShouldBe(c *C, stmt string, expected string) {
 	dir := c.MkDir()
-	file, err := os.CreateTemp(dir, "tidb_lightning_test_reader")
+	file, err := os.Create(filepath.Join(dir, "tidb_lightning_test_reader"))
 	c.Assert(err, IsNil)
 	defer os.Remove(file.Name())
 
@@ -105,7 +105,7 @@ func (s *testMydumpReaderSuite) exportStatmentShouldBe(c *C, stmt string, expect
 
 func (s *testMydumpReaderSuite) TestExportStatementGBK(c *C) {
 	dir := c.MkDir()
-	file, err := os.CreateTemp(dir, "tidb_lightning_test_reader")
+	file, err := os.Create(filepath.Join(dir, "tidb_lightning_test_reader"))
 	c.Assert(err, IsNil)
 	defer os.Remove(file.Name())
 
@@ -131,7 +131,7 @@ func (s *testMydumpReaderSuite) TestExportStatementGBK(c *C) {
 
 func (s *testMydumpReaderSuite) TestExportStatementGibberishError(c *C) {
 	dir := c.MkDir()
-	file, err := os.CreateTemp(dir, "tidb_lightning_test_reader")
+	file, err := os.Create(filepath.Join(dir, "tidb_lightning_test_reader"))
 	c.Assert(err, IsNil)
 	defer os.Remove(file.Name())
 

--- a/pkg/lightning/mydump/reader_test.go
+++ b/pkg/lightning/mydump/reader_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 
 	mockstorage "github.com/pingcap/br/pkg/mock/storage"
 
@@ -36,7 +37,7 @@ func (s *testMydumpReaderSuite) TearDownSuite(c *C) {}
 
 func (s *testMydumpReaderSuite) TestExportStatementNoTrailingNewLine(c *C) {
 	dir := c.MkDir()
-	file, err := os.CreateTemp(dir, "tidb_lightning_test_reader")
+	file, err := os.Create(filepath.Join(dir, "tidb_lightning_test_reader"))
 	c.Assert(err, IsNil)
 	defer os.Remove(file.Name())
 

--- a/pkg/lightning/mydump/region_test.go
+++ b/pkg/lightning/mydump/region_test.go
@@ -15,7 +15,6 @@ package mydump_test
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -263,7 +262,7 @@ func (s *testMydumpRegionSuite) TestSplitLargeFileNoNewLine(c *C) {
 	filePath := filepath.Join(dir, fileName)
 
 	content := []byte("a,b\r\n123,456\r\n789,101")
-	err := ioutil.WriteFile(filePath, content, 0o644)
+	err := os.WriteFile(filePath, content, 0o644)
 	c.Assert(err, IsNil)
 
 	dataFileInfo, err := os.Stat(filePath)

--- a/pkg/lightning/restore/restore_test.go
+++ b/pkg/lightning/restore/restore_test.go
@@ -16,7 +16,6 @@ package restore
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -352,7 +351,7 @@ func (s *tableRestoreSuiteBase) SetUpSuite(c *C) {
 	for i := 1; i <= fakeDataFilesCount; i++ {
 		fakeFileName := fmt.Sprintf("db.table.%d.sql", i)
 		fakeDataPath := filepath.Join(fakeDataDir, fakeFileName)
-		err = ioutil.WriteFile(fakeDataPath, fakeDataFilesContent, 0o644)
+		err = os.WriteFile(fakeDataPath, fakeDataFilesContent, 0o644)
 		c.Assert(err, IsNil)
 		fakeDataFiles = append(fakeDataFiles, mydump.FileInfo{
 			TableName: filter.Table{Schema: "db", Name: "table"},
@@ -367,7 +366,7 @@ func (s *tableRestoreSuiteBase) SetUpSuite(c *C) {
 
 	fakeCsvContent := []byte("1,2,3\r\n4,5,6\r\n")
 	csvName := "db.table.99.csv"
-	err = ioutil.WriteFile(filepath.Join(fakeDataDir, csvName), fakeCsvContent, 0o644)
+	err = os.WriteFile(filepath.Join(fakeDataDir, csvName), fakeCsvContent, 0o644)
 	c.Assert(err, IsNil)
 	fakeDataFiles = append(fakeDataFiles, mydump.FileInfo{
 		TableName: filter.Table{Schema: "db", Name: "table"},
@@ -551,7 +550,7 @@ func (s *tableRestoreSuite) TestPopulateChunksCSVHeader(c *C) {
 	total := 0
 	for i, s := range fakeCsvContents {
 		csvName := fmt.Sprintf("db.table.%02d.csv", i)
-		err := ioutil.WriteFile(filepath.Join(fakeDataDir, csvName), []byte(s), 0o644)
+		err := os.WriteFile(filepath.Join(fakeDataDir, csvName), []byte(s), 0o644)
 		c.Assert(err, IsNil)
 		fakeDataFiles = append(fakeDataFiles, mydump.FileInfo{
 			TableName: filter.Table{Schema: "db", Name: "table"},
@@ -1240,7 +1239,7 @@ func (s *chunkRestoreSuite) TestEncodeLoopDeliverLimit(c *C) {
 
 	dir := c.MkDir()
 	fileName := "db.limit.000.csv"
-	err = ioutil.WriteFile(filepath.Join(dir, fileName), []byte("1,2,3\r\n4,5,6\r\n7,8,9\r"), 0o644)
+	err = os.WriteFile(filepath.Join(dir, fileName), []byte("1,2,3\r\n4,5,6\r\n7,8,9\r"), 0o644)
 	c.Assert(err, IsNil)
 
 	store, err := storage.NewLocalStorage(dir)
@@ -1304,7 +1303,7 @@ func (s *chunkRestoreSuite) TestEncodeLoopDeliverErrored(c *C) {
 func (s *chunkRestoreSuite) TestEncodeLoopColumnsMismatch(c *C) {
 	dir := c.MkDir()
 	fileName := "db.table.000.csv"
-	err := ioutil.WriteFile(filepath.Join(dir, fileName), []byte("1,2,3,4\r\n4,5,6,7\r\n"), 0o644)
+	err := os.WriteFile(filepath.Join(dir, fileName), []byte("1,2,3,4\r\n4,5,6,7\r\n"), 0o644)
 	c.Assert(err, IsNil)
 
 	store, err := storage.NewLocalStorage(dir)

--- a/pkg/mock/mock_cluster.go
+++ b/pkg/mock/mock_cluster.go
@@ -5,7 +5,7 @@ package mock
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
@@ -180,7 +180,7 @@ func waitUntilServerOnline(addr string, statusPort uint) string {
 		resp, err := http.Get(statusURL) // nolint:noctx
 		if err == nil {
 			// Ignore errors.
-			_, _ = ioutil.ReadAll(resp.Body)
+			_, _ = io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
 			break
 		}

--- a/pkg/pdutil/pd.go
+++ b/pkg/pdutil/pd.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -165,11 +164,11 @@ func pdRequest(
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		res, _ := ioutil.ReadAll(resp.Body)
+		res, _ := io.ReadAll(resp.Body)
 		return nil, errors.Annotatef(berrors.ErrPDInvalidResponse, "[%d] %s %s", resp.StatusCode, res, reqURL)
 	}
 
-	r, err := ioutil.ReadAll(resp.Body)
+	r, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/restore/split_client.go
+++ b/pkg/restore/split_client.go
@@ -8,7 +8,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"strconv"
@@ -410,7 +410,7 @@ func (c *pdClient) GetPlacementRule(ctx context.Context, groupID, ruleID string)
 	if err != nil {
 		return rule, errors.Trace(err)
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return rule, errors.Trace(err)
 	}

--- a/pkg/storage/compress.go
+++ b/pkg/storage/compress.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 
 	berrors "github.com/pingcap/br/pkg/errors"
 
@@ -79,7 +78,7 @@ func (w *withCompression) ReadFile(ctx context.Context, name string) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(compressBf)
+	return io.ReadAll(compressBf)
 }
 
 type compressReader struct {

--- a/pkg/storage/compress_test.go
+++ b/pkg/storage/compress_test.go
@@ -4,7 +4,7 @@ package storage
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,7 +31,7 @@ func (r *testStorageSuite) TestWithCompressReadWriteFile(c *C) {
 	c.Assert(err, IsNil)
 	uncompressedFile, err := newCompressReader(Gzip, file)
 	c.Assert(err, IsNil)
-	newContent, err := ioutil.ReadAll(uncompressedFile)
+	newContent, err := io.ReadAll(uncompressedFile)
 	c.Assert(err, IsNil)
 	c.Assert(string(newContent), Equals, content)
 

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -5,7 +5,7 @@ package storage
 import (
 	"context"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -43,7 +43,7 @@ func (options *GCSBackendOptions) apply(gcs *backuppb.GCS) error {
 	gcs.PredefinedAcl = options.PredefinedACL
 
 	if options.CredentialsFile != "" {
-		b, err := ioutil.ReadFile(options.CredentialsFile)
+		b, err := os.ReadFile(options.CredentialsFile)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -121,7 +121,7 @@ func (s *gcsStorage) ReadFile(ctx context.Context, name string) ([]byte, error) 
 	var b []byte
 	if size < 0 {
 		// happened when using fake-gcs-server in integration test
-		b, err = ioutil.ReadAll(rc)
+		b, err = io.ReadAll(rc)
 	} else {
 		b = make([]byte, size)
 		_, err = io.ReadFull(rc, b)

--- a/pkg/storage/gcs_test.go
+++ b/pkg/storage/gcs_test.go
@@ -4,7 +4,7 @@ package storage
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
@@ -42,7 +42,7 @@ func (r *testStorageSuite) TestGCS(c *C) {
 
 	rc, err := server.Client().Bucket(bucketName).Object("a/b/key").NewReader(ctx)
 	c.Assert(err, IsNil)
-	d, err := ioutil.ReadAll(rc)
+	d, err := io.ReadAll(rc)
 	rc.Close()
 	c.Assert(err, IsNil)
 	c.Assert(d, DeepEquals, []byte("data"))
@@ -108,7 +108,7 @@ func (r *testStorageSuite) TestNewGCSStorage(c *C) {
 	}
 
 	{
-		fakeCredentialsFile, err := ioutil.TempFile("", "fakeCredentialsFile")
+		fakeCredentialsFile, err := os.CreateTemp("", "fakeCredentialsFile")
 		c.Assert(err, IsNil)
 		defer func() {
 			fakeCredentialsFile.Close()
@@ -137,7 +137,7 @@ func (r *testStorageSuite) TestNewGCSStorage(c *C) {
 	}
 
 	{
-		fakeCredentialsFile, err := ioutil.TempFile("", "fakeCredentialsFile")
+		fakeCredentialsFile, err := os.CreateTemp("", "fakeCredentialsFile")
 		c.Assert(err, IsNil)
 		defer func() {
 			fakeCredentialsFile.Close()

--- a/pkg/storage/gcs_test.go
+++ b/pkg/storage/gcs_test.go
@@ -72,6 +72,7 @@ func (r *testStorageSuite) TestNewGCSStorage(c *C) {
 	c.Assert(err1, IsNil)
 	bucketName := "testbucket"
 	server.CreateBucketWithOpts(fakestorage.CreateBucketOpts{Name: bucketName})
+	testDir := c.MkDir()
 
 	{
 		gcs := &backuppb.GCS{
@@ -108,7 +109,7 @@ func (r *testStorageSuite) TestNewGCSStorage(c *C) {
 	}
 
 	{
-		fakeCredentialsFile, err := os.CreateTemp("", "fakeCredentialsFile")
+		fakeCredentialsFile, err := os.CreateTemp(testDir, "fakeCredentialsFile")
 		c.Assert(err, IsNil)
 		defer func() {
 			fakeCredentialsFile.Close()
@@ -137,7 +138,7 @@ func (r *testStorageSuite) TestNewGCSStorage(c *C) {
 	}
 
 	{
-		fakeCredentialsFile, err := os.CreateTemp("", "fakeCredentialsFile")
+		fakeCredentialsFile, err := os.CreateTemp(testDir, "fakeCredentialsFile")
 		c.Assert(err, IsNil)
 		defer func() {
 			fakeCredentialsFile.Close()

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -5,7 +5,6 @@ package storage
 import (
 	"bufio"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -29,14 +28,14 @@ type LocalStorage struct {
 // WriteFile writes data to a file to storage.
 func (l *LocalStorage) WriteFile(ctx context.Context, name string, data []byte) error {
 	path := filepath.Join(l.base, name)
-	return ioutil.WriteFile(path, data, localFilePerm)
+	return os.WriteFile(path, data, localFilePerm)
 	// the backup meta file _is_ intended to be world-readable.
 }
 
 // ReadFile reads the file from the storage and returns the contents.
 func (l *LocalStorage) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	path := filepath.Join(l.base, name)
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 // FileExists implement ExternalStorage.FileExists.

--- a/pkg/storage/parse_test.go
+++ b/pkg/storage/parse_test.go
@@ -3,7 +3,6 @@
 package storage
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -105,7 +104,7 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 
 	var credFeilPerm os.FileMode = 0o600
 	fakeCredentialsFile := filepath.Join(c.MkDir(), "fakeCredentialsFile")
-	err = ioutil.WriteFile(fakeCredentialsFile, []byte("fakeCredentials"), credFeilPerm)
+	err = os.WriteFile(fakeCredentialsFile, []byte("fakeCredentials"), credFeilPerm)
 	c.Assert(err, IsNil)
 
 	gcsOpt.GCS.CredentialsFile = fakeCredentialsFile
@@ -119,7 +118,7 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	c.Assert(gcs.Endpoint, Equals, "https://gcs.example.com/")
 	c.Assert(gcs.CredentialsBlob, Equals, "fakeCredentials")
 
-	err = ioutil.WriteFile(fakeCredentialsFile, []byte("fakeCreds2"), credFeilPerm)
+	err = os.WriteFile(fakeCredentialsFile, []byte("fakeCreds2"), credFeilPerm)
 	c.Assert(err, IsNil)
 	s, err = ParseBackend("gs://bucket4/backup/?credentials-file="+url.QueryEscape(fakeCredentialsFile), nil)
 	c.Assert(err, IsNil)

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"path"
 	"regexp"
@@ -396,7 +395,7 @@ func (rs *S3Storage) ReadFile(ctx context.Context, file string) ([]byte, error) 
 			*input.Bucket, *input.Key)
 	}
 	defer result.Body.Close()
-	data, err := ioutil.ReadAll(result.Body)
+	data, err := io.ReadAll(result.Body)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -659,7 +658,7 @@ func (r *s3ObjectReader) Seek(offset int64, whence int) (int64, error) {
 
 	// if seek ahead no more than 64k, we discard these data
 	if realOffset > r.pos && realOffset-r.pos <= maxSkipOffsetByRead {
-		_, err := io.CopyN(ioutil.Discard, r, realOffset-r.pos)
+		_, err := io.CopyN(io.Discard, r, realOffset-r.pos)
 		if err != nil {
 			return r.pos, errors.Trace(err)
 		}

--- a/pkg/storage/s3_test.go
+++ b/pkg/storage/s3_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 
@@ -449,7 +448,7 @@ func (s *s3Suite) TestWriteNoError(c *C) {
 			c.Assert(aws.StringValue(input.ACL), Equals, "acl")
 			c.Assert(aws.StringValue(input.ServerSideEncryption), Equals, "sse")
 			c.Assert(aws.StringValue(input.StorageClass), Equals, "sc")
-			body, err := ioutil.ReadAll(input.Body)
+			body, err := io.ReadAll(input.Body)
 			c.Assert(err, IsNil)
 			c.Assert(body, DeepEquals, []byte("test"))
 			return &s3.PutObjectOutput{}, nil
@@ -480,7 +479,7 @@ func (s *s3Suite) TestReadNoError(c *C) {
 			c.Assert(aws.StringValue(input.Bucket), Equals, "bucket")
 			c.Assert(aws.StringValue(input.Key), Equals, "prefix/file")
 			return &s3.GetObjectOutput{
-				Body: ioutil.NopCloser(bytes.NewReader([]byte("test"))),
+				Body: io.NopCloser(bytes.NewReader([]byte("test"))),
 			}, nil
 		})
 
@@ -586,7 +585,7 @@ func (s *s3Suite) TestOpenAsBufio(c *C) {
 		DoAndReturn(func(_ context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 			c.Assert(aws.StringValue(input.Range), Equals, "bytes=0-")
 			return &s3.GetObjectOutput{
-				Body:         ioutil.NopCloser(bytes.NewReader([]byte("plain text\ncontent"))),
+				Body:         io.NopCloser(bytes.NewReader([]byte("plain text\ncontent"))),
 				ContentRange: aws.String("bytes 0-17/18"),
 			}, nil
 		})
@@ -639,7 +638,7 @@ func (s *s3Suite) TestOpenReadSlowly(c *C) {
 
 	reader, err := s.storage.Open(ctx, "alphabets")
 	c.Assert(err, IsNil)
-	res, err := ioutil.ReadAll(reader)
+	res, err := io.ReadAll(reader)
 	c.Assert(err, IsNil)
 	c.Assert(res, DeepEquals, []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
 }
@@ -655,7 +654,7 @@ func (s *s3Suite) TestOpenSeek(c *C) {
 	// ^ we just want some random bytes for testing, we don't care about its security.
 
 	s.expectedCalls(ctx, c, someRandomBytes, []int{0, 998000, 990100}, func(data []byte, offset int) io.ReadCloser {
-		return ioutil.NopCloser(bytes.NewReader(data[offset:]))
+		return io.NopCloser(bytes.NewReader(data[offset:]))
 	})
 
 	reader, err := s.storage.Open(ctx, "random")
@@ -746,7 +745,7 @@ func (s *s3Suite) TestS3ReaderWithRetryEOF(c *C) {
 	// ^ we just want some random bytes for testing, we don't care about its security.
 
 	s.expectedCalls(ctx, c, someRandomBytes, []int{0, 20, 50, 75}, func(data []byte, offset int) io.ReadCloser {
-		return ioutil.NopCloser(&limitedBytesReader{Reader: bytes.NewReader(data[offset:]), limit: 30})
+		return io.NopCloser(&limitedBytesReader{Reader: bytes.NewReader(data[offset:]), limit: 30})
 	})
 
 	reader, err := s.storage.Open(ctx, "random")
@@ -791,7 +790,7 @@ func (s *s3Suite) TestS3ReaderWithRetryFailed(c *C) {
 	// ^ we just want some random bytes for testing, we don't care about its security.
 
 	s.expectedCalls(ctx, c, someRandomBytes, []int{0, 20, 40, 60}, func(data []byte, offset int) io.ReadCloser {
-		return ioutil.NopCloser(&limitedBytesReader{Reader: bytes.NewReader(data[offset:]), limit: 30})
+		return io.NopCloser(&limitedBytesReader{Reader: bytes.NewReader(data[offset:]), limit: 30})
 	})
 
 	reader, err := s.storage.Open(ctx, "random")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -72,9 +72,9 @@ type Writer interface {
 
 // ExternalStorage represents a kind of file system storage.
 type ExternalStorage interface {
-	// WriteFile writes a complete file to storage, similar to ioutil.WriteFile
+	// WriteFile writes a complete file to storage, similar to os.WriteFile
 	WriteFile(ctx context.Context, name string, data []byte) error
-	// ReadFile reads a complete file from storage, similar to ioutil.ReadFile
+	// ReadFile reads a complete file from storage, similar to os.ReadFile
 	ReadFile(ctx context.Context, name string) ([]byte, error)
 	// FileExists return true if file exists
 	FileExists(ctx context.Context, name string) (bool, error)

--- a/pkg/storage/writer_test.go
+++ b/pkg/storage/writer_test.go
@@ -5,7 +5,7 @@ package storage
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +38,7 @@ func (r *testStorageSuite) TestExternalFileWriter(c *C) {
 		}
 		err = writer.Close(ctx)
 		c.Assert(err, IsNil)
-		content, err := ioutil.ReadFile(filepath.Join(dir, fileName))
+		content, err := os.ReadFile(filepath.Join(dir, fileName))
 		c.Assert(err, IsNil)
 		c.Assert(string(content), Equals, strings.Join(test.content, ""))
 	}
@@ -128,7 +128,7 @@ func (r *testStorageSuite) TestCompressReaderWriter(c *C) {
 		// test withCompression Open
 		r, err = storage.Open(ctx, fileName)
 		c.Assert(err, IsNil)
-		content, err := ioutil.ReadAll(r)
+		content, err := io.ReadAll(r)
 		c.Assert(err, IsNil)
 		c.Assert(string(content), Equals, strings.Join(test.content, ""))
 

--- a/pkg/trace/tracing_test.go
+++ b/pkg/trace/tracing_test.go
@@ -4,7 +4,7 @@ package trace
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -50,7 +50,7 @@ func (t *testTracingSuite) TestSpan(c *C) {
 	ctx, store := TracerStartSpan(context.Background())
 	jobA(ctx)
 	TracerFinishSpan(ctx, store)
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	c.Assert(err, IsNil)
 	s := string(content)
 	// possible result:

--- a/tests/br_key_locked/locker.go
+++ b/tests/br_key_locked/locker.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net"
 	"net/http"
@@ -156,7 +156,7 @@ func getTableID(ctx context.Context, dbAddr, dbName, table string) (int64, error
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Since we have upgraded to go 1.16 in https://github.com/pingcap/br/pull/1159, I think we can remove the [Deprecation of io/ioutil](https://golang.org/doc/go1.16#ioutil).

### What is changed and how it works?

Remove all deprecated io/ioutil usages except `pkg/lightning/web/res_vfsdata.go`, because it was generated by vfsgen.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

### Release note

No release note

<!-- fill in the release note, or just write "No release note" -->
