### PR TITLE
Fix speed compute

### DIFF
--- a/pkg/summary/collector.go
+++ b/pkg/summary/collector.go
@@ -195,25 +195,14 @@ func (tc *logCollector) Summary(name string) {
 		tc.log(name+" failed summary", logFields...)
 		return
 	}
-	totalCost := time.Duration(0)
-	for _, cost := range tc.successCosts {
-		totalCost += cost
-	}
 
 	totalDureTime := time.Since(tc.startTime)
 	logFields = append(logFields, zap.Duration("total-take", totalDureTime))
 	for name, data := range tc.successData {
 		if name == TotalBytes {
-			var averageSpeed float64
-			if totalDureTime.Seconds() > 0 {
-				averageSpeed = float64(data) / totalDureTime.Seconds()
-			} else {
-				averageSpeed = float64(data)
-			}
-
 			logFields = append(logFields,
 				zap.String("total-kv-size", units.HumanSize(float64(data))),
-				zap.String("average-speed", units.HumanSize(averageSpeed)+"/s"))
+				zap.String("average-speed", units.HumanSize(float64(data)/totalDureTime.Seconds())+"/s"))
 			continue
 		}
 		if name == BackupDataSize {

--- a/pkg/summary/collector.go
+++ b/pkg/summary/collector.go
@@ -200,12 +200,20 @@ func (tc *logCollector) Summary(name string) {
 		totalCost += cost
 	}
 
-	logFields = append(logFields, zap.Duration("total-take", time.Since(tc.startTime)))
+	totalDureTime := time.Since(tc.startTime)
+	logFields = append(logFields, zap.Duration("total-take", totalDureTime))
 	for name, data := range tc.successData {
 		if name == TotalBytes {
+			var averageSpeed float64
+			if totalDureTime.Seconds() > 0 {
+				averageSpeed = float64(data) / totalDureTime.Seconds()
+			} else {
+				averageSpeed = float64(data)
+			}
+
 			logFields = append(logFields,
 				zap.String("total-kv-size", units.HumanSize(float64(data))),
-				zap.String("average-speed", units.HumanSize(float64(data)/totalCost.Seconds())+"/s"))
+				zap.String("average-speed", units.HumanSize(averageSpeed)+"/s"))
 			continue
 		}
 		if name == BackupDataSize {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix issue: the average speed isn't accurate(https://github.com/pingcap/br/issues/1405)

### What is changed and how it works?
change the  Calculation method for speed

### Check List
Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
 
**command**
  ./br backup full --pd "172.16.6.117:2379" --compression-level 3 --storage "local:///home/zak/new_br"
  ./br restore full --pd "172.16.6.117:2379" --storage "local:///home/zak/new_br"
**log**
[2021/08/04 10:03:34.913 +08:00] [INFO] [collector.go:67] ["Full backup success summary"] [total-ranges=45] [ranges-succeed=45] [ranges-failed=0] [backup-checksum=3.515718214s] [backup-fast-checksum=7.003603ms] [backup-total-ranges=58] [backup-total-regions=77] [total-take=14.017946255s] [total-kv=15463846] [total-kv-size=1.859GB] [average-speed=132.6MB/s] ["backup data size(after compressed)"=496.8MB] [BackupTS=426781599562989570]

[2021/08/04 10:06:45.055 +08:00] [INFO] [collector.go:67] ["Full restore success summary"] [total-ranges=37] [ranges-succeed=37] [ranges-failed=0] [split-region=362.373805ms] [restore-checksum=6.890396086s] [restore-ranges=29] [total-take=17.328491842s] ["restore data size(after compressed)"=496.7MB] [total-kv=15462460] [total-kv-size=1.858GB] [average-speed=107.2MB/s]

### Release note
- fix the bug that the average speed isn't accurate in `backup` and `restore`