### PR TITLE
lightning: fix incorrect seek of duplicate iter

### DIFF
--- a/pkg/lightning/backend/local/iterator.go
+++ b/pkg/lightning/backend/local/iterator.go
@@ -60,7 +60,7 @@ type duplicateIter struct {
 
 func (d *duplicateIter) Seek(key []byte) bool {
 	encodedKey := d.keyAdapter.Encode(nil, key, 0, 0)
-	if d.err != nil || !d.iter.SeekGE(codec.EncodeBytes(nil, encodedKey)) {
+	if d.err != nil || !d.iter.SeekGE(encodedKey) {
 		return false
 	}
 	d.fill()


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The `Seek` method of `duplicateIter` wrongly encodes the key twice, which leads to incorrect result.

### What is changed and how it works?

Fix the bug of `Seek` and add more tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes


### Release note

No release note

<!-- fill in the release note, or just write "No release note" -->
