### PR TITLE
[cherry-pick] skip rebase auto id(#27199)

### DIFF
--- a/pkg/restore/db.go
+++ b/pkg/restore/db.go
@@ -107,7 +107,6 @@ func (db *DB) CreateTable(ctx context.Context, table *utils.Table) error {
 		return errors.Trace(err)
 	}
 
-	var restoreMetaSQL string
 	if table.Info.IsSequence() {
 		setValFormat := fmt.Sprintf("do setval(%s.%s, %%d);",
 			utils.EncloseName(table.DB.Name.O),
@@ -149,55 +148,16 @@ func (db *DB) CreateTable(ctx context.Context, table *utils.Table) error {
 				return errors.Trace(err)
 			}
 		}
-		restoreMetaSQL = fmt.Sprintf(setValFormat, table.Info.AutoIncID)
-		err = db.se.Execute(ctx, restoreMetaSQL)
-	} else {
-		var alterAutoIncIDFormat string
-		switch {
-		case table.Info.IsView():
-			return nil
-		default:
-			alterAutoIncIDFormat = "alter table %s.%s auto_increment = %d;"
-		}
-		restoreMetaSQL = fmt.Sprintf(
-			alterAutoIncIDFormat,
-			utils.EncloseName(table.DB.Name.O),
-			utils.EncloseName(table.Info.Name.O),
-			table.Info.AutoIncID)
-		if utils.NeedAutoID(table.Info) {
-			err = db.se.Execute(ctx, restoreMetaSQL)
-		}
-	}
-
-	if err != nil {
-		log.Error("restore meta sql failed",
-			zap.String("query", restoreMetaSQL),
-			zap.Stringer("db", table.DB.Name),
-			zap.Stringer("table", table.Info.Name),
-			zap.Error(err))
-		return errors.Trace(err)
-	}
-	if table.Info.PKIsHandle && table.Info.ContainsAutoRandomBits() {
-		// this table has auto random id, we need rebase it
-
-		// we can't merge two alter query, because
-		// it will cause Error: [ddl:8200]Unsupported multi schema change
-		alterAutoRandIDSQL := fmt.Sprintf(
-			"alter table %s.%s auto_random_base = %d",
-			utils.EncloseName(table.DB.Name.O),
-			utils.EncloseName(table.Info.Name.O),
-			table.Info.AutoRandID)
-
-		err = db.se.Execute(ctx, alterAutoRandIDSQL)
-		if err != nil {
-			log.Error("alter AutoRandID failed",
-				zap.String("query", alterAutoRandIDSQL),
+		restoreMetaSQL := fmt.Sprintf(setValFormat, table.Info.AutoIncID)
+		if err = db.se.Execute(ctx, restoreMetaSQL); err != nil {
+			log.Error("restore meta sql failed",
+				zap.String("query", restoreMetaSQL),
 				zap.Stringer("db", table.DB.Name),
 				zap.Stringer("table", table.Info.Name),
 				zap.Error(err))
+			return errors.Trace(err)
 		}
 	}
-
 	return errors.Trace(err)
 }
 

--- a/tests/br_views_and_sequences/run.sh
+++ b/tests/br_views_and_sequences/run.sh
@@ -16,6 +16,10 @@
 set -eu
 DB="$TEST_NAME"
 
+trim_sql_result() {
+    tail -n1 | sed 's/[^0-9]//g'
+}
+
 run_sql "create schema $DB;"
 run_sql "create view $DB.view_1 as select 331 as m;"
 run_sql "create view $DB.view_2 as select * from $DB.view_1;"
@@ -29,6 +33,13 @@ run_sql "create view $DB.view_3 as select m from $DB.table_1 union select a * b 
 run_sql "drop view $DB.view_1;"
 run_sql "create view $DB.view_1 as select 133 as m;"
 
+run_sql "create table $DB.auto_inc (n int primary key AUTO_INCREMENT);"
+run_sql "insert into $DB.auto_inc values (), (), (), (), ();"
+last_id=$(run_sql "select n from $DB.auto_inc order by n desc limit 1" | trim_sql_result)
+
+run_sql "create table $DB.auto_rnd (n BIGINT primary key AUTO_RANDOM(8));"
+last_rnd_id=$(run_sql "insert into $DB.auto_rnd values (), (), (), (), ();select last_insert_id() & 0xffffffffffffff;" | trim_sql_result )
+
 echo "backup start..."
 run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 
@@ -39,11 +50,20 @@ run_br restore db --db $DB -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 
 set -x
 
-views_count=$(run_sql "select count(*) c, sum(m) s from $DB.view_3;" | tail -2 | paste -sd ';')
+views_count=$(run_sql "select count(*) c, sum(m) s from $DB.view_3;" | tail -2 | paste -sd ';' -)
 [ "$views_count" = 'c: 8;s: 181' ]
 
 run_sql "insert into $DB.table_2 (c) values (33);"
 seq_val=$(run_sql "select a >= 8 and b >= 4 as g from $DB.table_2 where c = 33;" | tail -1)
 [ "$seq_val" = 'g: 1' ]
+
+run_sql "insert into $DB.auto_inc values ();"
+last_id_after_restore=$(run_sql "select n from $DB.auto_inc order by n desc limit 1;" | trim_sql_result)
+[ $last_id_after_restore -gt $last_id ]
+rnd_last_id_after_restore=$(run_sql "insert into $DB.auto_rnd values ();select last_insert_id() & 0xffffffffffffff;" | trim_sql_result )
+[ $rnd_last_id_after_restore -gt $last_rnd_id ]
+rnd_count_after_restore=$(run_sql "select count(*) from $DB.auto_rnd;" | trim_sql_result )
+[ $rnd_count_after_restore -gt 5 ]
+
 
 run_sql "drop schema $DB"

--- a/tests/br_views_and_sequences/run.sh
+++ b/tests/br_views_and_sequences/run.sh
@@ -38,7 +38,7 @@ run_sql "insert into $DB.auto_inc values (), (), (), (), ();"
 last_id=$(run_sql "select n from $DB.auto_inc order by n desc limit 1" | trim_sql_result)
 
 run_sql "create table $DB.auto_rnd (n BIGINT primary key AUTO_RANDOM(8));"
-last_rnd_id=$(run_sql "insert into $DB.auto_rnd values (), (), (), (), ();select last_insert_id() & 0xffffffffffffff;" | trim_sql_result )
+last_rnd_id=$(run_sql "insert into $DB.auto_rnd values (), (), (), (), ();select last_insert_id() & 0x7fffffffffffff;" | trim_sql_result )
 
 echo "backup start..."
 run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
@@ -60,7 +60,7 @@ seq_val=$(run_sql "select a >= 8 and b >= 4 as g from $DB.table_2 where c = 33;"
 run_sql "insert into $DB.auto_inc values ();"
 last_id_after_restore=$(run_sql "select n from $DB.auto_inc order by n desc limit 1;" | trim_sql_result)
 [ $last_id_after_restore -gt $last_id ]
-rnd_last_id_after_restore=$(run_sql "insert into $DB.auto_rnd values ();select last_insert_id() & 0xffffffffffffff;" | trim_sql_result )
+rnd_last_id_after_restore=$(run_sql "insert into $DB.auto_rnd values ();select last_insert_id() & 0x7fffffffffffff;" | trim_sql_result )
 [ $rnd_last_id_after_restore -gt $last_rnd_id ]
 rnd_count_after_restore=$(run_sql "select count(*) from $DB.auto_rnd;" | trim_sql_result )
 [ $rnd_count_after_restore -gt 5 ]


### PR DESCRIPTION
cherry-picking pingcap/tidb#27199

=== 

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Speed up create tables via omit a DDL job.

Problem Summary:

### What is changed and how it works?

What's Changed: Remove all DDLs of rebasing autos.

How it Works: When creating table with `CreateTableWithInfo`, TiDB has rebased the auto ids via the table info:

https://github.com/pingcap/tidb/blob/a9cba7c8e8b6da512609863b56ee7265c06c50dc/ddl/ddl_api.go#L1924-L1937

It's no meaning for rebasing the auto ids again.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Integration test (at `br_views_and_sequences`)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Merged the rebase auto id operation into create table.
```
