### PR TITLE
lightning: fix disk-quota for local backend

### DIFF
--- a/pkg/lightning/backend/backend.go
+++ b/pkg/lightning/backend/backend.go
@@ -319,6 +319,11 @@ func (be Backend) UnsafeImportAndReset(ctx context.Context, engineUUID uuid.UUID
 	return be.abstract.ResetEngine(ctx, engineUUID)
 }
 
+// FlushEngine ensures all KV pairs written to an open engine has been synchronized
+func (be Backend) FlushEngine(ctx context.Context, engineUUID uuid.UUID) error {
+	return be.abstract.FlushEngine(ctx, engineUUID)
+}
+
 // OpenEngine opens an engine with the given table name and engine ID.
 func (be Backend) OpenEngine(ctx context.Context, config *EngineConfig, tableName string, engineID int32) (*OpenedEngine, error) {
 	tag, engineUUID := MakeUUID(tableName, engineID)

--- a/pkg/lightning/restore/restore.go
+++ b/pkg/lightning/restore/restore.go
@@ -1739,7 +1739,10 @@ func (rc *Controller) enforceDiskQuota(ctx context.Context) {
 			task := logger.Begin(zap.WarnLevel, "importing large engines for disk quota")
 			var importErr error
 			for _, engine := range largeEngines {
-				if err := rc.backend.UnsafeImportAndReset(ctx, engine); err != nil {
+				var err error
+				if err = rc.backend.FlushEngine(ctx, engine); err != nil {
+					importErr = multierr.Append(importErr, err)
+				} else if err = rc.backend.UnsafeImportAndReset(ctx, engine); err != nil {
 					importErr = multierr.Append(importErr, err)
 				}
 			}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Disk-quota may lead to data loss with local backend.

### What is changed and how it works?
Do a flush before unsafe import for local backend.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

### Release note

 - No release note

<!-- fill in the release note, or just write "No release note" -->
