### PR TITLE
check cluster id

### DIFF
--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -2309,6 +2309,14 @@ func (local *local) CheckRequirements(ctx context.Context, checkCtx *backend.Che
 	if err != nil {
 		return errors.Trace(err)
 	}
+	clusterId, err := local.g.GetSQLExecutor().ObtainStringWithLog(
+		ctx,
+		"select substring(type,8) from METRICS_SCHEMA.PD_CLUSTER_METADATA limit 1;",
+		"check TiDB Cluster ID",
+		log.L())
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if err := checkTiDBVersion(ctx, versionStr, localMinTiDBVersion, localMaxTiDBVersion); err != nil {
 		return err
 	}
@@ -2316,6 +2324,9 @@ func (local *local) CheckRequirements(ctx context.Context, checkCtx *backend.Che
 		return err
 	}
 	if err := tikv.CheckTiKVVersion(ctx, local.tls, local.pdAddr, localMinTiKVVersion, localMaxTiKVVersion); err != nil {
+		return err
+	}
+	if err := tikv.CheckTiDBDestination(ctx, local.tls, local.pdAddr, clusterId); err != nil {
 		return err
 	}
 

--- a/pkg/lightning/restore/check_info.go
+++ b/pkg/lightning/restore/check_info.go
@@ -120,7 +120,7 @@ func (rc *Controller) ClusterResource(ctx context.Context, localSource int64) er
 // ClusterIsAvailable check cluster is available to import data. this test can be skipped.
 func (rc *Controller) ClusterIsAvailable(ctx context.Context) error {
 	passed := true
-	message := "Cluster is available"
+	message := "Cluster is available and correct"
 	defer func() {
 		rc.checkTemplate.Collect(Critical, passed, message)
 	}()

--- a/pkg/lightning/tikv/tikv.go
+++ b/pkg/lightning/tikv/tikv.go
@@ -217,6 +217,18 @@ func CheckPDVersion(ctx context.Context, tls *common.TLS, pdAddr string, require
 	return version.CheckVersion("PD", *ver, requiredMinVersion, requiredMaxVersion)
 }
 
+func CheckTiDBDestination(ctx context.Context, tls *common.TLS, pdAddr string, clusterId string) error {
+	id, err := pdutil.FetchClusterID(ctx, tls, pdAddr)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if id != clusterId {
+		return errors.Errorf("Failed to match the cluster ID, Please check whether status-port is correct")
+	}
+	return nil
+}
+
 func CheckTiKVVersion(ctx context.Context, tls *common.TLS, pdAddr string, requiredMinVersion, requiredMaxVersion semver.Version) error {
 	return ForAllStores(
 		ctx,

--- a/pkg/pdutil/pd.go
+++ b/pkg/pdutil/pd.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -709,4 +710,22 @@ func FetchPDVersion(ctx context.Context, tls *common.TLS, pdAddr string) (*semve
 	}
 
 	return parseVersion([]byte(rawVersion.Version)), nil
+}
+
+// FetchClusterID get Cluster ID
+func FetchClusterID(ctx context.Context, tls *common.TLS, pdAddr string) (string, error) {
+	// An example of PD Cluster ID API.
+	// curl http://pd_address/pd/api/v1/cluster
+	// {
+	//   "id": 7125154571691814555
+	// }
+	var rawClusterID struct {
+		Id int `json:"id"`
+	}
+	err := tls.WithHost(pdAddr).GetJSON(ctx, "/pd/api/v1/cluster", &rawClusterID)
+	if err != nil {
+		return strconv.Itoa(rawClusterID.Id), errors.Trace(err)
+	}
+
+	return strings.TrimSpace(strconv.Itoa(rawClusterID.Id)), nil
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
Issue Number: close #1473

### What problem does this PR solve? <!--add issue link with summary if exists-->
avoid table data inconsistency with table index.

### What is changed and how it works?
1. get cluster id from tidb port using `select substring(type,8) from METRICS_SCHEMA.PD_CLUSTER_METADATA limit 1;`
2. get cluster id from pd api using `/pd/api/v1/cluster`
3. compare result of the two value,if it's equal,it will continue.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

 -

<!-- fill in the release note, or just write "No release note" -->
