### PR TITLE
lightning: Return error for empty path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 # for the web interface
 web/node_modules/
 web/dist/
+.vscode/

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -513,6 +513,8 @@ func (worker *restoreSchemaWorker) makeJobs(
 				// we already has this table in TiDB.
 				// we should skip ddl job and let SchemaValid check.
 				continue
+			} else if tblMeta.SchemaFile.FileMeta.Path == "" {
+				return errors.Errorf("table `%s`.`%s` schema not found", dbMeta.Name, tblMeta.Name)
 			}
 			sql, err := tblMeta.GetSchema(worker.ctx, worker.store)
 			if sql != "" {


### PR DESCRIPTION




<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If `Path` is empty this leads to lightning trying to open the basedir,
which then results in an error like `Error: read /home/ubuntu/csv: is a
directory` which is misleading.

Issue: https://github.com/pingcap/br/issues/1394

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)


### Release note

 - Fix the error message when trying to load CSV data in tables that don't exist.

<!-- fill in the release note, or just write "No release note" -->
