### PR TITLE
[cherry-pick] restore: fix failed to retry grpc errors(tidb#27423)

### DIFF
--- a/pkg/backup/push.go
+++ b/pkg/backup/push.go
@@ -162,13 +162,16 @@ func (push *pushDown) pushBackup(
 						log.Error("", zap.String("error", berrors.ErrKVStorage.Error()+": "+errMsg),
 							zap.String("work around", "please ensure br and tikv node share a same disk and the user of br and tikv has same uid."))
 					}
-
 					if utils.MessageIsPermissionDeniedStorageError(errPb.GetMsg()) {
 						errMsg := fmt.Sprintf("I/O permission denied error occurs on TiKV Node(store id: %v; Address: %s)", store.GetId(), redact.String(store.GetAddress()))
 						log.Error("", zap.String("error", berrors.ErrKVStorage.Error()+": "+errMsg),
 							zap.String("work around", "please ensure tikv has permission to read from & write to the storage."))
 					}
-					return res, berrors.ErrKVStorage
+					return res, errors.Annotatef(berrors.ErrKVStorage, "error happen in store %v at %s: %s",
+						store.GetId(),
+						redact.String(store.GetAddress()),
+						errPb.Msg,
+					)
 				}
 			}
 		case err := <-push.errCh:

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -248,6 +248,10 @@ func (importer *FileImporter) Import(
 					log.Debug("failpoint restore-storage-error injected.", zap.String("msg", msg))
 					e = errors.Annotate(e, msg)
 				})
+				failpoint.Inject("restore-gRPC-error", func(_ failpoint.Value) {
+					log.Warn("the connection to TiKV has been cut by a neko, meow :3")
+					e = status.Error(codes.Unavailable, "the connection to TiKV has been cut by a neko, meow :3")
+				})
 				return errors.Trace(e)
 			}, utils.NewDownloadSSTBackoffer())
 			if errDownload != nil {

--- a/pkg/restore/import.go
+++ b/pkg/restore/import.go
@@ -20,8 +20,10 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
 
 	berrors "github.com/pingcap/br/pkg/errors"
 	"github.com/pingcap/br/pkg/logutil"

--- a/pkg/utils/backoff.go
+++ b/pkg/utils/backoff.go
@@ -59,7 +59,8 @@ func (bo *importerBackoffer) NextBackoff(err error) time.Duration {
 		bo.delayTime = 2 * bo.delayTime
 		bo.attempt--
 	} else {
-		switch errors.Cause(err) { // nolint:errorlint
+		e := errors.Cause(err)
+		switch e { // nolint:errorlint
 		case berrors.ErrKVEpochNotMatch, berrors.ErrKVDownloadFailed, berrors.ErrKVIngestFailed:
 			bo.delayTime = 2 * bo.delayTime
 			bo.attempt--
@@ -68,7 +69,7 @@ func (bo *importerBackoffer) NextBackoff(err error) time.Duration {
 			bo.delayTime = 0
 			bo.attempt = 0
 		default:
-			switch status.Code(err) {
+			switch status.Code(e) {
 			case codes.Unavailable, codes.Aborted:
 				bo.delayTime = 2 * bo.delayTime
 				bo.attempt--

--- a/tests/br_full/run.sh
+++ b/tests/br_full/run.sh
@@ -70,7 +70,7 @@ for ct in limit lz4 zstd; do
 
   # restore full
   echo "restore with $ct backup start..."
-  export GO_FAILPOINTS="github.com/pingcap/br/pkg/restore/restore-storage-error=1*return(\"connection refused\")"
+  export GO_FAILPOINTS="github.com/pingcap/br/pkg/restore/restore-storage-error=1*return(\"connection refused\");github.com/pingcap/br/pkg/restore/restore-gRPC-error=1*return(true)"
   run_br restore full -s "local://$TEST_DIR/$DB-$ct" --pd $PD_ADDR --ratelimit 1024
   export GO_FAILPOINTS=""
 


### PR DESCRIPTION
cherry-picking tidb#27423

=== 

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27421 

Problem Summary:
BR used the wrapped error to get the gRPC error code, which would always returning a Unknown code.

### What is changed and how it works?

What's Changed:
Use the unwrapped error.

How it Works:
So the code would be right.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Increase the robustness for restoring. 
```