### PR TITLE
[cherry-pick] br: add region range check for batch scan regions(tidb#27192)

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -106,6 +106,11 @@ error = '''
 unknown error occur on tikv
 '''
 
+["BR:PD:ErrPDBatchScanRegion"]
+error = '''
+batch scan region
+'''
+
 ["BR:PD:ErrPDInvalidResponse"]
 error = '''
 PD invalid response

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrPDUpdateFailed    = errors.Normalize("failed to update PD", errors.RFCCodeText("BR:PD:ErrPDUpdateFailed"))
 	ErrPDLeaderNotFound  = errors.Normalize("PD leader not found", errors.RFCCodeText("BR:PD:ErrPDLeaderNotFound"))
 	ErrPDInvalidResponse = errors.Normalize("PD invalid response", errors.RFCCodeText("BR:PD:ErrPDInvalidResponse"))
+	ErrPDBatchScanRegion = errors.Normalize("batch scan region", errors.RFCCodeText("BR:PD:ErrPDBatchScanRegion"))
 
 	ErrBackupChecksumMismatch    = errors.Normalize("backup checksum mismatch", errors.RFCCodeText("BR:Backup:ErrBackupChecksumMismatch"))
 	ErrBackupInvalidRange        = errors.Normalize("backup range invalid", errors.RFCCodeText("BR:Backup:ErrBackupInvalidRange"))

--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1116,7 +1116,7 @@ WriteAndIngest:
 		}
 		startKey := codec.EncodeBytes([]byte{}, pairStart)
 		endKey := codec.EncodeBytes([]byte{}, nextKey(pairEnd))
-		regions, err = paginateScanRegion(ctx, local.splitCli, startKey, endKey, 128)
+		regions, err = split.PaginateScanRegion(ctx, local.splitCli, startKey, endKey, 128)
 		if err != nil || len(regions) == 0 {
 			log.L().Warn("scan region failed", log.ShortError(err), zap.Int("region_len", len(regions)),
 				logutil.Key("startKey", startKey), logutil.Key("endKey", endKey), zap.Int("retry", retry))

--- a/pkg/lightning/backend/local/localhelper_test.go
+++ b/pkg/lightning/backend/local/localhelper_test.go
@@ -404,7 +404,7 @@ func (s *localSuite) doTestBatchSplitRegionByRanges(ctx context.Context, c *C, h
 	// current region ranges: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
 	rangeStart := codec.EncodeBytes([]byte{}, []byte("b"))
 	rangeEnd := codec.EncodeBytes([]byte{}, []byte("c"))
-	regions, err := paginateScanRegion(ctx, client, rangeStart, rangeEnd, 5)
+	regions, err := restore.PaginateScanRegion(ctx, client, rangeStart, rangeEnd, 5)
 	c.Assert(err, IsNil)
 	// regions is: [aay, bba), [bba, bbh), [bbh, cca)
 	checkRegionRanges(c, regions, [][]byte{[]byte("aay"), []byte("bba"), []byte("bbh"), []byte("cca")})
@@ -429,7 +429,7 @@ func (s *localSuite) doTestBatchSplitRegionByRanges(ctx context.Context, c *C, h
 	splitHook.check(c, client)
 
 	// check split ranges
-	regions, err = paginateScanRegion(ctx, client, rangeStart, rangeEnd, 5)
+	regions, err = restore.PaginateScanRegion(ctx, client, rangeStart, rangeEnd, 5)
 	c.Assert(err, IsNil)
 	result := [][]byte{
 		[]byte("b"), []byte("ba"), []byte("bb"), []byte("bba"), []byte("bbh"), []byte("bc"),
@@ -493,7 +493,7 @@ func (h *scanRegionEmptyHook) AfterScanRegions(res []*restore.RegionInfo, err er
 }
 
 func (s *localSuite) TestBatchSplitRegionByRangesScanFailed(c *C) {
-	s.doTestBatchSplitRegionByRanges(context.Background(), c, &scanRegionEmptyHook{}, "paginate scan region returns empty result", defaultHook{})
+	s.doTestBatchSplitRegionByRanges(context.Background(), c, &scanRegionEmptyHook{}, ".*scan region return empty result.*", defaultHook{})
 }
 
 type splitRegionEpochNotMatchHook struct {

--- a/pkg/restore/split.go
+++ b/pkg/restore/split.go
@@ -20,7 +20,9 @@ import (
 
 	berrors "github.com/pingcap/br/pkg/errors"
 	"github.com/pingcap/br/pkg/logutil"
+	"github.com/pingcap/br/pkg/redact"
 	"github.com/pingcap/br/pkg/rtree"
+	"github.com/pingcap/br/pkg/utils"
 )
 
 // Constants for split retry machinery.
@@ -273,6 +275,33 @@ func (rs *RegionSplitter) splitAndScatterRegions(
 	return newRegions, nil
 }
 
+func checkRegionConsistency(startKey, endKey []byte, regions []*RegionInfo) error {
+	// current pd can't guarantee the consistency of returned regions
+	if len(regions) == 0 {
+		return errors.Annotatef(berrors.ErrPDBatchScanRegion, "scan region return empty result, startKey: %s, endkey: %s",
+			redact.Key(startKey), redact.Key(endKey))
+	}
+
+	if bytes.Compare(regions[0].Region.StartKey, startKey) > 0 {
+		return errors.Annotatef(berrors.ErrPDBatchScanRegion, "first region's startKey > startKey, startKey: %s, regionStartKey: %s",
+			redact.Key(startKey), redact.Key(regions[0].Region.StartKey))
+	} else if len(regions[len(regions)-1].Region.EndKey) != 0 && bytes.Compare(regions[len(regions)-1].Region.EndKey, endKey) < 0 {
+		return errors.Annotatef(berrors.ErrPDBatchScanRegion, "last region's endKey < startKey, startKey: %s, regionStartKey: %s",
+			redact.Key(endKey), redact.Key(regions[len(regions)-1].Region.EndKey))
+	}
+
+	cur := regions[0]
+	for _, r := range regions[1:] {
+		if !bytes.Equal(cur.Region.EndKey, r.Region.StartKey) {
+			return errors.Annotatef(berrors.ErrPDBatchScanRegion, "region endKey not equal to next region startKey, endKey: %s, startKey: %s",
+				redact.Key(cur.Region.EndKey), redact.Key(r.Region.StartKey))
+		}
+		cur = r
+	}
+
+	return nil
+}
+
 // PaginateScanRegion scan regions with a limit pagination and
 // return all regions at once.
 // It reduces max gRPC message size.
@@ -284,50 +313,61 @@ func PaginateScanRegion(
 			hex.EncodeToString(startKey), hex.EncodeToString(endKey))
 	}
 
-	regions := []*RegionInfo{}
-	scanStartKey := startKey
-	for {
-		batch, err := client.ScanRegions(ctx, scanStartKey, endKey, limit)
-		if err != nil {
-			return nil, errors.Trace(err)
+	var regions []*RegionInfo
+	err := utils.WithRetry(ctx, func() error {
+		regions = []*RegionInfo{}
+		scanStartKey := startKey
+		for {
+			batch, err := client.ScanRegions(ctx, scanStartKey, endKey, limit)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			regions = append(regions, batch...)
+			if len(batch) < limit {
+				// No more region
+				break
+			}
+			scanStartKey = batch[len(batch)-1].Region.GetEndKey()
+			if len(scanStartKey) == 0 ||
+				(len(endKey) > 0 && bytes.Compare(scanStartKey, endKey) >= 0) {
+				// All key space have scanned
+				break
+			}
 		}
-		regions = append(regions, batch...)
-		if len(batch) < limit {
-			// No more region
-			break
+		if err := checkRegionConsistency(startKey, endKey, regions); err != nil {
+			log.Warn("failed to scan region, retrying", logutil.ShortError(err))
+			return err
 		}
-		scanStartKey = batch[len(batch)-1].Region.GetEndKey()
-		if len(scanStartKey) == 0 ||
-			(len(endKey) > 0 && bytes.Compare(scanStartKey, endKey) >= 0) {
-			// All key space have scanned
-			break
-		}
-	}
+		return nil
+	}, newScanRegionBackoffer())
 
-	// current pd can't guarantee the consistency of returned regions
-	if len(regions) == 0 {
-		return nil, errors.Annotatef(berrors.ErrPDBatchScanRegion, "scan region return empty result, startKey: %s, endkey: %s",
-			hex.EncodeToString(startKey), hex.EncodeToString(endKey))
-	}
+	return regions, err
+}
 
-	if bytes.Compare(regions[0].Region.StartKey, startKey) > 0 {
-		return nil, errors.Annotatef(berrors.ErrPDBatchScanRegion, "first region's startKey > startKey, startKey: %s, regionStartKey: %s",
-			hex.EncodeToString(startKey), hex.EncodeToString(regions[0].Region.StartKey))
-	} else if len(regions[len(regions)-1].Region.EndKey) != 0 && bytes.Compare(regions[len(regions)-1].Region.EndKey, endKey) < 0 {
-		return nil, errors.Annotatef(berrors.ErrPDBatchScanRegion, "last region's endKey < startKey, startKey: %s, regionStartKey: %s",
-			hex.EncodeToString(endKey), hex.EncodeToString(regions[len(regions)-1].Region.EndKey))
-	}
+type scanRegionBackoffer struct {
+	attempt int
+}
 
-	cur := regions[0]
-	for _, r := range regions[1:] {
-		if !bytes.Equal(cur.Region.EndKey, r.Region.StartKey) {
-			return nil, errors.Annotatef(berrors.ErrPDBatchScanRegion, "region endKey not equal to next region startKey, endKey: %s, startKey: %s",
-				hex.EncodeToString(cur.Region.EndKey), hex.EncodeToString(r.Region.StartKey))
-		}
-		cur = r
+func newScanRegionBackoffer() utils.Backoffer {
+	return &scanRegionBackoffer{
+		attempt: 3,
 	}
+}
 
-	return regions, nil
+// NextBackoff returns a duration to wait before retrying again
+func (b *scanRegionBackoffer) NextBackoff(err error) time.Duration {
+	if berrors.ErrPDBatchScanRegion.Equal(err) {
+		// 500ms * 3 could be enough for splitting remain regions in the hole.
+		b.attempt--
+		return 500 * time.Millisecond
+	}
+	b.attempt = 0
+	return 0
+}
+
+// Attempt returns the remain attempt times
+func (b *scanRegionBackoffer) Attempt() int {
+	return b.attempt
 }
 
 // GetSplitKeys checks if the regions should be split by the new prefix of the rewrites rule and the end key of

--- a/pkg/restore/split.go
+++ b/pkg/restore/split.go
@@ -5,6 +5,7 @@ package restore
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"strings"
 	"time"
 

--- a/pkg/restore/util_test.go
+++ b/pkg/restore/util_test.go
@@ -223,9 +223,8 @@ func (s *testRestoreUtilSuite) TestPaginateScanRegion(c *C) {
 	ctx := context.Background()
 	regionMap := make(map[uint64]*restore.RegionInfo)
 	regions := []*restore.RegionInfo{}
-	batch, err := restore.PaginateScanRegion(ctx, newTestClient(stores, regionMap, 0), []byte{}, []byte{}, 3)
-	c.Assert(err, IsNil)
-	c.Assert(batch, DeepEquals, regions)
+	batch, err := restore.PaginateScanRegion(ctx, NewTestClient(stores, regionMap, 0), []byte{}, []byte{}, 3)
+	c.Assert(err, ErrorMatches, ".*scan region return empty result.*")
 
 	regionMap, regions = makeRegions(1)
 	batch, err = restore.PaginateScanRegion(ctx, newTestClient(stores, regionMap, 0), []byte{}, []byte{}, 3)
@@ -265,4 +264,11 @@ func (s *testRestoreUtilSuite) TestPaginateScanRegion(c *C) {
 
 	_, err = restore.PaginateScanRegion(ctx, newTestClient(stores, regionMap, 0), []byte{2}, []byte{1}, 3)
 	c.Assert(err, ErrorMatches, ".*startKey >= endKey.*")
+
+	// make the regionMap losing some region, this will cause scan region check fails
+	delete(regionMap, uint64(3))
+	_, err = restore.PaginateScanRegion(
+		ctx, NewTestClient(stores, regionMap, 0), regions[1].Region.EndKey, regions[5].Region.EndKey, 3)
+	c.Assert(err, ErrorMatches, ".*region endKey not equal to next region startKey.*")
+
 }

--- a/pkg/restore/util_test.go
+++ b/pkg/restore/util_test.go
@@ -223,7 +223,7 @@ func (s *testRestoreUtilSuite) TestPaginateScanRegion(c *C) {
 	ctx := context.Background()
 	regionMap := make(map[uint64]*restore.RegionInfo)
 	regions := []*restore.RegionInfo{}
-	batch, err := restore.PaginateScanRegion(ctx, NewTestClient(stores, regionMap, 0), []byte{}, []byte{}, 3)
+	batch, err := restore.PaginateScanRegion(ctx, newTestClient(stores, regionMap, 0), []byte{}, []byte{}, 3)
 	c.Assert(err, ErrorMatches, ".*scan region return empty result.*")
 
 	regionMap, regions = makeRegions(1)
@@ -268,7 +268,7 @@ func (s *testRestoreUtilSuite) TestPaginateScanRegion(c *C) {
 	// make the regionMap losing some region, this will cause scan region check fails
 	delete(regionMap, uint64(3))
 	_, err = restore.PaginateScanRegion(
-		ctx, NewTestClient(stores, regionMap, 0), regions[1].Region.EndKey, regions[5].Region.EndKey, 3)
+		ctx, newTestClient(stores, regionMap, 0), regions[1].Region.EndKey, regions[5].Region.EndKey, 3)
 	c.Assert(err, ErrorMatches, ".*region endKey not equal to next region startKey.*")
 
 }

--- a/pkg/restore/util_test.go
+++ b/pkg/restore/util_test.go
@@ -270,5 +270,4 @@ func (s *testRestoreUtilSuite) TestPaginateScanRegion(c *C) {
 	_, err = restore.PaginateScanRegion(
 		ctx, newTestClient(stores, regionMap, 0), regions[1].Region.EndKey, regions[5].Region.EndKey, 3)
 	c.Assert(err, ErrorMatches, ".*region endKey not equal to next region startKey.*")
-
 }


### PR DESCRIPTION
cherry-picking pingcap/tidb#27192

=== 

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Currently, the implement of pd's batch scan regions can't guarantee consistency, so we add extra check for return returned region [startKey, endKey) check to ensure if there are potential range gap, the method will return an error.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

Side effects

Documentation

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
