### PR TITLE
compatibility: filter the tags don't have corresponding docker images

### DIFF
--- a/compatibility/get_last_tags.sh
+++ b/compatibility/get_last_tags.sh
@@ -5,7 +5,11 @@ getLatestTags() {
   release_5_branch_regex="^release-5\.[0-9].*$"
   release_4_branch_regex="^release-4\.[0-9].*$"
   TOTAL_TAGS=$(git for-each-ref --sort=creatordate  refs/tags | awk -F '/' '{print $3}')
-  filter='alpha'
+  # we should filter such tags
+  # v5.0.2-20210628
+  # v5.0.2-alpha
+  # because these tags don't have corresponding docker images.
+  filter='-'
   # latest tags
   TAGS=$(echo $TOTAL_TAGS | tr ' ' '\n' | grep -v $filter | tail -n3)
   if git rev-parse --abbrev-ref HEAD | egrep -q $release_5_branch_regex


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
we found new tag like 'v5.0.2-20210628' doesn't have docker image.

### What is changed and how it works?
change filter from 'alpha' to '-' to work around;

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


 - Need to cherry-pick to the release branch

### Release note

 - No Release note.

<!-- fill in the release note, or just write "No release note" -->
