### PR TITLE
br: Ignore ddl jobs with empty query or blacklist type when exec restore

### DIFF
--- a/pkg/restore/db.go
+++ b/pkg/restore/db.go
@@ -24,6 +24,20 @@ type DB struct {
 	se glue.Session
 }
 
+type UniqueTableName struct {
+	DB    string
+	Table string
+}
+
+type DDLJobFilterRule func(ddlJob *model.Job) bool
+
+var incrementalRestoreActionBlockList = map[model.ActionType]struct{}{
+	model.ActionSetTiFlashReplica:          {},
+	model.ActionUpdateTiFlashReplicaStatus: {},
+	model.ActionLockTable:                  {},
+	model.ActionUnlockTable:                {},
+}
+
 // NewDB returns a new DB.
 func NewDB(g glue.Glue, store kv.Storage) (*DB, error) {
 	se, err := g.CreateSession(store)
@@ -65,6 +79,13 @@ func (db *DB) ExecDDL(ctx context.Context, ddlJob *model.Job) error {
 				zap.Error(err))
 		}
 		return errors.Trace(err)
+	}
+
+	if ddlJob.Query == "" {
+		log.Warn("query of ddl job is empty, ignore it",
+			zap.Stringer("type", ddlJob.Type),
+			zap.String("db", ddlJob.SchemaName))
+		return nil
 	}
 
 	if tableInfo != nil {
@@ -265,6 +286,31 @@ func FilterDDLJobs(allDDLJobs []*model.Job, tables []*metautil.Table) (ddlJobs [
 	return ddlJobs
 }
 
+// FilterDDLJobByRules if one of rules returns true, the job in srcDDLJobs will be filtered.
+func FilterDDLJobByRules(srcDDLJobs []*model.Job, rules ...DDLJobFilterRule) (dstDDLJobs []*model.Job) {
+	dstDDLJobs = make([]*model.Job, 0, len(srcDDLJobs))
+	for _, ddlJob := range srcDDLJobs {
+		passed := true
+		for _, rule := range rules {
+			if rule(ddlJob) {
+				passed = false
+				break
+			}
+		}
+
+		if passed {
+			dstDDLJobs = append(dstDDLJobs, ddlJob)
+		}
+	}
+
+	return
+}
+
+// DDLJobBlockListRule rule for filter ddl job with type in block list.
+func DDLJobBlockListRule(ddlJob *model.Job) bool {
+	return checkIsInActions(ddlJob.Type, incrementalRestoreActionBlockList)
+}
+
 func getDatabases(tables []*metautil.Table) (dbs []*model.DBInfo) {
 	dbIDs := make(map[int64]bool)
 	for _, table := range tables {
@@ -274,4 +320,9 @@ func getDatabases(tables []*metautil.Table) (dbs []*model.DBInfo) {
 		}
 	}
 	return
+}
+
+func checkIsInActions(action model.ActionType, actions map[model.ActionType]struct{}) bool {
+	_, ok := actions[action]
+	return ok
 }

--- a/pkg/restore/db.go
+++ b/pkg/restore/db.go
@@ -24,11 +24,13 @@ type DB struct {
 	se glue.Session
 }
 
+// UniqueTableName identifies a unique table
 type UniqueTableName struct {
 	DB    string
 	Table string
 }
 
+// DDLJobFilterRule judges whether a ddl job should be ignored
 type DDLJobFilterRule func(ddlJob *model.Job) bool
 
 var incrementalRestoreActionBlockList = map[model.ActionType]struct{}{

--- a/pkg/restore/db_test.go
+++ b/pkg/restore/db_test.go
@@ -220,3 +220,74 @@ func (s *testRestoreSchemaSuite) TestFilterDDLJobsV2(c *C) {
 	}
 	c.Assert(len(ddlJobs), Equals, 7)
 }
+
+func (s *testRestoreSchemaSuite) TestDB_ExecDDL(c *C) {
+	ctx := context.Background()
+	ddlJobs := []*model.Job{
+		{
+			Type:       model.ActionAddIndex,
+			Query:      "CREATE DATABASE IF NOT EXISTS test_db;",
+			BinlogInfo: &model.HistoryInfo{},
+		},
+		{
+			Type:       model.ActionAddIndex,
+			Query:      "",
+			BinlogInfo: &model.HistoryInfo{},
+		},
+	}
+
+	db, err := restore.NewDB(gluetidb.New(), s.mock.Storage)
+	c.Assert(err, IsNil)
+
+	for _, ddlJob := range ddlJobs {
+		err = db.ExecDDL(ctx, ddlJob)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *testRestoreSchemaSuite) TestFilterDDLJobByRules(c *C) {
+	ddlJobs := []*model.Job{
+		{
+			Type: model.ActionSetTiFlashReplica,
+		},
+		{
+			Type: model.ActionAddPrimaryKey,
+		},
+		{
+			Type: model.ActionUpdateTiFlashReplicaStatus,
+		},
+		{
+			Type: model.ActionCreateTable,
+		},
+		{
+			Type: model.ActionLockTable,
+		},
+		{
+			Type: model.ActionAddIndex,
+		},
+		{
+			Type: model.ActionUnlockTable,
+		},
+		{
+			Type: model.ActionCreateSchema,
+		},
+		{
+			Type: model.ActionModifyColumn,
+		},
+	}
+
+	expectedDDLTypes := []model.ActionType{
+		model.ActionAddPrimaryKey,
+		model.ActionCreateTable,
+		model.ActionAddIndex,
+		model.ActionCreateSchema,
+		model.ActionModifyColumn,
+	}
+
+	ddlJobs = restore.FilterDDLJobByRules(ddlJobs, restore.DDLJobBlockListRule)
+
+	c.Assert(len(ddlJobs), Equals, len(expectedDDLTypes))
+	for i, ddlJob := range ddlJobs {
+		c.Assert(ddlJob.Type, Equals, expectedDDLTypes[i])
+	}
+}

--- a/pkg/task/restore.go
+++ b/pkg/task/restore.go
@@ -293,6 +293,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		newTS = restoreTS
 	}
 	ddlJobs := restore.FilterDDLJobs(client.GetDDLJobs(), tables)
+	ddlJobs = restore.FilterDDLJobByRules(ddlJobs, restore.DDLJobBlockListRule)
 
 	err = client.PreCheckTableTiFlashReplica(ctx, tables)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: WangLe1321 <wangle1321@163.com>

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Issue Number: #33322

cherry-pick https://github.com/pingcap/tidb/pull/33384

Problem Summary: Sometimes, query of ddl job can be empty, which will cause error when execute incremental restore.

### What is changed and how it works?

During backup, when we find ddl job with action types about TiFlash or lock/unlock table, we will set the query empty. So we add an action type blacklist, ddl job with action type in blacklist will be ignored. We also ignore ddl job with empty query in case other unexpected situation.

This means that we will ignore ddl jobs about TiFlash or lock/unlock table and ddl jobs with empty query, so they won't cause error by mistake.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

```release-note
Fix a bug that BR incremental restore return error by mistake caused by ddl job with empty query.
```

<!-- fill in the release note, or just write "No release note" -->
