### PR TITLE
pdutil: use the correct unit for pausing schedulers

### DIFF
--- a/pkg/pdutil/pd.go
+++ b/pkg/pdutil/pd.go
@@ -365,7 +365,7 @@ func (p *PdController) getStoreInfoWith(
 
 func (p *PdController) doPauseSchedulers(ctx context.Context, schedulers []string, post pdHTTPRequest) ([]string, error) {
 	// pause this scheduler with 300 seconds
-	body, err := json.Marshal(pauseSchedulerBody{Delay: int64(pauseTimeout)})
+	body, err := json.Marshal(pauseSchedulerBody{Delay: int64(pauseTimeout.Seconds())})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
ref: pingcap/tidb#33546

### What is changed and how it works?
cherry-pick pingcap/tidb#33545 to br

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release note

 - Fix the issue that the schedulers won't be resumed after BR/Lightning exits abnormally.
