### PR TITLE
Lightning: Changed data-source-dir to use StorageBackend to prevent leaking secret access key to JSON output

### DIFF
--- a/pkg/lightning/checkpoints/checkpoints.go
+++ b/pkg/lightning/checkpoints/checkpoints.go
@@ -1006,7 +1006,7 @@ func (cpdb *FileCheckpointsDB) Initialize(ctx context.Context, cfg *config.Confi
 
 	cpdb.checkpoints.TaskCheckpoint = &checkpointspb.TaskCheckpointModel{
 		TaskId:       cfg.TaskID,
-		SourceDir:    cfg.Mydumper.SourceDir,
+		SourceDir:    cfg.Mydumper.SourceDir.String(),
 		Backend:      cfg.TikvImporter.Backend,
 		ImporterAddr: cfg.TikvImporter.Addr,
 		TidbHost:     cfg.TiDB.Host,

--- a/pkg/lightning/checkpoints/glue_checkpoint.go
+++ b/pkg/lightning/checkpoints/glue_checkpoint.go
@@ -138,7 +138,7 @@ func (g GlueCheckpointsDB) Initialize(ctx context.Context, cfg *config.Config, d
 		defer dropPreparedStmt(s, stmtID)
 		_, err = s.ExecutePreparedStmt(c, stmtID, []types.Datum{
 			types.NewIntDatum(cfg.TaskID),
-			types.NewStringDatum(cfg.Mydumper.SourceDir),
+			types.NewStringDatum(cfg.Mydumper.SourceDir.String()),
 			types.NewStringDatum(cfg.TikvImporter.Backend),
 			types.NewStringDatum(cfg.TikvImporter.Addr),
 			types.NewStringDatum(cfg.TiDB.Host),

--- a/pkg/lightning/config/global.go
+++ b/pkg/lightning/config/global.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/errors"
 
 	"github.com/pingcap/br/pkg/lightning/log"
+	"github.com/pingcap/br/pkg/storage"
 	"github.com/pingcap/br/pkg/version/build"
 )
 
@@ -50,7 +51,7 @@ type GlobalTiDB struct {
 }
 
 type GlobalMydumper struct {
-	SourceDir string `toml:"data-source-dir" json:"data-source-dir"`
+	SourceDir SourceDir `toml:"data-source-dir" json:"data-source-dir"`
 	// Deprecated
 	NoSchema      bool             `toml:"no-schema" json:"no-schema"`
 	Filter        []string         `toml:"filter" json:"filter"`
@@ -225,7 +226,11 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 		cfg.TiDB.PdAddr = *pdAddr
 	}
 	if *dataSrcPath != "" {
-		cfg.Mydumper.SourceDir = *dataSrcPath
+		var err error
+		cfg.Mydumper.SourceDir.StorageBackend, err = storage.ParseBackend(*dataSrcPath, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if *importerAddr != "" {
 		cfg.TikvImporter.Addr = *importerAddr

--- a/pkg/lightning/config/sourcedir.go
+++ b/pkg/lightning/config/sourcedir.go
@@ -1,0 +1,55 @@
+// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pingcap/errors"
+	backuppb "github.com/pingcap/kvproto/pkg/backup"
+
+	"github.com/pingcap/br/pkg/storage"
+)
+
+// SourceDir is the parsed data source directory. It hides the "access-key" and
+// "secret-access-key" when dumped as JSON.
+type SourceDir struct {
+	*backuppb.StorageBackend
+}
+
+// String implements fmt.Stringer
+func (sd SourceDir) String() string {
+	// need the intermediate variable to avoid "cannot call pointer method" compiler error.
+	u := storage.FormatBackendURL(sd.StorageBackend)
+	return u.String()
+}
+
+func (sd *SourceDir) UnmarshalText(text []byte) error {
+	var err error
+	sd.StorageBackend, err = storage.ParseBackend(string(text), nil)
+	return errors.Trace(err)
+}
+
+func (sd SourceDir) MarshalJSON() ([]byte, error) {
+	return json.Marshal(sd.String())
+}
+
+// NewStorage creates a new external storage interface from the storage backend
+// URL. It is basically a wrapper around `storage.New()` function.
+func (sd SourceDir) NewStorage(ctx context.Context, checkPermissions []storage.Permission) (storage.ExternalStorage, error) {
+	return storage.New(
+		ctx, sd.StorageBackend,
+		&storage.ExternalStorageOptions{CheckPermissions: checkPermissions},
+	)
+}
+
+// NewSourceDirFromPath creates a SourceDir from a file path.
+// This should only be used in test.
+func NewSourceDirFromPath(path string) SourceDir {
+	return SourceDir{
+		StorageBackend: &backuppb.StorageBackend{
+			Backend: &backuppb.StorageBackend_Local{Local: &backuppb.Local{Path: path}},
+		},
+	}
+}

--- a/pkg/lightning/lightning_test.go
+++ b/pkg/lightning/lightning_test.go
@@ -62,7 +62,7 @@ func (s *lightningSuite) TestRun(c *C) {
 	globalConfig.TiDB.Host = "test.invalid"
 	globalConfig.TiDB.Port = 4000
 	globalConfig.TiDB.PdAddr = "test.invalid:2379"
-	globalConfig.Mydumper.SourceDir = "not-exists"
+	globalConfig.Mydumper.SourceDir = config.NewSourceDirFromPath("not-exists")
 	globalConfig.TikvImporter.Backend = config.BackendLocal
 	globalConfig.TikvImporter.SortedKVDir = c.MkDir()
 	lightning := New(globalConfig)
@@ -70,14 +70,14 @@ func (s *lightningSuite) TestRun(c *C) {
 	err := cfg.LoadFromGlobal(globalConfig)
 	c.Assert(err, IsNil)
 	err = lightning.RunOnce(context.Background(), cfg, nil)
-	c.Assert(err, ErrorMatches, ".*mydumper dir does not exist")
+	c.Assert(err, ErrorMatches, ".*(no such file or directory|The system cannot find the file specified).*")
 
 	path, _ := filepath.Abs(".")
 	ctx := context.Background()
 	invalidGlue := glue.NewExternalTiDBGlue(nil, 0)
 	err = lightning.run(ctx, &config.Config{
 		Mydumper: config.MydumperRuntime{
-			SourceDir:        "file://" + filepath.ToSlash(path),
+			SourceDir:        config.NewSourceDirFromPath(path),
 			Filter:           []string{"*.*"},
 			DefaultFileRules: true,
 		},
@@ -90,7 +90,7 @@ func (s *lightningSuite) TestRun(c *C) {
 
 	err = lightning.run(ctx, &config.Config{
 		Mydumper: config.MydumperRuntime{
-			SourceDir: ".",
+			SourceDir: config.NewSourceDirFromPath("."),
 			Filter:    []string{"*.*"},
 		},
 		Checkpoint: config.Checkpoint{
@@ -116,7 +116,7 @@ func (s *lightningServerSuite) SetUpTest(c *C) {
 	cfg.TiDB.PdAddr = "test.invalid:2379"
 	cfg.App.ServerMode = true
 	cfg.App.StatusAddr = "127.0.0.1:0"
-	cfg.Mydumper.SourceDir = "file://."
+	cfg.Mydumper.SourceDir = config.NewSourceDirFromPath(".")
 	cfg.TikvImporter.Backend = config.BackendLocal
 	cfg.TikvImporter.SortedKVDir = c.MkDir()
 

--- a/pkg/lightning/mydump/loader.go
+++ b/pkg/lightning/mydump/loader.go
@@ -87,11 +87,7 @@ type mdLoaderSetup struct {
 }
 
 func NewMyDumpLoader(ctx context.Context, cfg *config.Config) (*MDLoader, error) {
-	u, err := storage.ParseBackend(cfg.Mydumper.SourceDir, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	s, err := storage.New(ctx, u, &storage.ExternalStorageOptions{})
+	s, err := cfg.Mydumper.SourceDir.NewStorage(ctx, nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/lightning/mydump/loader.go
+++ b/pkg/lightning/mydump/loader.go
@@ -15,7 +15,6 @@ package mydump
 
 import (
 	"context"
-	"path/filepath"
 	"sort"
 
 	"github.com/pingcap/errors"
@@ -279,7 +278,7 @@ func (s *mdLoaderSetup) listFiles(ctx context.Context, store storage.ExternalSto
 	err := store.WalkDir(ctx, &storage.WalkOption{}, func(path string, size int64) error {
 		logger := log.With(zap.String("path", path))
 
-		res, err := s.loader.fileRouter.Route(filepath.ToSlash(path))
+		res, err := s.loader.fileRouter.Route(path)
 		if err != nil {
 			return errors.Annotatef(err, "apply file routing on file '%s' failed", path)
 		}

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -532,27 +532,27 @@ func (s *testMydumpLoaderSuite) TestFileRouting(c *C) {
 	c.Assert(mdl.GetDatabases(), DeepEquals, []*md.MDDatabaseMeta{
 		{
 			Name:       "d1",
-			SchemaFile: filepath.FromSlash("d1/schema.sql"),
+			SchemaFile: "d1/schema.sql",
 			Tables: []*md.MDTableMeta{
 				{
 					DB:   "d1",
 					Name: "test",
 					SchemaFile: md.FileInfo{
 						TableName: filter.Table{Schema: "d1", Name: "test"},
-						FileMeta:  md.SourceFileMeta{Path: filepath.FromSlash("d1/test-table.sql"), Type: md.SourceTypeTableSchema},
+						FileMeta:  md.SourceFileMeta{Path: "d1/test-table.sql", Type: md.SourceTypeTableSchema},
 					},
 					DataFiles: []md.FileInfo{
 						{
 							TableName: filter.Table{Schema: "d1", Name: "test"},
-							FileMeta:  md.SourceFileMeta{Path: filepath.FromSlash("d1/test0.sql"), Type: md.SourceTypeSQL},
+							FileMeta:  md.SourceFileMeta{Path: "d1/test0.sql", Type: md.SourceTypeSQL},
 						},
 						{
 							TableName: filter.Table{Schema: "d1", Name: "test"},
-							FileMeta:  md.SourceFileMeta{Path: filepath.FromSlash("d1/test1.sql"), Type: md.SourceTypeSQL},
+							FileMeta:  md.SourceFileMeta{Path: "d1/test1.sql", Type: md.SourceTypeSQL},
 						},
 						{
 							TableName: filter.Table{Schema: "d1", Name: "test"},
-							FileMeta:  md.SourceFileMeta{Path: filepath.FromSlash("d1/test2.001.sql"), Type: md.SourceTypeSQL},
+							FileMeta:  md.SourceFileMeta{Path: "d1/test2.001.sql", Type: md.SourceTypeSQL},
 						},
 					},
 				},
@@ -561,7 +561,7 @@ func (s *testMydumpLoaderSuite) TestFileRouting(c *C) {
 					Name: "v1",
 					SchemaFile: md.FileInfo{
 						TableName: filter.Table{Schema: "d1", Name: "v1"},
-						FileMeta:  md.SourceFileMeta{Path: filepath.FromSlash("d1/v1-table.sql"), Type: md.SourceTypeTableSchema},
+						FileMeta:  md.SourceFileMeta{Path: "d1/v1-table.sql", Type: md.SourceTypeTableSchema},
 					},
 					DataFiles: []md.FileInfo{},
 				},
@@ -572,21 +572,21 @@ func (s *testMydumpLoaderSuite) TestFileRouting(c *C) {
 					Name: "v1",
 					SchemaFile: md.FileInfo{
 						TableName: filter.Table{Schema: "d1", Name: "v1"},
-						FileMeta:  md.SourceFileMeta{Path: filepath.FromSlash("d1/v1-view.sql"), Type: md.SourceTypeViewSchema},
+						FileMeta:  md.SourceFileMeta{Path: "d1/v1-view.sql", Type: md.SourceTypeViewSchema},
 					},
 				},
 			},
 		},
 		{
 			Name:       "d2",
-			SchemaFile: filepath.FromSlash("d2/schema.sql"),
+			SchemaFile: "d2/schema.sql",
 			Tables: []*md.MDTableMeta{
 				{
 					DB:   "d2",
 					Name: "abc",
 					SchemaFile: md.FileInfo{
 						TableName: filter.Table{Schema: "d2", Name: "abc"},
-						FileMeta:  md.SourceFileMeta{Path: filepath.FromSlash("d2/abc-table.sql"), Type: md.SourceTypeTableSchema},
+						FileMeta:  md.SourceFileMeta{Path: "d2/abc-table.sql", Type: md.SourceTypeTableSchema},
 					},
 					DataFiles: []md.FileInfo{{TableName: filter.Table{Schema: "d2", Name: "abc"}, FileMeta: md.SourceFileMeta{Path: "abc.1.sql", Type: md.SourceTypeSQL}}},
 				},

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -46,7 +46,7 @@ func newConfigWithSourceDir(sourceDir string) *config.Config {
 	path, _ := filepath.Abs(sourceDir)
 	return &config.Config{
 		Mydumper: config.MydumperRuntime{
-			SourceDir:        "file://" + filepath.ToSlash(path),
+			SourceDir:        config.NewSourceDirFromPath(path),
 			Filter:           []string{"*.*"},
 			DefaultFileRules: true,
 		},

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -790,7 +790,7 @@ func verifyCheckpoint(cfg *config.Config, taskCp *checkpoints.TaskCheckpoint) er
 		}
 
 		errorFmt := "config '%s' value '%s' different from checkpoint value '%s'. You may set 'check-requirements = false' to skip this check or " + retryUsage
-		if cfg.Mydumper.SourceDir != taskCp.SourceDir {
+		if cfg.Mydumper.SourceDir.String() != taskCp.SourceDir {
 			return errors.Errorf(errorFmt, "mydumper.data-source-dir", cfg.Mydumper.SourceDir, taskCp.SourceDir)
 		}
 
@@ -1801,10 +1801,6 @@ func (rc *Controller) preCheckRequirements(ctx context.Context) error {
 		return nil
 	}
 	if err := rc.ClusterIsAvailable(ctx); err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := rc.StoragePermission(ctx); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/pkg/storage/parse_test.go
+++ b/pkg/storage/parse_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -135,6 +136,20 @@ func (r *testStorageSuite) TestCreateStorage(c *C) {
 	expectedLocalPath, err := filepath.Abs("/test")
 	c.Assert(err, IsNil)
 	c.Assert(local.GetPath(), Equals, expectedLocalPath)
+}
+
+func (r *testStorageSuite) TestParseWindowsBackend(c *C) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+
+	s, err := ParseBackend(`L:\Data\Backup`, nil)
+	c.Assert(err, IsNil)
+	local := s.GetLocal()
+	c.Assert(local, NotNil)
+	c.Assert(local.GetPath(), Equals, `L:\Data\Backup`)
+	url := FormatBackendURL(s)
+	c.Assert(url.String(), Equals, "local://L:/Data/Backup")
 }
 
 func (r *testStorageSuite) TestFormatBackendURL(c *C) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -120,16 +120,8 @@ type ExternalStorageOptions struct {
 	// NoCredentials means that no cloud credentials are supplied to BR
 	NoCredentials bool
 
-	// SkipCheckPath marks whether to skip checking path's existence.
-	//
-	// This should only be set to true in testing, to avoid interacting with the
-	// real world.
-	// When this field is false (i.e. path checking is enabled), the New()
-	// function will ensure the path referred by the backend exists by
-	// recursively creating the folders. This will also throw an error if such
-	// operation is impossible (e.g. when the bucket storing the path is missing).
-
-	// deprecated: use checkPermissions and specify the checkPermission instead.
+	// SkipCheckPath is deprecated and does nothing.
+	// Use the CheckPermissions field to recover the old `SkipCheckPath = false` behavior.
 	SkipCheckPath bool
 
 	// HTTPClient to use. The created storage may ignore this field if it is not
@@ -147,7 +139,6 @@ type ExternalStorageOptions struct {
 func Create(ctx context.Context, backend *backuppb.StorageBackend, sendCreds bool) (ExternalStorage, error) {
 	return New(ctx, backend, &ExternalStorageOptions{
 		SendCredentials: sendCreds,
-		SkipCheckPath:   false,
 		HTTPClient:      nil,
 	})
 }
@@ -159,7 +150,7 @@ func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalSt
 		if backend.Local == nil {
 			return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "local config not found")
 		}
-		return NewLocalStorage(backend.Local.Path)
+		return newLocalStorage(backend.Local.Path, opts)
 	case *backuppb.StorageBackend_S3:
 		if backend.S3 == nil {
 			return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "s3 config not found")

--- a/pkg/task/backup.go
+++ b/pkg/task/backup.go
@@ -258,7 +258,11 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	opts := storage.ExternalStorageOptions{
 		NoCredentials:   cfg.NoCreds,
 		SendCredentials: cfg.SendCreds,
-		SkipCheckPath:   cfg.SkipCheckPath,
+		// we only include AccessBuckets for backward compatibility, and probably can be relaxed.
+		CheckPermissions: []storage.Permission{storage.PutObject, storage.AccessBuckets},
+	}
+	if cfg.SkipCheckPath {
+		opts.CheckPermissions = nil
 	}
 	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return errors.Trace(err)

--- a/pkg/task/backup_raw.go
+++ b/pkg/task/backup_raw.go
@@ -152,7 +152,11 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	opts := storage.ExternalStorageOptions{
 		NoCredentials:   cfg.NoCreds,
 		SendCredentials: cfg.SendCreds,
-		SkipCheckPath:   cfg.SkipCheckPath,
+		// we only include AccessBuckets for backward compatibility, and probably can be relaxed.
+		CheckPermissions: []storage.Permission{storage.PutObject, storage.AccessBuckets},
+	}
+	if cfg.SkipCheckPath {
+		opts.CheckPermissions = nil
 	}
 	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return errors.Trace(err)

--- a/pkg/task/common.go
+++ b/pkg/task/common.go
@@ -412,7 +412,7 @@ func NewMgr(ctx context.Context,
 	)
 }
 
-// GetStorage gets the storage backend from the config.
+// GetStorage gets the storage backend from the config for the `br debug encode` command.
 func GetStorage(
 	ctx context.Context,
 	cfg *Config,
@@ -429,11 +429,15 @@ func GetStorage(
 }
 
 func storageOpts(cfg *Config) *storage.ExternalStorageOptions {
-	return &storage.ExternalStorageOptions{
-		NoCredentials:   cfg.NoCreds,
-		SendCredentials: cfg.SendCreds,
-		SkipCheckPath:   cfg.SkipCheckPath,
+	opts := &storage.ExternalStorageOptions{
+		NoCredentials:    cfg.NoCreds,
+		SendCredentials:  cfg.SendCreds,
+		CheckPermissions: []storage.Permission{storage.GetObject, storage.PutObject},
 	}
+	if cfg.SkipCheckPath {
+		opts.CheckPermissions = nil
+	}
+	return opts
 }
 
 // ReadBackupMeta reads the backupmeta file from the storage.

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -222,9 +222,12 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		return errors.Trace(err)
 	}
 	opts := storage.ExternalStorageOptions{
-		NoCredentials:   cfg.NoCreds,
-		SendCredentials: cfg.SendCreds,
-		SkipCheckPath:   cfg.SkipCheckPath,
+		NoCredentials:    cfg.NoCreds,
+		SendCredentials:  cfg.SendCreds,
+		CheckPermissions: []storage.Permission{storage.GetObject},
+	}
+	if cfg.SkipCheckPath {
+		opts.CheckPermissions = nil
 	}
 	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return errors.Trace(err)

--- a/pkg/task/restore_log.go
+++ b/pkg/task/restore_log.go
@@ -120,9 +120,12 @@ func RunLogRestore(c context.Context, g glue.Glue, cfg *LogRestoreConfig) error 
 	defer client.Close()
 
 	opts := storage.ExternalStorageOptions{
-		NoCredentials:   cfg.NoCreds,
-		SendCredentials: cfg.SendCreds,
-		SkipCheckPath:   cfg.SkipCheckPath,
+		NoCredentials:    cfg.NoCreds,
+		SendCredentials:  cfg.SendCreds,
+		CheckPermissions: []storage.Permission{storage.GetObject},
+	}
+	if cfg.SkipCheckPath {
+		opts.CheckPermissions = nil
 	}
 	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When using Lightning to load from S3, the non-environmental access key and secret key have to be provided through URL parameters in `mydumper.data-source-dir`. This is stored as a plain string.

Lightning also prints the config as JSON before starting a task for debugging. 

These two together means the access key and secret key will be leaked to the log.

### What is changed and how it works?

The type of `mydumper.data-source-dir` is changed from a string to a custom type (`*backuppb.StorageBackend`) which scrubs all extra parameters when serializing as JSON.

The change introduces some additional effects needing refactoring:

* There was a check whether `mydumper.data-source-dir` exists before running. This overlaps with the `StoragePermissions` pre-check for S3. These, along with GCS, are combined into the existing  `CheckPermissions` check.
* The `SkipCheckPath` field for external storage is thus entirely ignored (it is already set to `true` on Dumpling and TiCDC so it is safe to ignore). *The BR flag `--skip-check-path` is unaffected.*
* (More in review comments below.)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release note

 - Lightning will stop printing the explicit S3 secret access key from the config file into the log. (It is still discouraged to put the secret access key in the config file.)

<!-- fill in the release note, or just write "No release note" -->
