### PR TITLE
restore: Add cdc log sync

### DIFF
--- a/pkg/restore/log_client.go
+++ b/pkg/restore/log_client.go
@@ -677,15 +677,41 @@ func (l *LogClient) RestoreLogData(ctx context.Context, dom *domain.Domain) erro
 	// 3. Encode and ingest data to tikv
 
 	// parse meta file
-	data, err := l.restoreClient.storage.ReadFile(ctx, metaFile)
-	if err != nil {
+	now := time.Now()
+	syncTimeout := 5 * time.Second
+	cdcSync := make(chan struct{})
+	errCh := make(chan error)
+
+	go func() {
+		for {
+			if time.Since(now) >= syncTimeout {
+				now = time.Now()
+				if l.meta != nil && l.meta.GlobalResolvedTS >= l.endTS {
+					cdcSync <- struct{}{}
+					close(cdcSync)
+					break
+				}
+				data, err := l.restoreClient.storage.ReadFile(ctx, metaFile)
+				if err != nil {
+					errCh <- err
+					close(errCh)
+					break
+				}
+				err = json.Unmarshal(data, l.meta)
+				if err != nil {
+					errCh <- err
+					close(errCh)
+					break
+				}
+			}
+		}
+	}()
+	// parse meta file
+	select {
+	case err := <-errCh:
 		return errors.Trace(err)
+	case <-cdcSync:
 	}
-	err = json.Unmarshal(data, l.meta)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	log.Info("get meta from storage", zap.Binary("data", data))
 
 	if l.startTS > l.meta.GlobalResolvedTS {
 		return errors.Annotatef(berrors.ErrRestoreRTsConstrain,


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The current implementation of log restore lack mechanism to ensure the cdc logs had sync in disk.

### What is changed and how it works?
Update `RestoreLogData`, fork another go routine to periodically check whether the global resolveTS is greater than endTS

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

 -

<!-- fill in the release note, or just write "No release note" -->
